### PR TITLE
✨ チャット回答のコードブロックをシンタックスハイライトする

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",
+    "highlight.js": "^11.11.1",
     "hono": "^4.12.34",
     "jotai": "^2.15.0",
     "neverthrow": "^8.2.0",
@@ -28,6 +29,7 @@
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.6",
     "react-router": "^8.3.0",
+    "rehype-highlight": "^7.0.2",
     "remark-gfm": "^4.0.1",
     "swr": "^2.4.2",
     "ulid": "^3.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@5.20260711.1)
+      highlight.js:
+        specifier: ^11.11.1
+        version: 11.11.1
       hono:
         specifier: ^4.12.34
         version: 4.12.34
@@ -53,6 +56,9 @@ importers:
       react-router:
         specifier: ^8.3.0
         version: 8.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      rehype-highlight:
+        specifier: ^7.0.2
+        version: 7.0.2
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -2009,14 +2015,24 @@ packages:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
+  hast-util-is-element@3.0.0:
+    resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-text@4.0.2:
+    resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
 
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hono@4.12.34:
     resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
@@ -2230,6 +2246,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
@@ -2555,6 +2574,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  rehype-highlight@7.0.2:
+    resolution: {integrity: sha512-k158pK7wdC2qL3M5NcZROZ2tR/l7zOzjxXd5VGdcfIyoijjQqpHd3JKtYSBDpDZ38UI2WJWuFAtkMDxmx5kstA==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -2759,6 +2781,9 @@ packages:
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-find-after@5.0.0:
+    resolution: {integrity: sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -4184,6 +4209,10 @@ snapshots:
 
   graphql@16.14.2: {}
 
+  hast-util-is-element@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -4204,6 +4233,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-text@4.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      hast-util-is-element: 3.0.0
+      unist-util-find-after: 5.0.0
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
@@ -4212,6 +4248,8 @@ snapshots:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.2
+
+  highlight.js@11.11.1: {}
 
   hono@4.12.34: {}
 
@@ -4376,6 +4414,12 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
 
   longest-streak@3.1.0: {}
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@11.5.2: {}
 
@@ -4947,6 +4991,14 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  rehype-highlight@7.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-to-text: 4.0.2
+      lowlight: 3.3.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -5191,6 +5243,11 @@ snapshots:
       is-plain-obj: 4.1.0
       trough: 2.2.0
       vfile: 6.0.3
+
+  unist-util-find-after@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
 
   unist-util-is@6.0.1:
     dependencies:

--- a/src/front/components/ChatArea/ChatMessageBubble.test.tsx
+++ b/src/front/components/ChatArea/ChatMessageBubble.test.tsx
@@ -37,6 +37,30 @@ describe("ChatMessageBubble", () => {
     expect(code.closest("pre")).not.toBeNull();
   });
 
+  it("colors keywords in a fenced code block that names its language", () => {
+    const { container } = render(
+      <ChatMessageBubble message={message({ content: "```js\nconst app = 1\n```" })} />,
+    );
+
+    const code = container.querySelector("pre code");
+    expect(code?.className).toBe("block hljs language-js");
+    expect(screen.getByText("const").className).toBe("hljs-keyword");
+  });
+
+  // The answer streams in token by token, so a fence is rendered many times
+  // while its language is still half-typed and names nothing that exists
+  it.each([
+    ["a language nothing can highlight", "```mermaid\ngraph TD\n```"],
+    ["a language name still being streamed", "```typescr\ngraph TD"],
+  ])("renders a code block with %s as plain text", (_name, content) => {
+    const { container } = render(<ChatMessageBubble message={message({ content })} />);
+
+    // innerHTML, because highlighting would break the code into <span>s while
+    // leaving textContent identical
+    const code = container.querySelector("pre code");
+    expect(code?.innerHTML).toBe("graph TD\n");
+  });
+
   it("shows the answer without the Sources section, which the badges already carry", () => {
     const content = `Workers はエッジで動きます。\n\n## Sources\n[1] 「エッジで動きます」（本書 第1章）`;
     render(

--- a/src/front/components/ChatArea/ChatMessageBubble.tsx
+++ b/src/front/components/ChatArea/ChatMessageBubble.tsx
@@ -1,5 +1,6 @@
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import rehypeHighlight from "rehype-highlight";
 import type { ChatMessage } from "../../atoms/chatAtom";
 import { CitationBadge } from "./CitationBadge";
 import { stripSources } from "../../lib/stripSources";
@@ -24,11 +25,16 @@ const MARKDOWN_COMPONENTS = {
   a: (props: object) => (
     <a className="text-blue-600 underline" target="_blank" rel="noopener noreferrer" {...props} />
   ),
-  code: (props: { className?: string }) =>
-    props.className?.startsWith("language-") ? (
-      <code className="block" {...props} />
+  // rehype-highlight prepends `hljs` to the fence's `language-x`, so the class
+  // that marks a block has to be searched for rather than matched at the start
+  code: ({ className, ...props }: { className?: string }) =>
+    className?.includes("language-") ? (
+      <code className={`block ${className}`} {...props} />
     ) : (
-      <code className="rounded bg-gray-200 px-1 py-0.5 font-mono text-[0.85em]" {...props} />
+      <code
+        className={`rounded bg-gray-200 px-1 py-0.5 font-mono text-[0.85em] ${className ?? ""}`}
+        {...props}
+      />
     ),
   pre: (props: object) => (
     <pre
@@ -69,7 +75,11 @@ export function ChatMessageBubble({ message }: ChatMessageBubbleProps) {
           <div className="whitespace-pre-wrap break-words">{message.content}</div>
         ) : (
           <div className="break-words">
-            <Markdown remarkPlugins={[remarkGfm]} components={MARKDOWN_COMPONENTS}>
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeHighlight]}
+              components={MARKDOWN_COMPONENTS}
+            >
               {stripSources(message.content)}
             </Markdown>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,14 @@
 @import "tailwindcss";
+@import "highlight.js/styles/github-dark.css";
+
+/*
+ * The theme paints its own background on every highlighted block. The chat
+ * bubble already gives `pre` its background, so let that one win and keep the
+ * theme to colouring the tokens.
+ */
+.hljs {
+  background: transparent;
+}
 
 /*
  * Text layer produced by pdf.js `TextLayer`. The spans are invisible copies of


### PR DESCRIPTION
## 背景

チャット回答の fenced code block が単色（`bg-gray-800` + `text-gray-100`）で表示され、言語を指定していても色分けされていなかった。`ChatMessageBubble` が `react-markdown` + `remark-gfm` だけで動いており、フェンスから渡ってくる `language-xxx` を受け取りながら何にも使っていなかったのが原因。

## 変更内容

- `rehype-highlight` + `highlight.js` を追加し、`react-markdown` の `rehypePlugins` に載せた。回答は SSE で 1 トークンずつ届き、そのたびに Markdown 全文が再パースされるため、非同期の shiki ではなく**同期**でハイライトできる highlight.js 系を選んでいる
- コードブロックの判定を `startsWith("language-")` → `includes(...)` に変更。rehype-highlight が `language-x` の前に `hljs` を差し込むため、そのままだとブロックがインラインコード用のグレー背景に落ちて見た目が崩れる。あわせて `className` が `{...props}` で上書きされていた箇所を明示的なマージに直した
- テーマは `github-dark`。`.hljs` の背景は透過させ、背景色は既存の `pre` に一本化した

## 動作確認

- 単体テスト 86 件通過（`ChatMessageBubble.test.tsx` に 2 件追加）。ハイライト検証テストは追加直後に RED を観測済み。`includes` を `startsWith` に戻す変異を入れると落ちることも確認しており、空振りしないテストになっている
- Worker テスト 21 件通過、`vp check` / `vp build` 通過
- 実機確認（Playwright）: 既存のチャット履歴でコードが色分けされること、新規質問のストリーミング中〜完了まで例外もコンソールエラーもなく色が付き続けることを確認

## 補足

言語指定のないフェンス（``` だけ）が `pre` の中でインラインコード用スタイルのままになる既存の挙動は、本 PR の回帰ではないため触っていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)