### PR TITLE
✨ feat: 本と紐づく履歴を削除できるようにする

### DIFF
--- a/src/front/pages/ShelfPage.test.tsx
+++ b/src/front/pages/ShelfPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, Route, Routes, useParams } from "react-router";
 import { ShelfPage, type Book } from "./ShelfPage";
 
 function book(overrides: Partial<Book> = {}): Book {
@@ -21,9 +21,17 @@ function renderShelf(props: {
 }) {
   render(
     <MemoryRouter>
-      <ShelfPage {...props} />
+      <Routes>
+        <Route path="/" element={<ShelfPage {...props} />} />
+        <Route path="/books/:pdfId" element={<ReaderStub />} />
+      </Routes>
     </MemoryRouter>,
   );
+}
+
+/** Stands in for the reader so navigation away from the shelf is observable. */
+function ReaderStub() {
+  return <p>リーダー: {useParams().pdfId}</p>;
 }
 
 /** Records the ids it was asked to delete so tests can assert on them. */
@@ -40,15 +48,21 @@ function recordingDeleter() {
 const TWO_BOOKS = async () => [book(), book({ id: "book-2", fileName: "Rust 入門.pdf" })];
 
 describe("ShelfPage", () => {
-  it("lists the books it loaded", async () => {
-    renderShelf({
-      loadBooks: async () => [book(), book({ id: "book-2", fileName: "Rust 入門.pdf" })],
-    });
+  it("shows a card per book once the shelf has loaded", async () => {
+    renderShelf({ loadBooks: TWO_BOOKS });
 
     expect(
       await screen.findByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Rust 入門 を開く" })).toBeInTheDocument();
+  });
+
+  it("opens the reader for the book whose card was clicked", async () => {
+    renderShelf({ loadBooks: TWO_BOOKS });
+
+    await userEvent.click(await screen.findByRole("button", { name: "Rust 入門 を開く" }));
+
+    expect(await screen.findByText("リーダー: book-2")).toBeInTheDocument();
   });
 
   it("reports why the shelf is empty when loading fails", async () => {
@@ -77,18 +91,22 @@ describe("ShelfPage", () => {
       screen.queryByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
     ).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Rust 入門 を開く" })).toBeInTheDocument();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
   });
 
-  it("warns that the highlights and chats go with the book", async () => {
+  it("warns that the highlights and chats go too when asked to delete a book", async () => {
     renderShelf({ loadBooks: TWO_BOOKS, deleteBook: recordingDeleter().deleteBook });
 
     await userEvent.click(
       await screen.findByRole("button", { name: "Cloudflare Workers 入門 を削除" }),
     );
 
-    expect(screen.getByRole("alertdialog")).toHaveTextContent(
-      "「Cloudflare Workers 入門」を削除しますか？ハイライトとチャット履歴も削除されます。",
-    );
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "「Cloudflare Workers 入門」を削除しますか？ハイライトとチャット履歴も削除されます。",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("keeps the book when the deletion is cancelled", async () => {
@@ -124,5 +142,39 @@ describe("ShelfPage", () => {
     expect(
       screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
     ).toBeInTheDocument();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("keeps the book when the confirmation is dismissed with Escape", async () => {
+    const { deletedIds, deleteBook } = recordingDeleter();
+    renderShelf({ loadBooks: TWO_BOOKS, deleteBook });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Cloudflare Workers 入門 を削除" }),
+    );
+    await userEvent.keyboard("{Escape}");
+
+    expect(deletedIds).toEqual([]);
+    expect(
+      screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("keeps the book when the click lands outside the confirmation", async () => {
+    const { deletedIds, deleteBook } = recordingDeleter();
+    renderShelf({ loadBooks: TWO_BOOKS, deleteBook });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Cloudflare Workers 入門 を削除" }),
+    );
+    // The backdrop is the dialog's own wrapper; it has no role of its own
+    await userEvent.click(screen.getByRole("alertdialog").parentElement!);
+
+    expect(deletedIds).toEqual([]);
+    expect(
+      screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
   });
 });

--- a/src/front/pages/ShelfPage.test.tsx
+++ b/src/front/pages/ShelfPage.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vite-plus/test";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { ShelfPage, type Book } from "./ShelfPage";
+
+function book(overrides: Partial<Book> = {}): Book {
+  return {
+    id: "book-1",
+    fileName: "Cloudflare Workers 入門.pdf",
+    pageCount: 209,
+    updatedAt: "2026-01-01T00:00:00Z",
+    hasThumbnail: false,
+    ...overrides,
+  };
+}
+
+function renderShelf(props: { loadBooks?: () => Promise<Book[]> }) {
+  render(
+    <MemoryRouter>
+      <ShelfPage {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ShelfPage", () => {
+  it("lists the books it loaded", async () => {
+    renderShelf({
+      loadBooks: async () => [book(), book({ id: "book-2", fileName: "Rust 入門.pdf" })],
+    });
+
+    expect(
+      await screen.findByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Rust 入門 を開く" })).toBeInTheDocument();
+  });
+
+  it("reports why the shelf is empty when loading fails", async () => {
+    renderShelf({
+      loadBooks: async () => {
+        throw new Error("Network down");
+      },
+    });
+
+    expect(
+      await screen.findByText("本棚の読み込みに失敗しました: Network down"),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/front/pages/ShelfPage.test.tsx
+++ b/src/front/pages/ShelfPage.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { ShelfPage, type Book } from "./ShelfPage";
 
@@ -14,13 +15,29 @@ function book(overrides: Partial<Book> = {}): Book {
   };
 }
 
-function renderShelf(props: { loadBooks?: () => Promise<Book[]> }) {
+function renderShelf(props: {
+  loadBooks?: () => Promise<Book[]>;
+  deleteBook?: (id: string) => Promise<unknown>;
+}) {
   render(
     <MemoryRouter>
       <ShelfPage {...props} />
     </MemoryRouter>,
   );
 }
+
+/** Records the ids it was asked to delete so tests can assert on them. */
+function recordingDeleter() {
+  const deletedIds: string[] = [];
+  return {
+    deletedIds,
+    deleteBook: async (id: string) => {
+      deletedIds.push(id);
+    },
+  };
+}
+
+const TWO_BOOKS = async () => [book(), book({ id: "book-2", fileName: "Rust 入門.pdf" })];
 
 describe("ShelfPage", () => {
   it("lists the books it loaded", async () => {
@@ -43,6 +60,69 @@ describe("ShelfPage", () => {
 
     expect(
       await screen.findByText("本棚の読み込みに失敗しました: Network down"),
+    ).toBeInTheDocument();
+  });
+
+  it("deletes the book once the deletion is confirmed, and takes it off the shelf", async () => {
+    const { deletedIds, deleteBook } = recordingDeleter();
+    renderShelf({ loadBooks: TWO_BOOKS, deleteBook });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Cloudflare Workers 入門 を削除" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "削除する" }));
+
+    expect(deletedIds).toEqual(["book-1"]);
+    expect(
+      screen.queryByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Rust 入門 を開く" })).toBeInTheDocument();
+  });
+
+  it("warns that the highlights and chats go with the book", async () => {
+    renderShelf({ loadBooks: TWO_BOOKS, deleteBook: recordingDeleter().deleteBook });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Cloudflare Workers 入門 を削除" }),
+    );
+
+    expect(screen.getByRole("alertdialog")).toHaveTextContent(
+      "「Cloudflare Workers 入門」を削除しますか？ハイライトとチャット履歴も削除されます。",
+    );
+  });
+
+  it("keeps the book when the deletion is cancelled", async () => {
+    const { deletedIds, deleteBook } = recordingDeleter();
+    renderShelf({ loadBooks: TWO_BOOKS, deleteBook });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Cloudflare Workers 入門 を削除" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+
+    expect(deletedIds).toEqual([]);
+    expect(
+      screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("keeps the book on the shelf and says why when the deletion fails", async () => {
+    renderShelf({
+      loadBooks: TWO_BOOKS,
+      deleteBook: async () => {
+        throw new Error("Server exploded");
+      },
+    });
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Cloudflare Workers 入門 を削除" }),
+    );
+    await userEvent.click(screen.getByRole("button", { name: "削除する" }));
+
+    expect(await screen.findByText("削除に失敗しました: Server exploded")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
     ).toBeInTheDocument();
   });
 });

--- a/src/front/pages/ShelfPage.tsx
+++ b/src/front/pages/ShelfPage.tsx
@@ -15,15 +15,27 @@ export interface Book {
 /** Module-level so the effect below keeps a stable dependency. */
 const fetchBooks = () => fetcher<{ books: Book[] }>("/api/pdfs").then((data) => data.books);
 
+const requestBookDeletion = (id: string) =>
+  fetcher<{ deleted: true }>(`/api/pdf/${id}`, { method: "DELETE" });
+
 interface ShelfPageProps {
   loadBooks?: () => Promise<Book[]>;
+  deleteBook?: (id: string) => Promise<unknown>;
 }
 
 function bookTitle(fileName: string): string {
   return fileName.replace(/\.pdf$/i, "");
 }
 
-function BookCard({ book, onOpen }: { book: Book; onOpen: (id: string) => void }) {
+function BookCard({
+  book,
+  onOpen,
+  onDelete,
+}: {
+  book: Book;
+  onOpen: (id: string) => void;
+  onDelete: (book: Book) => void;
+}) {
   const [coverFailed, setCoverFailed] = useState(false);
   const showCover = book.hasThumbnail && !coverFailed;
   const title = bookTitle(book.fileName);
@@ -56,14 +68,79 @@ function BookCard({ book, onOpen }: { book: Book; onOpen: (id: string) => void }
         <p className="mt-2 line-clamp-2 text-sm font-medium text-gray-800">{title}</p>
         <p className="text-xs text-gray-500">{book.pageCount} ページ</p>
       </button>
+
+      <button
+        type="button"
+        aria-label={`${title} を削除`}
+        onClick={() => onDelete(book)}
+        className="absolute right-1.5 top-1.5 rounded-full bg-black/55 px-2 py-0.5 text-sm leading-normal text-white opacity-0 transition-opacity cursor-pointer hover:bg-red-600 focus-visible:opacity-100 group-hover/card:opacity-100"
+      >
+        ×
+      </button>
     </div>
   );
 }
 
-export function ShelfPage({ loadBooks = fetchBooks }: ShelfPageProps = {}) {
+function DeleteConfirmDialog({
+  book,
+  onConfirm,
+  onCancel,
+}: {
+  book: Book;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    // Escape is handled here rather than on document, so the listener lives and
+    // dies with the dialog itself.
+    <div
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onCancel();
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-label="本の削除"
+        className="w-full max-w-sm rounded-lg bg-white p-5 shadow-xl"
+      >
+        <p className="text-sm text-gray-800">
+          「{bookTitle(book.fileName)}」を削除しますか？ハイライトとチャット履歴も削除されます。
+        </p>
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            autoFocus
+            onClick={onCancel}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 cursor-pointer hover:bg-gray-50"
+          >
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white cursor-pointer hover:bg-red-700"
+          >
+            削除する
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ShelfPage({
+  loadBooks = fetchBooks,
+  deleteBook = requestBookDeletion,
+}: ShelfPageProps = {}) {
   const navigate = useNavigate();
   const [books, setBooks] = useState<Book[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [bookPendingDeletion, setBookPendingDeletion] = useState<Book | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -83,6 +160,17 @@ export function ShelfPage({ loadBooks = fetchBooks }: ShelfPageProps = {}) {
   }, [loadBooks]);
 
   const openBook = useCallback((id: string) => navigate(`/books/${id}`), [navigate]);
+
+  const removeBook = async (book: Book) => {
+    setError(null);
+    setBookPendingDeletion(null);
+    try {
+      await deleteBook(book.id);
+      setBooks((current) => current?.filter((b) => b.id !== book.id) ?? current);
+    } catch (err) {
+      setError(`削除に失敗しました: ${(err as Error).message}`);
+    }
+  };
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -109,12 +197,20 @@ export function ShelfPage({ loadBooks = fetchBooks }: ShelfPageProps = {}) {
           <ul className="grid grid-cols-2 gap-x-5 gap-y-7 sm:grid-cols-3 lg:grid-cols-5">
             {books.map((book) => (
               <li key={book.id}>
-                <BookCard book={book} onOpen={openBook} />
+                <BookCard book={book} onOpen={openBook} onDelete={setBookPendingDeletion} />
               </li>
             ))}
           </ul>
         )}
       </main>
+
+      {bookPendingDeletion && (
+        <DeleteConfirmDialog
+          book={bookPendingDeletion}
+          onConfirm={() => removeBook(bookPendingDeletion)}
+          onCancel={() => setBookPendingDeletion(null)}
+        />
+      )}
     </div>
   );
 }

--- a/src/front/pages/ShelfPage.tsx
+++ b/src/front/pages/ShelfPage.tsx
@@ -4,12 +4,19 @@ import { useNavigate } from "react-router";
 import { FileSelector } from "../components/PdfViewer/FileSelector";
 import { fetcher } from "../lib/fetcher";
 
-interface Book {
+export interface Book {
   id: string;
   fileName: string;
   pageCount: number;
   updatedAt: string;
   hasThumbnail: boolean;
+}
+
+/** Module-level so the effect below keeps a stable dependency. */
+const fetchBooks = () => fetcher<{ books: Book[] }>("/api/pdfs").then((data) => data.books);
+
+interface ShelfPageProps {
+  loadBooks?: () => Promise<Book[]>;
 }
 
 function bookTitle(fileName: string): string {
@@ -22,55 +29,58 @@ function BookCard({ book, onOpen }: { book: Book; onOpen: (id: string) => void }
   const title = bookTitle(book.fileName);
 
   return (
-    <button
-      type="button"
-      onClick={() => onOpen(book.id)}
-      className="group flex w-full flex-col text-left cursor-pointer focus:outline-none"
-    >
-      <div className="relative aspect-3/4 w-full overflow-hidden rounded-r-md rounded-l-sm border-l-4 border-gray-300 bg-gray-100 shadow-md transition-all group-hover:-translate-y-1 group-hover:shadow-xl group-focus-visible:ring-2 group-focus-visible:ring-blue-500">
-        {showCover ? (
-          <img
-            src={`/api/pdf/${book.id}/thumbnail`}
-            alt={`${title} の表紙`}
-            loading="lazy"
-            onError={() => setCoverFailed(true)}
-            className="h-full w-full object-cover"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-slate-600 to-slate-800 p-3">
-            <span className="line-clamp-5 text-center text-xs font-medium text-white/90">
-              {title}
-            </span>
-          </div>
-        )}
-      </div>
-      <p className="mt-2 line-clamp-2 text-sm font-medium text-gray-800">{title}</p>
-      <p className="text-xs text-gray-500">{book.pageCount} ページ</p>
-    </button>
+    <div className="relative group/card">
+      <button
+        type="button"
+        aria-label={`${title} を開く`}
+        onClick={() => onOpen(book.id)}
+        className="group flex w-full flex-col text-left cursor-pointer focus:outline-none"
+      >
+        <div className="relative aspect-3/4 w-full overflow-hidden rounded-r-md rounded-l-sm border-l-4 border-gray-300 bg-gray-100 shadow-md transition-all group-hover:-translate-y-1 group-hover:shadow-xl group-focus-visible:ring-2 group-focus-visible:ring-blue-500">
+          {showCover ? (
+            <img
+              src={`/api/pdf/${book.id}/thumbnail`}
+              alt={`${title} の表紙`}
+              loading="lazy"
+              onError={() => setCoverFailed(true)}
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-linear-to-br from-slate-600 to-slate-800 p-3">
+              <span className="line-clamp-5 text-center text-xs font-medium text-white/90">
+                {title}
+              </span>
+            </div>
+          )}
+        </div>
+        <p className="mt-2 line-clamp-2 text-sm font-medium text-gray-800">{title}</p>
+        <p className="text-xs text-gray-500">{book.pageCount} ページ</p>
+      </button>
+    </div>
   );
 }
 
-export function ShelfPage() {
+export function ShelfPage({ loadBooks = fetchBooks }: ShelfPageProps = {}) {
   const navigate = useNavigate();
   const [books, setBooks] = useState<Book[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    fetcher<{ books: Book[] }>("/api/pdfs")
-      .then((data) => {
-        if (!cancelled) setBooks(data.books);
+    loadBooks()
+      .then((loaded) => {
+        if (!cancelled) setBooks(loaded);
       })
       .catch((err: Error) => {
         if (!cancelled) {
-          setError(err.message);
+          setError(`本棚の読み込みに失敗しました: ${err.message}`);
           setBooks([]);
         }
       });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [loadBooks]);
 
   const openBook = useCallback((id: string) => navigate(`/books/${id}`), [navigate]);
 
@@ -82,11 +92,7 @@ export function ShelfPage() {
       </header>
 
       <main className="mx-auto max-w-6xl p-6">
-        {error && (
-          <p className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-600">
-            本棚の読み込みに失敗しました: {error}
-          </p>
-        )}
+        {error && <p className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-600">{error}</p>}
 
         {books === null && <p className="text-sm text-gray-500">読み込み中...</p>}
 

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -7,6 +7,7 @@ import {
   openPdf,
   getPdf,
   listPdfs,
+  deletePdf,
   thumbnailObjectKey,
   THUMBNAIL_CONTENT_TYPE,
 } from "../services/pdfService";
@@ -412,6 +413,14 @@ export const pdfRoute = new Hono<Env>()
         Connection: "keep-alive",
       },
     });
+  })
+  .delete("/pdf/:pdfId", async (c) => {
+    const deleted = await deletePdf(c.env.DB, c.env.PDF_BUCKET, c.req.param("pdfId"));
+    if (!deleted) {
+      return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+    }
+
+    return c.json({ deleted: true });
   })
   .delete("/pdf/:pdfId/selections/:selId", async (c) => {
     const selId = c.req.param("selId");

--- a/src/server/services/pdfService.ts
+++ b/src/server/services/pdfService.ts
@@ -131,6 +131,25 @@ export async function openPdf(
 }
 
 /**
+ * Delete a book together with everything it owns: its selections and chat
+ * messages (via the schema's ON DELETE CASCADE) and its R2 objects.
+ * D1 is cleared first — if the R2 cleanup then fails, only an unreachable
+ * object is left behind, whereas the reverse order would leave a book on the
+ * shelf whose binary is gone.
+ * Returns false when no such book exists.
+ */
+export async function deletePdf(db: D1Database, bucket: R2Bucket, pdfId: string): Promise<boolean> {
+  const d1Db = drizzle(db);
+  const pdf = await d1Db.select().from(pdfs).where(eq(pdfs.id, pdfId)).get();
+  if (!pdf) return false;
+
+  await d1Db.delete(pdfs).where(eq(pdfs.id, pdfId));
+  await bucket.delete([pdfObjectKey(pdf.fileHash), thumbnailObjectKey(pdf.fileHash)]);
+
+  return true;
+}
+
+/**
  * Get a PDF record by id, including its selections.
  */
 export async function getPdf(db: D1Database, bucket: R2Bucket, pdfId: string) {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,3 +3,10 @@ import "@testing-library/jest-dom/vitest";
 // jsdom has no layout engine, so it ships no scrollIntoView. Components that
 // keep a conversation pinned to the bottom would throw on mount without it.
 Element.prototype.scrollIntoView = () => {};
+
+// pdf.js constructs a DOMMatrix at module scope, which jsdom does not provide.
+// jsdom tests never rasterize a page, so anything that can be constructed is
+// enough to let modules that transitively import pdf.js load.
+if (!("DOMMatrix" in globalThis)) {
+  (globalThis as { DOMMatrix?: unknown }).DOMMatrix = class {};
+}

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from "vite-plus/test";
 import { env, applyD1Migrations, SELF } from "cloudflare:test";
 import { MINIMAL_PDF_BYTES } from "./fixtures/minimalPdf";
+import { pdfObjectKey, thumbnailObjectKey } from "../../src/server/services/pdfService";
 
 beforeAll(async () => {
   await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
@@ -57,6 +58,14 @@ interface PdfResponse {
 }
 
 const FAKE_WEBP = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00, 0x57, 0x45, 0x42, 0x50]);
+
+/** Row count for a table filtered by one column, used to observe cascade deletes. */
+async function countRows(table: string, column: string, value: string): Promise<number> {
+  const row = (await env.DB.prepare(`SELECT COUNT(*) AS count FROM ${table} WHERE ${column} = ?`)
+    .bind(value)
+    .first()) as { count: number };
+  return row.count;
+}
 
 describe("POST /api/pdf/open", () => {
   it("uploads a PDF file and returns its metadata", async () => {
@@ -297,6 +306,78 @@ describe("PDF thumbnails", () => {
     });
 
     expect(response.status).toBe(404);
+  });
+});
+
+describe("DELETE /api/pdf/:pdfId", () => {
+  it("removes the book, its selections and chats, and its stored files", async () => {
+    const book = await uploadBook({
+      tag: "delete-book",
+      fileName: "delete-me.pdf",
+      thumbnail: new Blob([FAKE_WEBP], { type: "image/webp" }),
+    });
+
+    const selectionResponse = await SELF.fetch(
+      `https://example.com/api/pdf/${book.id}/selections`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          selectedText: "消えるべき選択",
+          pageNumber: 1,
+          positionData: { rects: [] },
+        }),
+      },
+    );
+    const selection = (await selectionResponse.json()) as { id: string };
+
+    // Seeded directly: POST .../chats streams from DeepSeek over SSE, which is far
+    // more machinery than this cascade check needs.
+    await env.DB.prepare(
+      "INSERT INTO chat_messages (id, selection_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)",
+    )
+      .bind(
+        "chat-delete-book",
+        selection.id,
+        "user",
+        "この選択について教えて",
+        "2026-01-01T00:00:00Z",
+      )
+      .run();
+
+    const { file_hash: fileHash } = (await env.DB.prepare("SELECT file_hash FROM pdfs WHERE id = ?")
+      .bind(book.id)
+      .first()) as { file_hash: string };
+
+    expect(await countRows("selections", "pdf_id", book.id)).toBe(1);
+    expect(await countRows("chat_messages", "selection_id", selection.id)).toBe(1);
+    expect(await env.PDF_BUCKET.head(pdfObjectKey(fileHash))).not.toBeNull();
+    expect(await env.PDF_BUCKET.head(thumbnailObjectKey(fileHash))).not.toBeNull();
+
+    const response = await SELF.fetch(`https://example.com/api/pdf/${book.id}`, {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toStrictEqual({ deleted: true });
+
+    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}`);
+    expect(getResponse.status).toBe(404);
+    expect(await countRows("selections", "pdf_id", book.id)).toBe(0);
+    expect(await countRows("chat_messages", "selection_id", selection.id)).toBe(0);
+    expect(await env.PDF_BUCKET.head(pdfObjectKey(fileHash))).toBeNull();
+    expect(await env.PDF_BUCKET.head(thumbnailObjectKey(fileHash))).toBeNull();
+  });
+
+  it("returns 404 for an unknown book", async () => {
+    const response = await SELF.fetch("https://example.com/api/pdf/does-not-exist", {
+      method: "DELETE",
+    });
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toStrictEqual({
+      error: { code: "PDF_NOT_FOUND", message: "PDF not found" },
+    });
   });
 });
 

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -59,6 +59,14 @@ interface PdfResponse {
 
 const FAKE_WEBP = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00, 0x57, 0x45, 0x42, 0x50]);
 
+/** The content hash a book is stored under, which its R2 keys are derived from. */
+async function storedFileHash(pdfId: string): Promise<string> {
+  const row = (await env.DB.prepare("SELECT file_hash FROM pdfs WHERE id = ?")
+    .bind(pdfId)
+    .first()) as { file_hash: string };
+  return row.file_hash;
+}
+
 /** Row count for a table filtered by one column, used to observe cascade deletes. */
 async function countRows(table: string, column: string, value: string): Promise<number> {
   const row = (await env.DB.prepare(`SELECT COUNT(*) AS count FROM ${table} WHERE ${column} = ?`)
@@ -310,10 +318,15 @@ describe("PDF thumbnails", () => {
 });
 
 describe("DELETE /api/pdf/:pdfId", () => {
-  it("removes the book, its selections and chats, and its stored files", async () => {
+  it("removes only the deleted book, along with its selections, chats and stored files", async () => {
     const book = await uploadBook({
       tag: "delete-book",
       fileName: "delete-me.pdf",
+      thumbnail: new Blob([FAKE_WEBP], { type: "image/webp" }),
+    });
+    const survivor = await uploadBook({
+      tag: "delete-survivor",
+      fileName: "keep-me.pdf",
       thumbnail: new Blob([FAKE_WEBP], { type: "image/webp" }),
     });
 
@@ -345,9 +358,8 @@ describe("DELETE /api/pdf/:pdfId", () => {
       )
       .run();
 
-    const { file_hash: fileHash } = (await env.DB.prepare("SELECT file_hash FROM pdfs WHERE id = ?")
-      .bind(book.id)
-      .first()) as { file_hash: string };
+    const fileHash = await storedFileHash(book.id);
+    const survivorHash = await storedFileHash(survivor.id);
 
     expect(await countRows("selections", "pdf_id", book.id)).toBe(1);
     expect(await countRows("chat_messages", "selection_id", selection.id)).toBe(1);
@@ -367,6 +379,12 @@ describe("DELETE /api/pdf/:pdfId", () => {
     expect(await countRows("chat_messages", "selection_id", selection.id)).toBe(0);
     expect(await env.PDF_BUCKET.head(pdfObjectKey(fileHash))).toBeNull();
     expect(await env.PDF_BUCKET.head(thumbnailObjectKey(fileHash))).toBeNull();
+
+    // A delete that lost its WHERE clause would empty the whole shelf
+    const survivorResponse = await SELF.fetch(`https://example.com/api/pdf/${survivor.id}`);
+    expect(survivorResponse.status).toBe(200);
+    expect(await env.PDF_BUCKET.head(pdfObjectKey(survivorHash))).not.toBeNull();
+    expect(await env.PDF_BUCKET.head(thumbnailObjectKey(survivorHash))).not.toBeNull();
   });
 
   it("returns 404 for an unknown book", async () => {


### PR DESCRIPTION
## 何をしたか

本棚から本 (PDF) を削除できるようにした。本を消すと、その本に紐づくハイライトとチャット履歴、R2 に置いた PDF 本体と表紙もまとめて消える。

これまで本は追加する一方で、一度開いた本を消す手段がなかった。

## 変更点

**サーバ** — `DELETE /api/pdf/:pdfId` を追加した。`pdfService.deletePdf` が `pdfs` の行を消すと、スキーマにもとから入っている `ON DELETE CASCADE` で `selections` と `chat_messages` が連鎖削除され、続けて R2 の 2 オブジェクトを削除する。存在しない本には 404 を返す。

D1 を先に消しているのは、R2 の後始末が失敗しても到達不能なオブジェクトが残るだけで済むため。逆順だとバイナリの無い本が本棚に残る。

**フロント** — 本カードにホバーで現れる削除ボタンを置き、確認ダイアログ (`role="alertdialog"`) で承諾した本だけを削除する。ダイアログはキャンセルボタン・Escape・背景クリックのいずれでも閉じられる。削除に成功したカードは本棚から取り除き、失敗したときは理由をバナーに出して本は残す。

ハイライトとチャット履歴も消えることはダイアログの文面で伝えている。

## 動作確認

- フロント単体 112 件 / Worker 単体 24 件とも green、`vp check` は 0 warning、`vp build` 成功
- 「壊した状態で落ちること」を 3 箇所で確認した。`deleteBook` の呼び出しを外す / `deletePdf` の `WHERE` 句を外す (本棚が全消えする回帰) / ダイアログの Escape・背景クリックのハンドラを外す、いずれもテストが失敗する
- 実機は Playwright で確認済み。ハイライト付きの本を削除すると本棚から消えて API も 404 になり、別の本は残る。console の error / warning はゼロ

## 既知の残り

削除 API の URL と HTTP メソッドの配線 (`requestBookDeletion`) は、コミット済みの自動テストでは実行されていない。単体テストは常に fake を注入するため。実際の配線は上記の Playwright 検証でのみ確認しており、E2E は既存フィクスチャ (209 ページの本) を消すと後続テストが重くなるため今回は見送った。

🤖 Generated with [Claude Code](https://claude.com/claude-code)