### PR TITLE
🐛 fix: ページ遷移したらページ先頭にスクロールする

### DIFF
--- a/e2e/chatbook.spec.ts
+++ b/e2e/chatbook.spec.ts
@@ -511,6 +511,13 @@ test("vim keys turn pages, scroll, and toggle the outline by default", async ({ 
   await page.keyboard.press("k");
   await expect.poll(() => pageScrollTop(page)).toBe(0);
 
+  // A page turn starts the next page at its top, wherever the last one was left
+  await page.keyboard.press("j");
+  await expect.poll(() => pageScrollTop(page)).toBeGreaterThan(0);
+  await page.keyboard.press("l");
+  await expect(page.getByText("2 / 209", { exact: true })).toBeVisible();
+  await expect.poll(() => pageScrollTop(page)).toBe(0);
+
   await page.keyboard.press("t");
   await expect(outline).toBeHidden();
   await page.keyboard.press("t");

--- a/src/front/components/PdfViewer/PdfViewer.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.tsx
@@ -1,4 +1,4 @@
-// oxlint-disable-next-line no-restricted-imports -- 本の切り替えに合わせたハイライト読み直しと、表示幅の ResizeObserver 購読に必要
+// oxlint-disable-next-line no-restricted-imports -- 本の切り替えに合わせたハイライト読み直し、表示幅の ResizeObserver 購読、ページ遷移時のスクロール位置リセットに必要
 import { useRef, useState, useCallback, useEffect } from "react";
 import { useAtomValue, useAtom } from "jotai";
 import {
@@ -143,6 +143,12 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
       observer.disconnect();
     };
   }, [pdfDocument]);
+
+  // A page turn swaps the canvas inside this same pane, so the scroll position
+  // would carry over and the next page would open part-way down.
+  useEffect(() => {
+    containerRef.current?.scrollTo({ top: 0 });
+  }, [currentPage]);
 
   // Draw the selection ourselves while the drag is still in progress. The
   // browser's own selection colour stacks up where pdf.js' spans overlap, which


### PR DESCRIPTION
## 何を直したか

PDF ビュアーでページを送っても、前のページで下までスクロールした位置がそのまま引き継がれていた。次のページが途中から表示されるので、毎回手で上まで戻す必要があった。

ページ遷移はスクロールコンテナの中で canvas が差し替わるだけなので、`currentPage` の変更を購読して、そのコンテナ (j/k のスクロールが操作しているのと同じ `containerRef`) を先頭に戻すようにした。

ページ番号を変える経路は 6 つあるが、atom の変更点で受けているのですべてに効く。

- 次へ / 前へボタン
- キーバインド (vim: `h` / `l` / `gg` / `G`、emacs: `C-n` / `C-p` / `M-<` / `M->`)
- 目次ジャンプ
- 回答の引用バッジ
- ハイライト一覧からのジャンプ
- URL (`?page=`) / テキストフラグメントからの復元

前のページへ戻るときも先頭にリセットする。

## 動作確認

- 追加した E2E (`vim keys turn pages, scroll, and toggle the outline by default` への追記) が pass。3 回連続で確認
- **実装を外すと落ちる**ことを確認 (Expected 0 / Received 80)
- フロント単体 103 passed / Worker 22 passed / `vp check` pass / `vp build` pass

検証は worktree 専用に立てた dev サーバーに対して実施した。リポジトリの `e2e/playwright.config.ts` は `baseURL: 5173` + `reuseExistingServer: true` なので、別のクローンで dev サーバーが動いているとそちらを検証してしまう点に注意。

## 補足

追加した E2E は CI では実行されない (CI は単体テスト・`vp check`・`vp build` のみ)。E2E のチャット系テストが実 DeepSeek API を叩いている件は #6 で別途対応する。
