### PR TITLE
✅ test: E2E がサーバーを専用ポートで自動起動するようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,25 @@ E2E を1件だけ走らせる: `pnpm run test:e2e -- -g "テスト名の一部"`
 
 `git push` 時に lefthook の `pre-push` が `vp check` + `vp build` を実行し、失敗すると push はブロックされる。
 
+### worktree を作ったら最初に `.dev.vars` を用意する
+
+`.dev.vars` は gitignore 済み（`.gitignore:4`）で **worktree には複製されない**。無いまま
+`vp dev`（`pnpm run test:e2e` の自動起動を含む）を動かすと、`@cloudflare/vite-plugin` が
+commit 済みの `worker-configuration.d.ts` を再生成し、`DEEPSEEK_API_KEY` の宣言が消えた差分が
+毎回出る。worktree を切ったら実装を始める前に用意する:
+
+```bash
+echo 'DEEPSEEK_API_KEY=dummy' > .dev.vars
+```
+
+型の差分は値ではなく鍵の**存在**で決まるので、ダミー値で消える。ただし DeepSeek へ実際に
+問い合わせるテスト（`e2e/chatbook.spec.ts` のチャット系）はダミー値だと認証が通らず、
+トークンが 1 つも届かないまま 60 秒のタイムアウトまで粘って落ちる。通したいとき（と E2E 全体を
+速く終わらせたいとき）はメインクローンの `.dev.vars` から実キーをコピーする。
+
+`.dev.vars.example` は Cognito 変数だけを列挙しており現在のコードと合っていないので、
+コピー元には使わない。
+
 ### `useEffect` の扱い
 
 `vite.config.ts` の `no-restricted-imports` が `useEffect` の import を禁止している。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ pnpm run db:migrate:local # D1 マイグレーション適用（初回 / migrati
 
 pnpm test                 # フロント単体 (jsdom)
 pnpm run test:worker      # Worker 単体 (@cloudflare/vitest-pool-workers)
-pnpm run test:e2e         # E2E (Playwright)。vp dev が起動している前提
+pnpm run test:e2e         # E2E (Playwright)。サーバーは自動起動するので vp dev は不要
 
 vp check                  # フォーマット + lint + 型チェック（--fix で自動修正）
 vp exec wrangler types    # wrangler.jsonc の bindings/main 変更後に Env 型を再生成
@@ -146,12 +146,19 @@ jsdom テストと Workers pool テストは同一プロセスで共存できな
 
 ### E2E の前提
 
-- `vp dev` が起動していること。テスト用 PDF は
+- **サーバーは Playwright が自動起動する**（`e2e/playwright.config.ts` の `webServer`）。
+  `pnpm run db:migrate:local && vp dev --port <port> --strictPort` を実行するので、
+  マイグレーション未適用の worktree でもそのまま走る。`reuseExistingServer: false` のため、
+  起動済みサーバーには相乗りせず必ずこのチェックアウトのコードでテストする
+- **ポートは worktree のパスから決定的に導出する**（5175〜5674 の範囲。`E2E_PORT` で上書き可）。
+  5173 固定だと別クローンの `vp dev` に誤接続したまま「成功」しうるため。`--strictPort` により
+  導出ポートが埋まっていれば黙って別ポートへ逃げず即座に失敗する
+- テスト用 PDF は
   `~/Documents/資料/本/Web開発者のための［入門］Cloudflare-Workers-――JavaScript・TypeScriptの簡単・高速プラットフォーム_00.pdf`（209ページ）。
   無い場合はスキップされる（パスは `e2e/chatbook.spec.ts` の `TEST_PDF` 定数）
-- **dev と E2E は同じローカル D1 / R2 を共有する**。ハイライトは永続化され、テキストレイヤーの
-  上に乗るため、残骸があると後続の選択テストを壊す。`openTestBook` ヘルパーが開始前に
-  selection を全削除する
+- **同じ worktree の dev サーバーと E2E は同じローカル D1 / R2（`.wrangler/`）を共有する**。
+  ハイライトは永続化され、テキストレイヤーの上に乗るため、残骸があると後続の選択テストを壊す。
+  `openTestBook` ヘルパーが開始前に selection を全削除する
 - UI の回帰テストを足したら、**実装を壊した状態で落ちること**を必ず確認する。
   ここは「動いていないのに通る」テストが生まれやすい（例: 計測用 canvas はサイズが 0 になる
   瞬間があるため box では検出できず、`display` を見る必要があった）

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,18 +1,27 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "@playwright/test";
+
+// worktree ごとに専用ポートを割り当てる。5173 固定だと別クローンの dev サーバーに
+// 誤接続したまま「成功」しうるため、リポジトリのパスから決定的に導出する。
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pathHash = createHash("sha256").update(projectRoot).digest().readUInt16BE(0);
+const port = Number(process.env.E2E_PORT ?? 5175 + (pathHash % 500));
 
 export default defineConfig({
   testDir: "./",
   timeout: 60000,
   retries: 0,
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: `http://localhost:${port}`,
     headless: true,
   },
   webServer: {
-    command: "cd .. && vp dev",
-    port: 5173,
-    timeout: 30000,
-    reuseExistingServer: true,
+    command: `pnpm run db:migrate:local && vp dev --port ${port} --strictPort`,
+    port,
+    timeout: 120000,
+    reuseExistingServer: false,
     cwd: "../",
   },
 });


### PR DESCRIPTION
## 背景

`pnpm run test:e2e` は `baseURL`/`webServer` のポートが 5173 固定 + `reuseExistingServer: true` だったため、
別クローン (worktree 運用時のメインクローン等) の `vp dev` が 5173 に居ると、**そのクローンのコードに対して
テストが走り、しかも成功してしまう**状態だった。実際に本 PR の検証中もメインクローンの dev サーバーが
5173 を占有していた。

また新しく切った worktree では D1 マイグレーションが未適用なためサーバーが 500 を返し、E2E がそのままでは動かなかった。

## 変更内容

### `e2e/playwright.config.ts`

- ポートをリポジトリのパスの SHA-256 から決定的に導出する (5175〜5674、`E2E_PORT` で上書き可)
- `vp dev` に `--strictPort` を渡し、ポートが埋まっていれば黙って隣のポートへ逃げず即座に失敗させる
- `reuseExistingServer: false` にして、常にこのチェックアウトのコードでサーバーを起動する
- 起動コマンドに `pnpm run db:migrate:local` を含め、新規 worktree でもそのまま走るようにする
- `command` の `cd .. &&` と `cwd` の二重指定を解消し、`timeout` をマイグレーション込みで 120s に延長

spec 側はすべて baseURL 相対だったため変更なし。

### `CLAUDE.md`

- E2E がサーバーを自動起動する旨とポート導出のルールを追記 (従来は「`vp dev` が起動している前提」)
- worktree を切ったら `.dev.vars` にダミーの `DEEPSEEK_API_KEY` を置く手順を追記。
  これが無いと `vp dev` / `test:e2e` のたびに commit 済みの `worker-configuration.d.ts` が再生成され、
  `DEEPSEEK_API_KEY` の宣言が消えた差分が毎回出るため

## 動作確認

- フル実行: **23 passed / 1 failed**。失敗は `asking from the popover ...` の 1 件のみで、これは実 DeepSeek API を
  叩くテストであり、ダミーキーの worktree では通らない (別途対応中)
- **誤接続防止**: 導出ポートをダミーの HTTP サーバーで塞いだ状態で実行し、
  `http://localhost:<port> is already used` で即失敗することを確認 (2 つの異なる導出ポートで検証)
- **dev サーバーとの共存**: メインクローンの `vp dev` が 5173 を占有したまま、E2E は専用ポートで独立して完走
- マイグレーションが非対話 (Playwright が spawn する非 TTY) でも自動継続することを確認
- `.dev.vars` を置いた状態でフル実行し、`worker-configuration.d.ts` が汚れないことを確認
- `vp check`: フォーマット・lint・型チェックすべて pass

なお CI は E2E を実行しないため、上記はすべてローカルでの確認結果。

🤖 Generated with [Claude Code](https://claude.com/claude-code)