### PR TITLE
♻️ refactor: 外界 (IO) の DI 違反を修正する

### DIFF
--- a/src/front/components/ChatArea/ChatMessageBubble.tsx
+++ b/src/front/components/ChatArea/ChatMessageBubble.tsx
@@ -6,7 +6,8 @@ import { CitationBadge } from "./CitationBadge";
 import { stripSources } from "../../lib/stripSources";
 
 interface ChatMessageBubbleProps {
-  message: ChatMessage;
+  /** Only what the bubble renders; a streaming answer has no id or timestamp yet. */
+  message: Pick<ChatMessage, "role" | "content" | "citations">;
 }
 
 /**

--- a/src/front/components/ChatArea/ChatMessageList.tsx
+++ b/src/front/components/ChatArea/ChatMessageList.tsx
@@ -26,10 +26,8 @@ export function ChatMessageList({ messages, streamingContent, isStreaming }: Cha
       {isStreaming && streamingContent && (
         <ChatMessageBubble
           message={{
-            id: "streaming",
             role: "assistant",
             content: streamingContent,
-            createdAt: new Date().toISOString(),
           }}
         />
       )}

--- a/src/front/hooks/useChatStream.test.tsx
+++ b/src/front/hooks/useChatStream.test.tsx
@@ -130,7 +130,7 @@ describe("useChatStream", () => {
       await sent;
     });
 
-    expect(store.get(chatMessagesAtom)).toEqual([
+    expect(store.get(chatMessagesAtom)).toStrictEqual([
       {
         id: `temp-${fixedNow.getTime()}`,
         role: "user",

--- a/src/front/hooks/useChatStream.test.tsx
+++ b/src/front/hooks/useChatStream.test.tsx
@@ -14,12 +14,12 @@ import { doneEvent, streamingFetchStub, tokenEvent } from "../../test/streamingF
 
 const QUESTION = "Durable Objects とは?";
 
-function renderChatStream(fetchFn: typeof fetch) {
+function renderChatStream(fetchFn: typeof fetch, now?: () => Date) {
   const store = createStore();
   const wrapper = ({ children }: { children: ReactNode }) => (
     <Provider store={store}>{children}</Provider>
   );
-  return { store, view: renderHook(() => useChatStream(fetchFn), { wrapper }) };
+  return { store, view: renderHook(() => useChatStream(fetchFn, now), { wrapper }) };
 }
 
 describe("useChatStream", () => {
@@ -112,5 +112,38 @@ describe("useChatStream", () => {
     ]);
     expect(store.get(isStreamingAtom)).toBe(false);
     expect(store.get(chatAbortControllerAtom)).toBeNull();
+  });
+
+  it("stamps both messages with the injected clock instead of the wall clock", async () => {
+    const fixedNow = new Date("2026-01-02T03:04:05.678Z");
+    const { fetchFn, calls } = streamingFetchStub();
+    const { store, view } = renderChatStream(fetchFn, () => fixedNow);
+
+    let sent!: Promise<void>;
+    await act(async () => {
+      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false);
+    });
+    await act(async () => {
+      calls[0].emit(tokenEvent("単一のインスタンスです"));
+      calls[0].emit(doneEvent("m1"));
+      calls[0].end();
+      await sent;
+    });
+
+    expect(store.get(chatMessagesAtom)).toEqual([
+      {
+        id: `temp-${fixedNow.getTime()}`,
+        role: "user",
+        content: QUESTION,
+        createdAt: "2026-01-02T03:04:05.678Z",
+      },
+      {
+        id: "m1",
+        role: "assistant",
+        content: "単一のインスタンスです",
+        citations: [],
+        createdAt: "2026-01-02T03:04:05.678Z",
+      },
+    ]);
   });
 });

--- a/src/front/hooks/useChatStream.ts
+++ b/src/front/hooks/useChatStream.ts
@@ -23,9 +23,15 @@ interface ChatStreamOptions {
 }
 
 /**
+ * Default clock. Kept at module level so its identity is stable across
+ * renders and `sendMessage` is not rebuilt on every render.
+ */
+const systemNow = () => new Date();
+
+/**
  * Send a question and render the answer as it streams in.
  */
-export function useChatStream(fetchFn: typeof fetch = fetch) {
+export function useChatStream(fetchFn: typeof fetch = fetch, now: () => Date = systemNow) {
   const [, setMessages] = useAtom(chatMessagesAtom);
   const [, setStreamingContent] = useAtom(streamingContentAtom);
   const [, setIsStreaming] = useAtom(isStreamingAtom);
@@ -46,10 +52,10 @@ export function useChatStream(fetchFn: typeof fetch = fetch) {
 
       // Show the question straight away, before the model has answered
       const userMsg: ChatMessage = {
-        id: `temp-${Date.now()}`,
+        id: `temp-${now().getTime()}`,
         role: "user",
         content,
-        createdAt: new Date().toISOString(),
+        createdAt: now().toISOString(),
       };
       setMessages((prev) => [...prev, userMsg]);
       setStreamingContent("");
@@ -118,11 +124,11 @@ export function useChatStream(fetchFn: typeof fetch = fetch) {
         setMessages((prev) => [
           ...prev,
           {
-            id: messageId || `temp-${Date.now()}`,
+            id: messageId || `temp-${now().getTime()}`,
             role: "assistant",
             content: fullContent,
             citations,
-            createdAt: new Date().toISOString(),
+            createdAt: now().toISOString(),
           },
         ]);
         setStreamingContent("");
@@ -147,6 +153,7 @@ export function useChatStream(fetchFn: typeof fetch = fetch) {
     [
       abortChatStream,
       fetchFn,
+      now,
       setMessages,
       setStreamingContent,
       setIsStreaming,

--- a/src/front/hooks/usePdfDocument.ts
+++ b/src/front/hooks/usePdfDocument.ts
@@ -10,15 +10,19 @@ import { renderCoverThumbnail } from "../lib/pdfLoader";
  * already holds the rendered document, so generate the cover here and store it
  * once; otherwise those books would stay blank on the shelf forever.
  */
-async function backfillCover(pdfId: string, doc: pdfjsTypes.PDFDocumentProxy) {
+async function backfillCover(
+  pdfId: string,
+  doc: pdfjsTypes.PDFDocumentProxy,
+  fetchFn: typeof fetch,
+) {
   try {
-    const book = await fetch(`/api/pdf/${pdfId}`).then((r) => (r.ok ? r.json() : null));
+    const book = await fetchFn(`/api/pdf/${pdfId}`).then((r) => (r.ok ? r.json() : null));
     if (!book || book.hasThumbnail) return;
 
     const thumbnail = await renderCoverThumbnail(doc);
     if (!thumbnail) return;
 
-    await fetch(`/api/pdf/${pdfId}/thumbnail`, {
+    await fetchFn(`/api/pdf/${pdfId}/thumbnail`, {
       method: "PUT",
       headers: { "Content-Type": "image/webp" },
       body: thumbnail,
@@ -32,7 +36,7 @@ async function backfillCover(pdfId: string, doc: pdfjsTypes.PDFDocumentProxy) {
  * Load the pdfjs-dist PDFDocumentProxy for the given book by fetching the
  * stored PDF binary from the API.
  */
-export function usePdfDocument(pdfDoc: PdfDoc | null) {
+export function usePdfDocument(pdfDoc: PdfDoc | null, fetchFn: typeof fetch = fetch) {
   const [pdfDocument, setPdfDocument] = useState<pdfjsTypes.PDFDocumentProxy | null>(null);
   const loadingRef = useRef<string | null>(null);
 
@@ -51,7 +55,7 @@ export function usePdfDocument(pdfDoc: PdfDoc | null) {
 
     async function loadPdf() {
       try {
-        const response = await fetch(`/api/pdf/${pdfId}/file`);
+        const response = await fetchFn(`/api/pdf/${pdfId}/file`);
         if (!response.ok) {
           console.warn("PDF file not found on server, rendering unavailable");
           return;
@@ -66,7 +70,7 @@ export function usePdfDocument(pdfDoc: PdfDoc | null) {
         if (cancelled) return;
 
         setPdfDocument(doc);
-        void backfillCover(pdfId, doc);
+        void backfillCover(pdfId, doc, fetchFn);
       } catch (err) {
         console.error("Failed to load PDF for rendering:", err);
       }

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -29,8 +29,9 @@ type Env = {
 };
 
 /**
- * Build the PDF routes. Ids and timestamps come from the injected clock, which
- * is the single seam tests use to make a request's writes deterministic.
+ * Build the PDF routes. Ids and timestamps come from the injected clock; the
+ * exported pdfRoute uses the system clock. Passing a fixed clock here makes a
+ * request's writes deterministic.
  */
 export function createPdfRoute(idClock: IdClock = systemIdClock) {
   return (

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -1,7 +1,6 @@
 import { Hono } from "hono";
 import { drizzle } from "drizzle-orm/d1";
 import { eq } from "drizzle-orm";
-import { ulid } from "ulid";
 import { pdfs, selections, chatMessages } from "../db/schema";
 import {
   openPdf,
@@ -10,6 +9,8 @@ import {
   deletePdf,
   thumbnailObjectKey,
   THUMBNAIL_CONTENT_TYPE,
+  systemIdClock,
+  type IdClock,
 } from "../services/pdfService";
 
 import {
@@ -27,405 +28,429 @@ type Env = {
   };
 };
 
-export const pdfRoute = new Hono<Env>()
-  .post("/pdf/open", async (c) => {
-    const formData = await c.req.parseBody().catch(() => null);
-    if (!formData) {
-      return c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid form body" } }, 400);
-    }
+/**
+ * Build the PDF routes. Ids and timestamps come from the injected clock, which
+ * is the single seam tests use to make a request's writes deterministic.
+ */
+export function createPdfRoute(idClock: IdClock = systemIdClock) {
+  return (
+    new Hono<Env>()
+      .post("/pdf/open", async (c) => {
+        const formData = await c.req.parseBody().catch(() => null);
+        if (!formData) {
+          return c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid form body" } }, 400);
+        }
 
-    const file = formData.file;
-    if (!file || !(file instanceof File)) {
-      return c.json({ error: { code: "VALIDATION_ERROR", message: "No PDF file provided" } }, 400);
-    }
+        const file = formData.file;
+        if (!file || !(file instanceof File)) {
+          return c.json(
+            { error: { code: "VALIDATION_ERROR", message: "No PDF file provided" } },
+            400,
+          );
+        }
 
-    // parseBody yields string | File per field; only strings are meaningful here
-    const fullText = typeof formData.fullText === "string" ? formData.fullText : "";
-    const pageCount = typeof formData.pageCount === "string" ? parseInt(formData.pageCount, 10) : 0;
-    if (!fullText || !Number.isFinite(pageCount) || pageCount <= 0) {
-      return c.json(
-        { error: { code: "VALIDATION_ERROR", message: "Missing fullText or pageCount" } },
-        400,
-      );
-    }
+        // parseBody yields string | File per field; only strings are meaningful here
+        const fullText = typeof formData.fullText === "string" ? formData.fullText : "";
+        const pageCount =
+          typeof formData.pageCount === "string" ? parseInt(formData.pageCount, 10) : 0;
+        if (!fullText || !Number.isFinite(pageCount) || pageCount <= 0) {
+          return c.json(
+            { error: { code: "VALIDATION_ERROR", message: "Missing fullText or pageCount" } },
+            400,
+          );
+        }
 
-    // Compute hash and get binary data
-    const arrayBuffer = await file.arrayBuffer();
-    const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
-    const fileHash = Array.from(new Uint8Array(hashBuffer))
-      .map((b) => b.toString(16).padStart(2, "0"))
-      .join("");
+        // Compute hash and get binary data
+        const arrayBuffer = await file.arrayBuffer();
+        const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
+        const fileHash = Array.from(new Uint8Array(hashBuffer))
+          .map((b) => b.toString(16).padStart(2, "0"))
+          .join("");
 
-    const thumbnailField = formData.thumbnail;
-    const thumbnail =
-      thumbnailField instanceof File ? await thumbnailField.arrayBuffer() : undefined;
+        const thumbnailField = formData.thumbnail;
+        const thumbnail =
+          thumbnailField instanceof File ? await thumbnailField.arrayBuffer() : undefined;
 
-    try {
-      const metadata = await openPdf(c.env.DB, c.env.PDF_BUCKET, {
-        fileName: file.name,
-        fileHash,
-        fullText,
-        pageCount,
-        arrayBuffer,
-        thumbnail,
-      });
-      return c.json(metadata);
-    } catch (err) {
-      console.error("PDF open error:", err);
-      return c.json(
-        { error: { code: "PDF_EXTRACT_FAILED", message: "Failed to process PDF" } },
-        500,
-      );
-    }
-  })
-  .get("/pdfs", async (c) => {
-    const books = await listPdfs(c.env.DB, c.env.PDF_BUCKET);
-    return c.json({ books });
-  })
-  .get("/pdf/:pdfId/thumbnail", async (c) => {
-    const pdf = await drizzle(c.env.DB)
-      .select({ fileHash: pdfs.fileHash })
-      .from(pdfs)
-      .where(eq(pdfs.id, c.req.param("pdfId")))
-      .get();
-    if (!pdf) {
-      return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-    }
+        try {
+          const metadata = await openPdf(
+            c.env.DB,
+            c.env.PDF_BUCKET,
+            {
+              fileName: file.name,
+              fileHash,
+              fullText,
+              pageCount,
+              arrayBuffer,
+              thumbnail,
+            },
+            idClock,
+          );
+          return c.json(metadata);
+        } catch (err) {
+          console.error("PDF open error:", err);
+          return c.json(
+            { error: { code: "PDF_EXTRACT_FAILED", message: "Failed to process PDF" } },
+            500,
+          );
+        }
+      })
+      .get("/pdfs", async (c) => {
+        const books = await listPdfs(c.env.DB, c.env.PDF_BUCKET);
+        return c.json({ books });
+      })
+      .get("/pdf/:pdfId/thumbnail", async (c) => {
+        const pdf = await drizzle(c.env.DB)
+          .select({ fileHash: pdfs.fileHash })
+          .from(pdfs)
+          .where(eq(pdfs.id, c.req.param("pdfId")))
+          .get();
+        if (!pdf) {
+          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+        }
 
-    const object = await c.env.PDF_BUCKET.get(thumbnailObjectKey(pdf.fileHash));
-    if (!object) {
-      return c.json(
-        { error: { code: "THUMBNAIL_MISSING", message: "No cover stored for this book" } },
-        404,
-      );
-    }
+        const object = await c.env.PDF_BUCKET.get(thumbnailObjectKey(pdf.fileHash));
+        if (!object) {
+          return c.json(
+            { error: { code: "THUMBNAIL_MISSING", message: "No cover stored for this book" } },
+            404,
+          );
+        }
 
-    return new Response(object.body, {
-      headers: {
-        "Content-Type": THUMBNAIL_CONTENT_TYPE,
-        "Cache-Control": "no-cache",
-      },
-    });
-  })
-  .put("/pdf/:pdfId/thumbnail", async (c) => {
-    const pdf = await drizzle(c.env.DB)
-      .select({ fileHash: pdfs.fileHash })
-      .from(pdfs)
-      .where(eq(pdfs.id, c.req.param("pdfId")))
-      .get();
-    if (!pdf) {
-      return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-    }
+        return new Response(object.body, {
+          headers: {
+            "Content-Type": THUMBNAIL_CONTENT_TYPE,
+            "Cache-Control": "no-cache",
+          },
+        });
+      })
+      .put("/pdf/:pdfId/thumbnail", async (c) => {
+        const pdf = await drizzle(c.env.DB)
+          .select({ fileHash: pdfs.fileHash })
+          .from(pdfs)
+          .where(eq(pdfs.id, c.req.param("pdfId")))
+          .get();
+        if (!pdf) {
+          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+        }
 
-    const body = await c.req.arrayBuffer();
-    if (body.byteLength === 0) {
-      return c.json({ error: { code: "VALIDATION_ERROR", message: "Empty thumbnail" } }, 400);
-    }
+        const body = await c.req.arrayBuffer();
+        if (body.byteLength === 0) {
+          return c.json({ error: { code: "VALIDATION_ERROR", message: "Empty thumbnail" } }, 400);
+        }
 
-    await c.env.PDF_BUCKET.put(thumbnailObjectKey(pdf.fileHash), body, {
-      httpMetadata: { contentType: THUMBNAIL_CONTENT_TYPE },
-    });
+        await c.env.PDF_BUCKET.put(thumbnailObjectKey(pdf.fileHash), body, {
+          httpMetadata: { contentType: THUMBNAIL_CONTENT_TYPE },
+        });
 
-    return c.json({ stored: true });
-  })
-  .get("/pdf/:pdfId/file", async (c) => {
-    const pdfId = c.req.param("pdfId");
-    const d1Db = drizzle(c.env.DB);
-    const pdf = await d1Db.select().from(pdfs).where(eq(pdfs.id, pdfId)).get();
-    if (!pdf) {
-      return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-    }
+        return c.json({ stored: true });
+      })
+      .get("/pdf/:pdfId/file", async (c) => {
+        const pdfId = c.req.param("pdfId");
+        const d1Db = drizzle(c.env.DB);
+        const pdf = await d1Db.select().from(pdfs).where(eq(pdfs.id, pdfId)).get();
+        if (!pdf) {
+          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+        }
 
-    const object = await c.env.PDF_BUCKET.get(pdf.filePath);
-    if (!object) {
-      return c.json(
-        { error: { code: "PDF_FILE_MISSING", message: "PDF binary not found in storage" } },
-        404,
-      );
-    }
+        const object = await c.env.PDF_BUCKET.get(pdf.filePath);
+        if (!object) {
+          return c.json(
+            { error: { code: "PDF_FILE_MISSING", message: "PDF binary not found in storage" } },
+            404,
+          );
+        }
 
-    return new Response(object.body, {
-      headers: {
-        "Content-Type": "application/pdf",
-        "Content-Disposition": `inline; filename="${encodeURIComponent(pdf.fileName)}"`,
-      },
-    });
-  })
-  // Resolves a passage from a `#:~:text=` link to the page that holds it. The
-  // browser cannot do this itself here: the page is only in the DOM once the
-  // reader has jumped to it.
-  .get("/pdf/:pdfId/locate", async (c) => {
-    const text = c.req.query("text");
-    const pdf = await drizzle(c.env.DB)
-      .select({ fullText: pdfs.fullText, pageCount: pdfs.pageCount })
-      .from(pdfs)
-      .where(eq(pdfs.id, c.req.param("pdfId")))
-      .get();
-    if (!pdf) {
-      return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-    }
-    if (!text) {
-      return c.json({ error: { code: "VALIDATION_ERROR", message: "Missing text" } }, 400);
-    }
+        return new Response(object.body, {
+          headers: {
+            "Content-Type": "application/pdf",
+            "Content-Disposition": `inline; filename="${encodeURIComponent(pdf.fileName)}"`,
+          },
+        });
+      })
+      // Resolves a passage from a `#:~:text=` link to the page that holds it. The
+      // browser cannot do this itself here: the page is only in the DOM once the
+      // reader has jumped to it.
+      .get("/pdf/:pdfId/locate", async (c) => {
+        const text = c.req.query("text");
+        const pdf = await drizzle(c.env.DB)
+          .select({ fullText: pdfs.fullText, pageCount: pdfs.pageCount })
+          .from(pdfs)
+          .where(eq(pdfs.id, c.req.param("pdfId")))
+          .get();
+        if (!pdf) {
+          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+        }
+        if (!text) {
+          return c.json({ error: { code: "VALIDATION_ERROR", message: "Missing text" } }, 400);
+        }
 
-    return c.json({ pageNumber: findPageNumber(text, pdf.fullText, pdf.pageCount) ?? null });
-  })
-  .get("/pdf/:pdfId", async (c) => {
-    const pdfId = c.req.param("pdfId");
-    const result = await getPdf(c.env.DB, c.env.PDF_BUCKET, pdfId);
+        return c.json({ pageNumber: findPageNumber(text, pdf.fullText, pdf.pageCount) ?? null });
+      })
+      .get("/pdf/:pdfId", async (c) => {
+        const pdfId = c.req.param("pdfId");
+        const result = await getPdf(c.env.DB, c.env.PDF_BUCKET, pdfId);
 
-    if (!result) {
-      return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-    }
+        if (!result) {
+          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+        }
 
-    return c.json(result);
-  })
-  .post("/pdf/:pdfId/selections", async (c) => {
-    const pdfId = c.req.param("pdfId");
-    const d1Db = drizzle(c.env.DB);
+        return c.json(result);
+      })
+      .post("/pdf/:pdfId/selections", async (c) => {
+        const pdfId = c.req.param("pdfId");
+        const d1Db = drizzle(c.env.DB);
 
-    // Verify pdf exists
-    const pdf = await d1Db.select().from(pdfs).where(eq(pdfs.id, pdfId)).get();
-    if (!pdf) {
-      return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-    }
+        // Verify pdf exists
+        const pdf = await d1Db.select().from(pdfs).where(eq(pdfs.id, pdfId)).get();
+        if (!pdf) {
+          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+        }
 
-    const body = await c.req.json().catch(() => null);
-    if (!body) {
-      return c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid JSON" } }, 400);
-    }
+        const body = await c.req.json().catch(() => null);
+        if (!body) {
+          return c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid JSON" } }, 400);
+        }
 
-    const { selectedText, pageNumber, positionData } = body;
-    if (!selectedText || !pageNumber || !positionData) {
-      return c.json(
-        { error: { code: "VALIDATION_ERROR", message: "Missing required fields" } },
-        400,
-      );
-    }
+        const { selectedText, pageNumber, positionData } = body;
+        if (!selectedText || !pageNumber || !positionData) {
+          return c.json(
+            { error: { code: "VALIDATION_ERROR", message: "Missing required fields" } },
+            400,
+          );
+        }
 
-    const id = ulid();
-    const now = new Date().toISOString();
-    await d1Db.insert(selections).values({
-      id,
-      pdfId,
-      selectedText,
-      pageNumber,
-      positionData: JSON.stringify(positionData),
-      createdAt: now,
-    });
+        const id = idClock.newId();
+        const now = idClock.now();
+        await d1Db.insert(selections).values({
+          id,
+          pdfId,
+          selectedText,
+          pageNumber,
+          positionData: JSON.stringify(positionData),
+          createdAt: now,
+        });
 
-    return c.json({ id, selectedText, pageNumber, positionData, createdAt: now }, 201);
-  })
-  .get("/pdf/:pdfId/selections/:selId/chats", async (c) => {
-    const selId = c.req.param("selId");
-    const d1Db = drizzle(c.env.DB);
+        return c.json({ id, selectedText, pageNumber, positionData, createdAt: now }, 201);
+      })
+      .get("/pdf/:pdfId/selections/:selId/chats", async (c) => {
+        const selId = c.req.param("selId");
+        const d1Db = drizzle(c.env.DB);
 
-    const sel = await d1Db.select().from(selections).where(eq(selections.id, selId)).get();
-    if (!sel) {
-      return c.json(
-        { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } },
-        404,
-      );
-    }
+        const sel = await d1Db.select().from(selections).where(eq(selections.id, selId)).get();
+        if (!sel) {
+          return c.json(
+            { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } },
+            404,
+          );
+        }
 
-    const messages = await d1Db
-      .select()
-      .from(chatMessages)
-      .where(eq(chatMessages.selectionId, selId))
-      .all();
+        const messages = await d1Db
+          .select()
+          .from(chatMessages)
+          .where(eq(chatMessages.selectionId, selId))
+          .all();
 
-    return c.json({
-      selectionId: selId,
-      messages: messages.map((m) => ({
-        id: m.id,
-        role: m.role,
-        content: m.content,
-        citations: m.citations ? JSON.parse(m.citations) : null,
-        createdAt: m.createdAt,
-      })),
-    });
-  })
-  .post("/pdf/:pdfId/selections/:selId/chats", async (c) => {
-    const selId = c.req.param("selId");
-    const d1Db = drizzle(c.env.DB);
-    const apiKey = c.env.DEEPSEEK_API_KEY;
+        return c.json({
+          selectionId: selId,
+          messages: messages.map((m) => ({
+            id: m.id,
+            role: m.role,
+            content: m.content,
+            citations: m.citations ? JSON.parse(m.citations) : null,
+            createdAt: m.createdAt,
+          })),
+        });
+      })
+      .post("/pdf/:pdfId/selections/:selId/chats", async (c) => {
+        const selId = c.req.param("selId");
+        const d1Db = drizzle(c.env.DB);
+        const apiKey = c.env.DEEPSEEK_API_KEY;
 
-    if (!apiKey) {
-      return c.json({ error: { code: "CONFIG_ERROR", message: "DEEPSEEK_API_KEY not set" } }, 500);
-    }
+        if (!apiKey) {
+          return c.json(
+            { error: { code: "CONFIG_ERROR", message: "DEEPSEEK_API_KEY not set" } },
+            500,
+          );
+        }
 
-    const sel = await d1Db.select().from(selections).where(eq(selections.id, selId)).get();
-    if (!sel) {
-      return c.json(
-        { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } },
-        404,
-      );
-    }
+        const sel = await d1Db.select().from(selections).where(eq(selections.id, selId)).get();
+        if (!sel) {
+          return c.json(
+            { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } },
+            404,
+          );
+        }
 
-    const body = await c.req.json().catch(() => null);
-    if (!body) {
-      return c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid JSON" } }, 400);
-    }
+        const body = await c.req.json().catch(() => null);
+        if (!body) {
+          return c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid JSON" } }, 400);
+        }
 
-    const { content, useWebSearch } = body as { content?: string; useWebSearch?: boolean };
-    if (!content || typeof content !== "string") {
-      return c.json({ error: { code: "VALIDATION_ERROR", message: "Missing content" } }, 400);
-    }
+        const { content, useWebSearch } = body as { content?: string; useWebSearch?: boolean };
+        if (!content || typeof content !== "string") {
+          return c.json({ error: { code: "VALIDATION_ERROR", message: "Missing content" } }, 400);
+        }
 
-    // Save user message
-    const userMsgId = ulid();
-    const now = new Date().toISOString();
-    await d1Db.insert(chatMessages).values({
-      id: userMsgId,
-      selectionId: selId,
-      role: "user",
-      content,
-      createdAt: now,
-    });
+        // Save user message
+        const userMsgId = idClock.newId();
+        const now = idClock.now();
+        await d1Db.insert(chatMessages).values({
+          id: userMsgId,
+          selectionId: selId,
+          role: "user",
+          content,
+          createdAt: now,
+        });
 
-    // Get PDF text for context
-    const pdfRow = await d1Db
-      .select({ fullText: pdfs.fullText, pageCount: pdfs.pageCount })
-      .from(pdfs)
-      .where(eq(pdfs.id, sel.pdfId))
-      .get();
+        // Get PDF text for context
+        const pdfRow = await d1Db
+          .select({ fullText: pdfs.fullText, pageCount: pdfs.pageCount })
+          .from(pdfs)
+          .where(eq(pdfs.id, sel.pdfId))
+          .get();
 
-    if (!pdfRow) {
-      return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-    }
+        if (!pdfRow) {
+          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+        }
 
-    // Get chat history
-    const history = await d1Db
-      .select()
-      .from(chatMessages)
-      .where(eq(chatMessages.selectionId, selId))
-      .all();
+        // Get chat history
+        const history = await d1Db
+          .select()
+          .from(chatMessages)
+          .where(eq(chatMessages.selectionId, selId))
+          .all();
 
-    // Build system prompt
-    const fullText = pdfRow.fullText;
-    const systemPrompt = buildSystemPrompt(fullText, sel.selectedText, !!useWebSearch);
-    const doWebSearch = !!useWebSearch;
+        // Build system prompt
+        const fullText = pdfRow.fullText;
+        const systemPrompt = buildSystemPrompt(fullText, sel.selectedText, !!useWebSearch);
+        const doWebSearch = !!useWebSearch;
 
-    // Set up SSE streaming
-    const encoder = new TextEncoder();
-    let fullResponse = "";
-    // Leaving the chat cancels the response body. That only means "stop
-    // sending"; the answer is still read to the end and saved below, so
-    // reopening the highlight shows it.
-    let clientGone = false;
-    let finished!: Promise<void>;
+        // Set up SSE streaming
+        const encoder = new TextEncoder();
+        let fullResponse = "";
+        // Leaving the chat cancels the response body. That only means "stop
+        // sending"; the answer is still read to the end and saved below, so
+        // reopening the highlight shows it.
+        let clientGone = false;
+        let finished!: Promise<void>;
 
-    const stream = new ReadableStream({
-      start(controller) {
-        // Writing to a cancelled stream is allowed to throw, and a throw here
-        // would escape into the AI service's own catch and lose the answer
-        // before it is saved. Swallowing it is what keeps the save reachable.
-        const send = (payload: string) => {
-          if (clientGone) return;
-          try {
-            controller.enqueue(encoder.encode(payload));
-          } catch {
-            // A cancel can beat its own handler, so a refused write means the
-            // client is gone too
+        const stream = new ReadableStream({
+          start(controller) {
+            // Writing to a cancelled stream is allowed to throw, and a throw here
+            // would escape into the AI service's own catch and lose the answer
+            // before it is saved. Swallowing it is what keeps the save reachable.
+            const send = (payload: string) => {
+              if (clientGone) return;
+              try {
+                controller.enqueue(encoder.encode(payload));
+              } catch {
+                // A cancel can beat its own handler, so a refused write means the
+                // client is gone too
+                clientGone = true;
+              }
+            };
+            const closeStream = () => {
+              if (clientGone) return;
+              try {
+                controller.close();
+              } catch {
+                clientGone = true;
+              }
+            };
+
+            const callbacks = {
+              onToken(token: string) {
+                fullResponse += token;
+                send(`event: token\ndata: ${JSON.stringify({ content: token })}\n\n`);
+              },
+              async onDone(usage: { inputTokens: number; outputTokens: number }) {
+                // Parse citations with page number lookup for PDF citations
+                const citations = parseCitations(fullResponse, fullText, pdfRow.pageCount);
+
+                // Save the answer before telling the client about it, so a client
+                // that already left cannot stop the save
+                const assistantMsgId = idClock.newId();
+                await d1Db
+                  .insert(chatMessages)
+                  .values({
+                    id: assistantMsgId,
+                    selectionId: selId,
+                    role: "assistant",
+                    content: fullResponse,
+                    citations: JSON.stringify(citations),
+                    createdAt: idClock.now(),
+                  })
+                  .run()
+                  .catch((err: Error) => console.error("Failed to save assistant message:", err));
+
+                for (const citation of citations) {
+                  send(`event: citation\ndata: ${JSON.stringify(citation)}\n\n`);
+                }
+                send(
+                  `event: done\ndata: ${JSON.stringify({ messageId: assistantMsgId, usage })}\n\n`,
+                );
+                closeStream();
+              },
+              onError(err: Error) {
+                send(
+                  `event: error\ndata: ${JSON.stringify({ code: "AI_API_ERROR", message: err.message })}\n\n`,
+                );
+                closeStream();
+              },
+            };
+
+            finished = (async () => {
+              try {
+                if (doWebSearch) {
+                  await streamResponseWithWebSearch(apiKey, systemPrompt, content, callbacks);
+                } else {
+                  const messages = buildMessages(
+                    systemPrompt,
+                    history.map((h) => ({ role: h.role, content: h.content })),
+                    content,
+                  );
+                  await streamChatCompletion(apiKey, messages, callbacks);
+                }
+              } catch (err) {
+                send(
+                  `event: error\ndata: ${JSON.stringify({ code: "AI_STREAM_ERROR", message: String(err) })}\n\n`,
+                );
+                closeStream();
+              }
+            })();
+          },
+          cancel() {
             clientGone = true;
-          }
-        };
-        const closeStream = () => {
-          if (clientGone) return;
-          try {
-            controller.close();
-          } catch {
-            clientGone = true;
-          }
-        };
-
-        const callbacks = {
-          onToken(token: string) {
-            fullResponse += token;
-            send(`event: token\ndata: ${JSON.stringify({ content: token })}\n\n`);
           },
-          async onDone(usage: { inputTokens: number; outputTokens: number }) {
-            // Parse citations with page number lookup for PDF citations
-            const citations = parseCitations(fullResponse, fullText, pdfRow.pageCount);
+        });
 
-            // Save the answer before telling the client about it, so a client
-            // that already left cannot stop the save
-            const assistantMsgId = ulid();
-            await d1Db
-              .insert(chatMessages)
-              .values({
-                id: assistantMsgId,
-                selectionId: selId,
-                role: "assistant",
-                content: fullResponse,
-                citations: JSON.stringify(citations),
-                createdAt: new Date().toISOString(),
-              })
-              .run()
-              .catch((err: Error) => console.error("Failed to save assistant message:", err));
+        // The save has to outlive the request the client just walked away from
+        c.executionCtx.waitUntil(finished);
 
-            for (const citation of citations) {
-              send(`event: citation\ndata: ${JSON.stringify(citation)}\n\n`);
-            }
-            send(`event: done\ndata: ${JSON.stringify({ messageId: assistantMsgId, usage })}\n\n`);
-            closeStream();
+        return new Response(stream, {
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
           },
-          onError(err: Error) {
-            send(
-              `event: error\ndata: ${JSON.stringify({ code: "AI_API_ERROR", message: err.message })}\n\n`,
-            );
-            closeStream();
-          },
-        };
+        });
+      })
+      .delete("/pdf/:pdfId", async (c) => {
+        const deleted = await deletePdf(c.env.DB, c.env.PDF_BUCKET, c.req.param("pdfId"));
+        if (!deleted) {
+          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+        }
 
-        finished = (async () => {
-          try {
-            if (doWebSearch) {
-              await streamResponseWithWebSearch(apiKey, systemPrompt, content, callbacks);
-            } else {
-              const messages = buildMessages(
-                systemPrompt,
-                history.map((h) => ({ role: h.role, content: h.content })),
-                content,
-              );
-              await streamChatCompletion(apiKey, messages, callbacks);
-            }
-          } catch (err) {
-            send(
-              `event: error\ndata: ${JSON.stringify({ code: "AI_STREAM_ERROR", message: String(err) })}\n\n`,
-            );
-            closeStream();
-          }
-        })();
-      },
-      cancel() {
-        clientGone = true;
-      },
-    });
+        return c.json({ deleted: true });
+      })
+      .delete("/pdf/:pdfId/selections/:selId", async (c) => {
+        const selId = c.req.param("selId");
+        const d1Db = drizzle(c.env.DB);
 
-    // The save has to outlive the request the client just walked away from
-    c.executionCtx.waitUntil(finished);
+        await d1Db.delete(selections).where(eq(selections.id, selId));
+        return c.json({ deleted: true });
+      })
+  );
+}
 
-    return new Response(stream, {
-      headers: {
-        "Content-Type": "text/event-stream",
-        "Cache-Control": "no-cache",
-        Connection: "keep-alive",
-      },
-    });
-  })
-  .delete("/pdf/:pdfId", async (c) => {
-    const deleted = await deletePdf(c.env.DB, c.env.PDF_BUCKET, c.req.param("pdfId"));
-    if (!deleted) {
-      return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-    }
-
-    return c.json({ deleted: true });
-  })
-  .delete("/pdf/:pdfId/selections/:selId", async (c) => {
-    const selId = c.req.param("selId");
-    const d1Db = drizzle(c.env.DB);
-
-    await d1Db.delete(selections).where(eq(selections.id, selId));
-    return c.json({ deleted: true });
-  });
+export const pdfRoute = createPdfRoute();

--- a/src/server/services/deepseekService.ts
+++ b/src/server/services/deepseekService.ts
@@ -111,9 +111,10 @@ export async function streamResponseWithWebSearch(
   userMessage: string,
   callbacks: StreamCallbacks,
   signal?: AbortSignal,
+  fetchFn: typeof fetch = fetch,
 ): Promise<void> {
   try {
-    const response = await fetch("https://api.deepseek.com/responses", {
+    const response = await fetchFn("https://api.deepseek.com/responses", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/src/server/services/pdfService.ts
+++ b/src/server/services/pdfService.ts
@@ -19,6 +19,20 @@ export function thumbnailObjectKey(fileHash: string): string {
 
 export const THUMBNAIL_CONTENT_TYPE = "image/webp";
 
+/**
+ * The two non-deterministic values every write needs. Injected so tests can
+ * pin the ids and timestamps a request produces.
+ */
+export interface IdClock {
+  newId: () => string;
+  now: () => string;
+}
+
+export const systemIdClock: IdClock = {
+  newId: ulid,
+  now: () => new Date().toISOString(),
+};
+
 export interface PdfMetadata {
   id: string;
   fileName: string;
@@ -78,6 +92,7 @@ export async function openPdf(
   db: D1Database,
   bucket: R2Bucket,
   input: OpenPdfInput,
+  idClock: IdClock = systemIdClock,
 ): Promise<PdfMetadata> {
   const { fileName, fileHash, fullText, pageCount, arrayBuffer, thumbnail } = input;
   const d1Db = drizzle(db);
@@ -103,7 +118,7 @@ export async function openPdf(
     // whatever was stored before. Selections and chats stay attached to the id.
     await d1Db
       .update(pdfs)
-      .set({ fileName, fullText, pageCount, updatedAt: new Date().toISOString() })
+      .set({ fileName, fullText, pageCount, updatedAt: idClock.now() })
       .where(eq(pdfs.id, existing.id));
 
     return { id: existing.id, fileName, pageCount, fullText };
@@ -113,8 +128,8 @@ export async function openPdf(
     httpMetadata: { contentType: "application/pdf" },
   });
 
-  const id = ulid();
-  const now = new Date().toISOString();
+  const id = idClock.newId();
+  const now = idClock.now();
 
   await d1Db.insert(pdfs).values({
     id,

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeAll } from "vite-plus/test";
 import { env, applyD1Migrations, SELF } from "cloudflare:test";
 import { MINIMAL_PDF_BYTES } from "./fixtures/minimalPdf";
-import { pdfObjectKey, thumbnailObjectKey } from "../../src/server/services/pdfService";
+import {
+  openPdf,
+  pdfObjectKey,
+  thumbnailObjectKey,
+  type IdClock,
+} from "../../src/server/services/pdfService";
 
 beforeAll(async () => {
   await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
@@ -447,6 +452,97 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     expect(response.status).toBe(404);
     expect(await response.json()).toStrictEqual({
       error: { code: "PDF_NOT_FOUND", message: "PDF not found" },
+    });
+  });
+});
+
+/** An IdClock that always hands out the same id and timestamp. */
+function fixedIdClock(id: string, now: string): IdClock {
+  return { newId: () => id, now: () => now };
+}
+
+/** The stored book row, so the ids and timestamps a write produced are visible. */
+async function storedBookRow(pdfId: string): Promise<Record<string, unknown> | null> {
+  return await env.DB.prepare(
+    "SELECT id, file_path, file_name, file_hash, full_text, page_count, created_at, updated_at FROM pdfs WHERE id = ?",
+  )
+    .bind(pdfId)
+    .first();
+}
+
+describe("openPdf with an injected IdClock", () => {
+  it("stores a new book under the id and timestamps the clock hands out", async () => {
+    const fileHash = "hash-idclock-new";
+
+    const metadata = await openPdf(
+      env.DB,
+      env.PDF_BUCKET,
+      {
+        fileName: "injected.pdf",
+        fileHash,
+        fullText: "本文",
+        pageCount: 3,
+        arrayBuffer: uniquePdfBytes("idclock-new").buffer as ArrayBuffer,
+      },
+      fixedIdClock("book-idclock-new", "2026-01-02T03:04:05.678Z"),
+    );
+
+    expect(metadata).toStrictEqual({
+      id: "book-idclock-new",
+      fileName: "injected.pdf",
+      pageCount: 3,
+      fullText: "本文",
+    });
+    expect(await storedBookRow("book-idclock-new")).toStrictEqual({
+      id: "book-idclock-new",
+      file_path: `pdfs/${fileHash}.pdf`,
+      file_name: "injected.pdf",
+      file_hash: fileHash,
+      full_text: "本文",
+      page_count: 3,
+      created_at: "2026-01-02T03:04:05.678Z",
+      updated_at: "2026-01-02T03:04:05.678Z",
+    });
+  });
+
+  it("keeps the first id and moves only updated_at when the same file is re-opened", async () => {
+    const fileHash = "hash-idclock-reopen";
+    const input = {
+      fileName: "first.pdf",
+      fileHash,
+      fullText: "初回の本文",
+      pageCount: 3,
+      arrayBuffer: uniquePdfBytes("idclock-reopen").buffer as ArrayBuffer,
+    };
+    await openPdf(
+      env.DB,
+      env.PDF_BUCKET,
+      input,
+      fixedIdClock("book-idclock-reopen", "2026-01-02T03:04:05.678Z"),
+    );
+
+    const metadata = await openPdf(
+      env.DB,
+      env.PDF_BUCKET,
+      { ...input, fileName: "second.pdf", fullText: "再抽出した本文", pageCount: 4 },
+      fixedIdClock("book-idclock-ignored", "2026-03-04T05:06:07.891Z"),
+    );
+
+    expect(metadata).toStrictEqual({
+      id: "book-idclock-reopen",
+      fileName: "second.pdf",
+      pageCount: 4,
+      fullText: "再抽出した本文",
+    });
+    expect(await storedBookRow("book-idclock-reopen")).toStrictEqual({
+      id: "book-idclock-reopen",
+      file_path: `pdfs/${fileHash}.pdf`,
+      file_name: "second.pdf",
+      file_hash: fileHash,
+      full_text: "再抽出した本文",
+      page_count: 4,
+      created_at: "2026-01-02T03:04:05.678Z",
+      updated_at: "2026-03-04T05:06:07.891Z",
     });
   });
 });


### PR DESCRIPTION
Closes #9

## 概要

外部世界に触れる処理 (fetch / `ulid()` / `Date`) を関数内部で直接呼ばず、引数経由で注入する形に統一した。DI の形式は既存イディオム `useChatStream(fetchFn: typeof fetch = fetch)` の**デフォルト引数注入**に揃えたので、プロダクションの呼び出し元は無変更。

**全 9 コミットが動作を変えない `[STRUCTURAL]`**。Tidy First に従い issue の項目ごとに分割している。

| # | 対応 | 変更点 |
| --- | --- | --- |
| 1 | `useChatStream` の時刻 DI | `now: () => Date = systemNow` を追加。`systemNow` はモジュールトップ定数で identity を安定させ `useCallback` の依存に入れる |
| 2 | `usePdfDocument` の fetch DI | `fetchFn: typeof fetch = fetch` を追加し `backfillCover` にも引数で渡す |
| 3 | `ChatMessageBubble` の props 縮小 | `Pick<ChatMessage, "role" \| "content" \| "citations">` に狭め、streaming 用 inline literal からレンダー中の `new Date().toISOString()` を除去 |
| 4 | `deepseekService` の fetch DI | `streamResponseWithWebSearch` の末尾 (`signal?` の後ろ) に `fetchFn` を追加 |
| 5 | サーバの ID 生成・時刻取得 DI | `IdClock` / `systemIdClock` を新設し `openPdf(..., idClock)`、`routes/pdf.ts` を `createPdfRoute(idClock = systemIdClock)` ファクトリ化 (`pdfRoute` を併置して `server/index.ts` は無変更) |

Hono の context / middleware 経由の注入は採用していない。Worker テストは `SELF.fetch` で実ワーカーを叩くため context 経由では注入できず、`Variables` 型など機構だけが増えるため。

## テスト

追加した 3 件は既存動作を固定する **characterization テスト**なので定義上 RED を経ていない (その旨は各コミットメッセージにも明記)。空虚でないことは変異テストで実測済み:

- `useChatStream` の `now()` を `new Date()` に戻す → 新規テストのみ失敗
- `pdfService` の `idClock.newId()` / `idClock.now()` を `ulid()` / `new Date()` に戻す → 新規 2 件が失敗
- 再オープン経路の `updatedAt: idClock.now()` だけを戻す → 該当 1 件が単独で失敗

件数は jsdom 122 → 123、worker 24 → 26 で増加のみ (既存テストの弱体化・skip・削除なし)。

## 動作確認

| ゲート | 結果 |
| --- | --- |
| `vp check` | pass |
| `pnpm test` (jsdom) | 23 files / 123 passed |
| `pnpm run test:worker` | 3 files / 26 passed |
| `pnpm run test:e2e` | 21 passed |
| `vp build` | pass |

issue の完了条件である grep も達成:

- `rg 'ulid\(\)|new Date\(' src/server` → `systemIdClock` の定義 1 行のみ
- `rg 'Date\.now|new Date' src/front` → `systemNow` の定義 + テストの固定 Date フィクスチャのみ (固定 Date は `new Date(リテラル)` でしか作れず決定的な値のため許容)

## レビュー

review-tdd / review-quality の 2 観点を fresh context で実施し、いずれも high/medium の指摘ゼロ。low 指摘のうち 2 件をこの PR で修正した (`createPdfRoute` の doc コメントの事実誤り、`toEqual` → `toStrictEqual`)。

## 申し送り (後続 issue で解消)

- `createPdfRoute` に固定 clock を渡すテストはまだ無く、`selections` / `chat_messages` の書き込みは決定的 clock 下で検証されていない
- `usePdfDocument` の `useEffect` 依存配列は `[pdfDoc?.id]` のまま。`fetchFn` を足すと副作用の再実行条件が変わり STRUCTURAL でなくなるため据え置いた。#5 の SWR 移行で同じ effect を作り直す際に解消する
- `deepseekService` の `fetchFn` seam を消費するテストが無い。#7 で `/responses` の SSE パースを検証する際に使う

🤖 Generated with [Claude Code](https://claude.com/claude-code)