### PR TITLE
✨ feat: 外部入力のバリデーションを zod に移行する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,11 +91,13 @@ front と server が交わす形は `src/shared/schemas/` に zod スキーマ�
   の形に揃える。メッセージは zod の文言ではなく違反フィールドのパスなので、zod の更新で
   変わらない
 - **クライアントの受け口**は `src/front/lib/fetcher.ts` の `fetcher(url, schema, init?, fetchFn?)`。
-  `schema.safeParse` を通った値だけを返し、失敗はすべて `ApiError`（`message` / `code` /
-  `status`）で throw する。サーバの `error.code` が取れないときは `"UNKNOWN"`、
-  レスポンスがスキーマに合わないときは `"INVALID_RESPONSE"`
-- **`chatService.ts` の `LlmMessage`** は LLM 送信用で `system` role を含み、保存される
-  `ChatMessage`（`shared/schemas/chat.ts`）とは別物。shared に混ぜないこと
+  `schema.safeParse` を通った値だけを返す。**レスポンスが返ったあとの失敗 2 系統**——サーバが
+  拒否した（`error.code` を載せる。取れないときは `"UNKNOWN"`）と、レスポンスがスキーマに
+  合わない（`"INVALID_RESPONSE"`）——を `ApiError`（`message` / `code` / `status`）に揃えて
+  throw する。`fetch` 自体が reject するネットワーク断・abort はここでは包まず、
+  `TypeError` / `AbortError` がそのまま呼び出し側へ伝わる
+- **`src/server/services/chatService.ts` の `LlmMessage`** は LLM 送信用で `system` role を
+  含み、保存される `ChatMessage`（`src/shared/schemas/chat.ts`）とは別物。shared に混ぜないこと
 
 エラー形式は 2 系統あり、**ペイロード `{ code, message }` だけを共通化して transport の差は
 残している**。ストリーム開始前は HTTP ステータス + `{ error: { code, message } }`、開始後は
@@ -153,6 +155,10 @@ union + `satisfies` で固定する。
 - クライアントは `src/front/lib/sseParser.ts` の `createSseParser` で読む。
   SSE は**空行がブロック境界**で、`event:` は同じブロックの `data:` と対にする。
   バッファ全体から `data:` を検索すると同時到着したイベントが混線する
+- `createSseParser` が返すのは `{ event, data: unknown }` まで。そのあと
+  `src/front/hooks/useChatStream.ts` が `src/shared/schemas/sse.ts` の
+  `chatSseEventSchema`（4 イベントの discriminated union）で `safeParse` し、通ったものだけ
+  扱う。**キャストで済ませないこと**——未知の種別の出典が `CitationBadge` の描画に届く
 - 送信は **必ず `useChatStream` の `sendMessage` を通す**。ポップオーバーからの初回質問も同様。
   ここを生 `fetch` にすると質問文の即時表示と「考え中…」が出なくなる
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,43 @@ pdf.js は workerd 上で動かない（native canvas を要求して落ちる�
 (`src/server/services/pdfService.ts` の `openPdf`)。ここを「既存レコードをそのまま返す」に
 戻すと、古いメタデータが残り続ける不具合になる。
 
+### 外部入力のバリデーション（zod）
+
+front と server が交わす形は `src/shared/schemas/` に zod スキーマとして 1 箇所だけ置き、
+型は `z.infer` で導出する（`error.ts` / `book.ts` / `selection.ts` / `citation.ts` /
+`chat.ts` / `sse.ts`）。front・server どちらにも同じ概念の型を書かないこと。
+
+- **サーバの受け口**は `src/server/routes/validation.ts` の `validate(target, schema)`
+  （`@hono/zod-validator` のラッパ）を通す。素の `zValidator` は zod のレポートをそのまま
+  400 で返すため、クライアントが読む `error.message` を持たない。`validate` は
+  `{ error: { code: "VALIDATION_ERROR", message: "Invalid request body: pageNumber" } }`
+  の形に揃える。メッセージは zod の文言ではなく違反フィールドのパスなので、zod の更新で
+  変わらない
+- **クライアントの受け口**は `src/front/lib/fetcher.ts` の `fetcher(url, schema, init?, fetchFn?)`。
+  `schema.safeParse` を通った値だけを返し、失敗はすべて `ApiError`（`message` / `code` /
+  `status`）で throw する。サーバの `error.code` が取れないときは `"UNKNOWN"`、
+  レスポンスがスキーマに合わないときは `"INVALID_RESPONSE"`
+- **`chatService.ts` の `LlmMessage`** は LLM 送信用で `system` role を含み、保存される
+  `ChatMessage`（`shared/schemas/chat.ts`）とは別物。shared に混ぜないこと
+
+エラー形式は 2 系統あり、**ペイロード `{ code, message }` だけを共通化して transport の差は
+残している**。ストリーム開始前は HTTP ステータス + `{ error: { code, message } }`、開始後は
+`event: error` + 裸の `{ code, message }`。SSE ではイベント名が判別子なので `error` で包む
+意味がない。ワイヤ上の `code` は前方互換のため `z.string()` で受け（読み手は知らない code を
+渡す以外にできることがない）、サーバ側の構築だけ `shared/schemas/error.ts` の `ErrorCode`
+union + `satisfies` で固定する。
+
+#### `positionData` の正準形
+
+ハイライトの座標は `{ rects, pageWidth? }` が正準形で、**未知のキーは strip する**。
+
+- 書き込み（`POST /api/pdf/:pdfId/selections`）は `validate("json", ...)` で厳格に検証する。
+  ビューアは計測結果（`startIndex` / `endIndex` / `pageNumber` も持つ）を丸ごと送ってくるが、
+  保存されるのは正準形だけ
+- 読み出し（`pdfService.ts` の `readPositionData`）は `safeParse` + `{ rects: [] }`
+  フォールバック。**ここを strict にすると正準形でない既存行のある本が開けなくなる**。
+  JSON として壊れた行 1 件で本ごと 500 にしないためでもある
+
 ### pdf.js のランタイムアセット
 
 `scripts/copy-pdfjs-assets.mjs`（`postinstall` で実行）が `cmaps` と `standard_fonts` を
@@ -138,7 +175,7 @@ PDF 引用は `fullText` 内の位置からページ番号を割り出してジ�
 
 ### 状態管理とルーティング
 
-Jotai の atom（`src/front/atoms/`）。`swr` / `zod` / `neverthrow` はテンプレート由来の
+Jotai の atom（`src/front/atoms/`）。`swr` / `neverthrow` はテンプレート由来の
 未使用依存で、現在どこからも import していない。
 
 - `/` … 本棚（`ShelfPage`）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,15 +196,21 @@ DOM 非依存の純粋関数として実装。`gg` や `C-c t` の2ストロー�
 
 ランナーが3つあり、それぞれ守備範囲が違う:
 
-| ランナー              | 設定                       | 対象                                      |
-| --------------------- | -------------------------- | ----------------------------------------- |
-| vitest (jsdom)        | `vite.config.ts`           | `src/front/**` の純粋関数・コンポーネント |
-| vitest (workers pool) | `vitest.workers.config.ts` | `test/worker/**` の API                   |
-| Playwright            | `e2e/playwright.config.ts` | ブラウザ実操作                            |
+| ランナー              | 設定                       | 対象                                                                                |
+| --------------------- | -------------------------- | ----------------------------------------------------------------------------------- |
+| vitest (jsdom)        | `vite.config.ts`           | `src/**` の `*.test.ts(x)`（`src/front/**` と、workerd を要さない `src/server/**`） |
+| vitest (workers pool) | `vitest.workers.config.ts` | `test/worker/**` の API（`SELF.fetch` / D1 / R2 を使うもの）                        |
+| Playwright            | `e2e/playwright.config.ts` | ブラウザ実操作                                                                      |
 
 jsdom テストと Workers pool テストは同一プロセスで共存できないため設定が分かれている
 （`vite.config.ts` は `process.env.VITEST` のとき `cloudflare()` を無効化する）。
-`vite.config.ts` の `exclude` に `e2e/**` を入れてあり、Playwright の spec を vitest が拾わないようにしている。
+
+**jsdom 側は `include` を書かず `exclude` だけで拾っている**（`node_modules` / `dist` /
+`test/worker/**` / `e2e/**` を除外）。そのため実装とコロケーションした
+`src/server/services/*.test.ts` も自動的に jsdom で走る。バインディングを触らない純粋な
+サーバロジック（`chatService` の引用パース、`deepseekService` の SSE パースを注入 fetch で
+叩くもの）はこちらで書き、workerd の実物が要るものだけ `test/worker/**` に置く。
+**`include` を足して絞ると、これらが無言で走らなくなる**ので注意。
 
 ### E2E の前提
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test:e2e": "playwright test --config=e2e/playwright.config.ts"
   },
   "dependencies": {
+    "@hono/zod-validator": "^0.9.0",
     "drizzle-orm": "^0.45.2",
     "highlight.js": "^11.11.1",
     "hono": "^4.12.34",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
 
   .:
     dependencies:
+      '@hono/zod-validator':
+        specifier: ^0.9.0
+        version: 0.9.0(hono@4.12.34)(zod@4.4.3)
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@cloudflare/workers-types@5.20260711.1)
@@ -612,6 +615,12 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@hono/zod-validator@0.9.0':
+    resolution: {integrity: sha512-n0ZSXmCiHVIp4Y5wlOOyZCeTd/rsawA/qW1cipB8QOYKZ9N8Tk0nZUZCXho9cu374AN4JpDNKioNKBJ/W+LBug==}
+    peerDependencies:
+      hono: '>=4.11.2'
+      zod: ^3.25.0 || ^4.0.0
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3261,6 +3270,11 @@ snapshots:
     optional: true
 
   '@exodus/bytes@1.15.1': {}
+
+  '@hono/zod-validator@0.9.0(hono@4.12.34)(zod@4.4.3)':
+    dependencies:
+      hono: 4.12.34
+      zod: 4.4.3
 
   '@img/colour@1.1.0': {}
 

--- a/src/front/atoms/chatAtom.ts
+++ b/src/front/atoms/chatAtom.ts
@@ -1,39 +1,16 @@
 import { atom } from "jotai";
+import type { ChatMessage } from "../../shared/schemas/chat";
+import type { SelectionHighlight } from "../../shared/schemas/selection";
 
-export interface ChatMessage {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-  citations?: Citation[];
-  createdAt: string;
-}
-
-export interface Citation {
-  id: string;
-  type: "pdf" | "web";
-  text: string;
-  pageNumber?: number;
-  url?: string;
-}
+export type { ChatMessage } from "../../shared/schemas/chat";
+export type { Citation } from "../../shared/schemas/citation";
+export type { SelectionHighlight } from "../../shared/schemas/selection";
 
 /** The highlighted passage the current conversation is about. */
 export interface ActiveSelection {
   id: string;
   selectedText: string;
   pageNumber: number;
-}
-
-/** A highlight of the open book, as the viewer draws it and the list shows it. */
-export interface SelectionHighlight {
-  id: string;
-  selectedText: string;
-  pageNumber: number;
-  positionData: {
-    rects: { x: number; y: number; width: number; height: number }[];
-    pageWidth?: number;
-  };
-  color: string;
-  createdAt: string;
 }
 
 export const activeSelectionAtom = atom<ActiveSelection | null>(null);

--- a/src/front/atoms/settingsAtom.test.ts
+++ b/src/front/atoms/settingsAtom.test.ts
@@ -16,6 +16,31 @@ async function restoredMode(stored: string) {
   return createStore().get(keybindingModeAtom);
 }
 
+/**
+ * A session with the atom mounted, which is what makes it listen for the
+ * storage events another tab's writes arrive as.
+ */
+async function openSession(stored: string) {
+  localStorage.clear();
+  localStorage.setItem(STORAGE_KEY, stored);
+  vi.resetModules();
+  const { keybindingModeAtom } = await import("./settingsAtom");
+  const store = createStore();
+  const unmount = store.sub(keybindingModeAtom, () => {});
+
+  return {
+    mode: () => store.get(keybindingModeAtom),
+    writeFromAnotherTab: (value: unknown) => {
+      const newValue = JSON.stringify(value);
+      localStorage.setItem(STORAGE_KEY, newValue);
+      window.dispatchEvent(
+        new StorageEvent("storage", { key: STORAGE_KEY, newValue, storageArea: localStorage }),
+      );
+    },
+    unmount,
+  };
+}
+
 afterEach(() => {
   localStorage.clear();
 });
@@ -44,5 +69,27 @@ describe("keybindingModeAtom", () => {
     const mode = await restoredMode(stored);
 
     expect(mode).toBe(starts);
+  });
+
+  it("follows another tab when it switches to a mode the reader has bindings for", async () => {
+    const session = await openSession(JSON.stringify("vim"));
+
+    session.writeFromAnotherTab("emacs");
+
+    expect(session.mode()).toBe("emacs");
+    session.unmount();
+  });
+
+  it("falls back to the default mode when another tab writes one the reader has no bindings for", async () => {
+    // Checking storage only at startup would leave this open: the value
+    // arrives on the storage event, which never goes through getItem.
+    // Falling back to the default matches what a fresh session would do with
+    // the same stored value.
+    const session = await openSession(JSON.stringify("emacs"));
+
+    session.writeFromAnotherTab("dvorak");
+
+    expect(session.mode()).toBe("vim");
+    session.unmount();
   });
 });

--- a/src/front/atoms/settingsAtom.test.ts
+++ b/src/front/atoms/settingsAtom.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vite-plus/test";
+import { describe, it, expect, vi, afterEach } from "vite-plus/test";
 import { createStore } from "jotai";
 
 const STORAGE_KEY = "chatbook:keybindings";
@@ -8,26 +8,41 @@ const STORAGE_KEY = "chatbook:keybindings";
  * storage. The atom reads storage when it is created, so each case needs the
  * module loaded again.
  */
-async function restoredMode(stored: string | null) {
+async function restoredMode(stored: string) {
   localStorage.clear();
-  if (stored !== null) localStorage.setItem(STORAGE_KEY, stored);
+  localStorage.setItem(STORAGE_KEY, stored);
   vi.resetModules();
   const { keybindingModeAtom } = await import("./settingsAtom");
   return createStore().get(keybindingModeAtom);
 }
 
+afterEach(() => {
+  localStorage.clear();
+});
+
 describe("keybindingModeAtom", () => {
-  it("restores the mode a previous session stored", async () => {
-    expect(await restoredMode(JSON.stringify("emacs"))).toBe("emacs");
-  });
+  // Anything that is not a mode has to come back as the default: resolveAction
+  // has no default branch, so an unknown mode makes it return undefined and
+  // useKeyboardShortcuts throws on the first key pressed.
+  it.each([
+    {
+      holds: "a mode a previous session stored",
+      stored: JSON.stringify("emacs"),
+      starts: "emacs",
+    },
+    {
+      holds: "a mode the reader has no bindings for",
+      stored: JSON.stringify("dvorak"),
+      starts: "vim",
+    },
+    {
+      holds: "something that is not a mode at all",
+      stored: JSON.stringify({ mode: "vim" }),
+      starts: "vim",
+    },
+  ])("starts in $starts when storage holds $holds", async ({ stored, starts }) => {
+    const mode = await restoredMode(stored);
 
-  it("falls back to vim when storage holds a mode the reader has no bindings for", async () => {
-    // resolveAction has no default branch, so an unknown mode makes it return
-    // undefined and useKeyboardShortcuts throws on the first key pressed.
-    expect(await restoredMode(JSON.stringify("dvorak"))).toBe("vim");
-  });
-
-  it("falls back to vim when storage holds something that is not a mode at all", async () => {
-    expect(await restoredMode(JSON.stringify({ mode: "vim" }))).toBe("vim");
+    expect(mode).toBe(starts);
   });
 });

--- a/src/front/atoms/settingsAtom.test.ts
+++ b/src/front/atoms/settingsAtom.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vite-plus/test";
+import { createStore } from "jotai";
+
+const STORAGE_KEY = "chatbook:keybindings";
+
+/**
+ * The mode the reader starts a session with, given what the last one left in
+ * storage. The atom reads storage when it is created, so each case needs the
+ * module loaded again.
+ */
+async function restoredMode(stored: string | null) {
+  localStorage.clear();
+  if (stored !== null) localStorage.setItem(STORAGE_KEY, stored);
+  vi.resetModules();
+  const { keybindingModeAtom } = await import("./settingsAtom");
+  return createStore().get(keybindingModeAtom);
+}
+
+describe("keybindingModeAtom", () => {
+  it("restores the mode a previous session stored", async () => {
+    expect(await restoredMode(JSON.stringify("emacs"))).toBe("emacs");
+  });
+
+  it("falls back to vim when storage holds a mode the reader has no bindings for", async () => {
+    // resolveAction has no default branch, so an unknown mode makes it return
+    // undefined and useKeyboardShortcuts throws on the first key pressed.
+    expect(await restoredMode(JSON.stringify("dvorak"))).toBe("vim");
+  });
+
+  it("falls back to vim when storage holds something that is not a mode at all", async () => {
+    expect(await restoredMode(JSON.stringify({ mode: "vim" }))).toBe("vim");
+  });
+});

--- a/src/front/atoms/settingsAtom.ts
+++ b/src/front/atoms/settingsAtom.ts
@@ -6,6 +6,15 @@ const keybindingModeSchema = z.enum(["none", "vim", "emacs"]);
 
 const jsonStorage = createJSONStorage<KeybindingMode>(() => localStorage);
 
+/** Anything that is not one of the modes is treated as nothing stored. */
+function asMode(value: unknown, fallback: KeybindingMode): KeybindingMode {
+  const parsed = keybindingModeSchema.safeParse(value);
+  return parsed.success ? parsed.data : fallback;
+}
+
+/** Present whenever the environment can report another tab's writes. */
+const subscribeToStorage = jsonStorage.subscribe;
+
 /**
  * localStorage as a source of modes, with anything else treated as absent.
  *
@@ -14,16 +23,23 @@ const jsonStorage = createJSONStorage<KeybindingMode>(() => localStorage);
  * has no default branch, so such a value makes it return undefined and the
  * shortcut hook throws while destructuring it, on the first key pressed.
  *
+ * **Both ways in have to be checked.** A value read at startup arrives through
+ * `getItem`, but a value another tab writes arrives through `subscribe`, which
+ * parses the new string itself and never consults `getItem`. Checking only the
+ * former leaves the session open to exactly the value it refused to start with.
+ *
  * Written out rather than built with jotai's `unstable_withStorageValidator`,
- * which does the same thing: a setting that has to survive upgrades should not
- * hang off an API the library marks unstable.
+ * which is both marked unstable and has that same gap: it replaces `getItem`
+ * alone.
  */
 const keybindingModeStorage = {
   ...jsonStorage,
-  getItem: (key: string, initialValue: KeybindingMode): KeybindingMode => {
-    const stored = keybindingModeSchema.safeParse(jsonStorage.getItem(key, initialValue));
-    return stored.success ? stored.data : initialValue;
-  },
+  getItem: (key: string, initialValue: KeybindingMode): KeybindingMode =>
+    asMode(jsonStorage.getItem(key, initialValue), initialValue),
+  subscribe: subscribeToStorage
+    ? (key: string, callback: (value: KeybindingMode) => void, initialValue: KeybindingMode) =>
+        subscribeToStorage(key, (value) => callback(asMode(value, initialValue)), initialValue)
+    : undefined,
 };
 
 /** Persisted so the reader keeps the chosen bindings across sessions. */

--- a/src/front/atoms/settingsAtom.ts
+++ b/src/front/atoms/settingsAtom.ts
@@ -1,10 +1,35 @@
-import { atomWithStorage } from "jotai/utils";
+import { atomWithStorage, createJSONStorage } from "jotai/utils";
+import { z } from "zod";
 import type { KeybindingMode } from "../lib/keybindings";
+
+const keybindingModeSchema = z.enum(["none", "vim", "emacs"]);
+
+const jsonStorage = createJSONStorage<KeybindingMode>(() => localStorage);
+
+/**
+ * localStorage as a source of modes, with anything else treated as absent.
+ *
+ * The stored value is outside this app's control — an older release, another
+ * tab, or the devtools can leave a string that is not a mode. `resolveAction`
+ * has no default branch, so such a value makes it return undefined and the
+ * shortcut hook throws while destructuring it, on the first key pressed.
+ *
+ * Written out rather than built with jotai's `unstable_withStorageValidator`,
+ * which does the same thing: a setting that has to survive upgrades should not
+ * hang off an API the library marks unstable.
+ */
+const keybindingModeStorage = {
+  ...jsonStorage,
+  getItem: (key: string, initialValue: KeybindingMode): KeybindingMode => {
+    const stored = keybindingModeSchema.safeParse(jsonStorage.getItem(key, initialValue));
+    return stored.success ? stored.data : initialValue;
+  },
+};
 
 /** Persisted so the reader keeps the chosen bindings across sessions. */
 export const keybindingModeAtom = atomWithStorage<KeybindingMode>(
   "chatbook:keybindings",
   "vim",
-  undefined,
+  keybindingModeStorage,
   { getOnInit: true },
 );

--- a/src/front/components/PdfViewer/FileSelector.tsx
+++ b/src/front/components/PdfViewer/FileSelector.tsx
@@ -3,6 +3,7 @@ import { useAtom } from "jotai";
 import { pdfDocAtom, pdfStatusAtom, pdfErrorAtom } from "../../atoms/pdfAtom";
 import { extractPdfData } from "../../lib/pdfLoader";
 import { fetcher } from "../../lib/fetcher";
+import { pdfMetadataSchema } from "../../../shared/schemas/book";
 
 interface FileSelectorProps {
   /** Called with the book id once the upload finished, so the caller can navigate. */
@@ -37,11 +38,7 @@ export function FileSelector({ onOpened, label = "PDFを開く", className }: Fi
         formData.append("thumbnail", extracted.thumbnail, "cover.webp");
       }
 
-      const result = await fetcher<{
-        id: string;
-        fileName: string;
-        pageCount: number;
-      }>("/api/pdf/open", {
+      const result = await fetcher("/api/pdf/open", pdfMetadataSchema, {
         method: "POST",
         body: formData,
       });

--- a/src/front/components/PdfViewer/HighlightOverlay.tsx
+++ b/src/front/components/PdfViewer/HighlightOverlay.tsx
@@ -1,14 +1,11 @@
-import type { SelectionRect } from "../../lib/selectionRects";
+import type { PositionData, SelectionRect } from "../../../shared/schemas/selection";
 
 interface Highlight {
   id: string;
   pageNumber: number;
-  positionData: {
-    rects: SelectionRect[];
-    /** Page width the rects were measured at. Missing on records stored before
-     * the viewer could be resized, which were always measured at 1.5x. */
-    pageWidth?: number;
-  };
+  /** `pageWidth` is missing on records stored before the viewer could be
+   * resized, which were always measured at 1.5x. */
+  positionData: PositionData;
   color: string;
 }
 

--- a/src/front/components/PdfViewer/PdfViewer.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.tsx
@@ -30,6 +30,8 @@ import { useChatStream } from "../../hooks/useChatStream";
 import { useHighlights } from "../../hooks/useHighlights";
 import type { ViewerAction } from "../../lib/keybindings";
 import { fetcher } from "../../lib/fetcher";
+import { bookDetailSchema } from "../../../shared/schemas/book";
+import { createdSelectionSchema } from "../../../shared/schemas/selection";
 
 interface PdfViewerProps {
   onSelectionClick: (selection: ActiveSelection) => void;
@@ -51,7 +53,7 @@ const SCROLL_STEP = 80;
 
 /** Books saved before highlights carried a colour fall back to the palette. */
 async function loadSelections(pdfId: string): Promise<SelectionHighlight[]> {
-  const data = await fetcher<{ selections: SelectionHighlight[] }>(`/api/pdf/${pdfId}`);
+  const data = await fetcher(`/api/pdf/${pdfId}`, bookDetailSchema);
   return data.selections.map((selection, i) => ({
     ...selection,
     color: selection.color || HIGHLIGHT_COLORS[i % HIGHLIGHT_COLORS.length],
@@ -229,21 +231,21 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
       setPopoverState(null);
 
       try {
-        const selection = await fetcher<{
-          id: string;
-          selectedText: string;
-          pageNumber: number;
-          positionData: { rects: { x: number; y: number; width: number; height: number }[] };
-          createdAt: string;
-        }>(`/api/pdf/${pdfDoc.id}/selections`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            selectedText: popoverState.selectedText,
-            pageNumber: popoverState.selectionPosition.pageNumber,
-            positionData: popoverState.selectionPosition,
-          }),
-        });
+        const selection = await fetcher(
+          `/api/pdf/${pdfDoc.id}/selections`,
+          createdSelectionSchema,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              selectedText: popoverState.selectedText,
+              pageNumber: popoverState.selectionPosition.pageNumber,
+              // The rest of the measurement (the text offsets the passage was
+              // found at) is stripped by the endpoint.
+              positionData: popoverState.selectionPosition,
+            }),
+          },
+        );
 
         // Add highlight
         const colorIdx = highlights.length % HIGHLIGHT_COLORS.length;

--- a/src/front/hooks/useChatStream.test.tsx
+++ b/src/front/hooks/useChatStream.test.tsx
@@ -10,7 +10,15 @@ import {
   isStreamingAtom,
   streamingContentAtom,
 } from "../atoms/chatAtom";
-import { doneEvent, streamingFetchStub, tokenEvent } from "../../test/streamingFetchStub";
+import {
+  citationEvent,
+  doneEvent,
+  errorEvent,
+  streamingFetchStub,
+  tokenEvent,
+} from "../../test/streamingFetchStub";
+import { ApiError } from "../lib/fetcher";
+import type { Citation } from "../atoms/chatAtom";
 
 const QUESTION = "Durable Objects とは?";
 
@@ -112,6 +120,58 @@ describe("useChatStream", () => {
     ]);
     expect(store.get(isStreamingAtom)).toBe(false);
     expect(store.get(chatAbortControllerAtom)).toBeNull();
+  });
+
+  it("keeps a citation of an unknown kind out of the answer's sources", async () => {
+    // `data as Citation` used to hand this straight to CitationBadge, which
+    // renders by `type`.
+    const { fetchFn, calls } = streamingFetchStub();
+    const { store, view } = renderChatStream(fetchFn);
+    const received: Citation[] = [];
+
+    let sent!: Promise<void>;
+    await act(async () => {
+      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false, {
+        onCitation: (citation) => received.push(citation),
+      });
+    });
+    await act(async () => {
+      calls[0].emit(tokenEvent("単一のインスタンスです"));
+      calls[0].emit(citationEvent({ id: "1", type: "podcast", text: "出所不明" }));
+      calls[0].emit(
+        citationEvent({ id: "2", type: "pdf", text: "エッジで動きます", pageNumber: 3 }),
+      );
+      calls[0].emit(doneEvent("m1"));
+      calls[0].end();
+      await sent;
+    });
+
+    const expected = [{ id: "2", type: "pdf", text: "エッジで動きます", pageNumber: 3 }];
+    expect(received).toStrictEqual(expected);
+    expect(store.get(chatMessagesAtom).at(-1)?.citations).toStrictEqual(expected);
+  });
+
+  it("reports the code the server sent with a failed answer, not just its message", async () => {
+    const { fetchFn, calls } = streamingFetchStub();
+    const { view } = renderChatStream(fetchFn);
+    const errors: Error[] = [];
+
+    let sent!: Promise<void>;
+    await act(async () => {
+      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false, {
+        onError: (err) => errors.push(err),
+      });
+    });
+    await act(async () => {
+      calls[0].emit(errorEvent("AI_API_ERROR", "upstream is down"));
+      calls[0].end();
+      await sent;
+    });
+
+    expect(errors.map((err) => [err.message, (err as ApiError).code])).toStrictEqual([
+      ["upstream is down", "AI_API_ERROR"],
+    ]);
+    expect(errors[0]).toBeInstanceOf(ApiError);
   });
 
   it("stamps both messages with the injected clock instead of the wall clock", async () => {

--- a/src/front/hooks/useChatStream.test.tsx
+++ b/src/front/hooks/useChatStream.test.tsx
@@ -151,7 +151,7 @@ describe("useChatStream", () => {
     expect(store.get(chatMessagesAtom).at(-1)?.citations).toStrictEqual(expected);
   });
 
-  it("reports the code the server sent with a failed answer, not just its message", async () => {
+  it("reports the code as well as the message when the stream carries an error event", async () => {
     const { fetchFn, calls } = streamingFetchStub();
     const { view } = renderChatStream(fetchFn);
     const errors: Error[] = [];

--- a/src/front/hooks/useChatStream.ts
+++ b/src/front/hooks/useChatStream.ts
@@ -10,6 +10,8 @@ import {
   type Citation,
 } from "../atoms/chatAtom";
 import { createSseParser } from "../lib/sseParser";
+import { ApiError } from "../lib/fetcher";
+import { chatSseEventSchema } from "../../shared/schemas/sse";
 
 /** fetch reports an abort with a DOMException, which does not extend Error. */
 function isAbortError(err: unknown): boolean {
@@ -91,28 +93,34 @@ export function useChatStream(fetchFn: typeof fetch = fetch, now: () => Date = s
           const { done, value } = await reader.read();
           if (done) break;
 
-          for (const { event, data } of parse(decoder.decode(value, { stream: true }))) {
-            switch (event) {
+          for (const block of parse(decoder.decode(value, { stream: true }))) {
+            // An event the schema does not recognise is skipped rather than
+            // passed on: a citation of an unknown kind would reach the badge
+            // that renders by `type`, and a malformed token would be appended
+            // to the answer as it is.
+            const parsed = chatSseEventSchema.safeParse(block);
+            if (!parsed.success) continue;
+
+            const event = parsed.data;
+            switch (event.event) {
               case "token": {
-                const { content: token } = data as { content?: string };
-                if (token) {
-                  fullContent += token;
-                  setStreamingContent(fullContent);
-                }
+                fullContent += event.data.content;
+                setStreamingContent(fullContent);
                 break;
               }
               case "citation": {
-                const citation = data as Citation;
-                citations.push(citation);
-                options.onCitation?.(citation);
+                citations.push(event.data);
+                options.onCitation?.(event.data);
                 break;
               }
               case "done": {
-                messageId = (data as { messageId?: string }).messageId ?? "";
+                messageId = event.data.messageId;
                 break;
               }
               case "error": {
-                streamError = new Error((data as { message?: string }).message ?? "stream error");
+                // The stream carries its failures at HTTP 200, so the status
+                // an error of this kind reports is the stream's own.
+                streamError = new ApiError(event.data.message, event.data.code, response.status);
                 break;
               }
             }

--- a/src/front/hooks/usePdfDocument.ts
+++ b/src/front/hooks/usePdfDocument.ts
@@ -4,6 +4,8 @@ import type * as pdfjsTypes from "pdfjs-dist";
 import type { PdfDoc } from "../atoms/pdfAtom";
 import { pdfjsLib, PDFJS_ASSET_OPTIONS } from "../lib/pdfjsConfig";
 import { renderCoverThumbnail } from "../lib/pdfLoader";
+import { fetcher } from "../lib/fetcher";
+import { bookDetailSchema, thumbnailStoredSchema } from "../../shared/schemas/book";
 
 /**
  * Books opened before covers existed have no thumbnail in storage. The reader
@@ -16,17 +18,22 @@ async function backfillCover(
   fetchFn: typeof fetch,
 ) {
   try {
-    const book = await fetchFn(`/api/pdf/${pdfId}`).then((r) => (r.ok ? r.json() : null));
-    if (!book || book.hasThumbnail) return;
+    const book = await fetcher(`/api/pdf/${pdfId}`, bookDetailSchema, undefined, fetchFn);
+    if (book.hasThumbnail) return;
 
     const thumbnail = await renderCoverThumbnail(doc);
     if (!thumbnail) return;
 
-    await fetchFn(`/api/pdf/${pdfId}/thumbnail`, {
-      method: "PUT",
-      headers: { "Content-Type": "image/webp" },
-      body: thumbnail,
-    });
+    await fetcher(
+      `/api/pdf/${pdfId}/thumbnail`,
+      thumbnailStoredSchema,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "image/webp" },
+        body: thumbnail,
+      },
+      fetchFn,
+    );
   } catch (err) {
     console.warn("Failed to backfill the book cover (non-critical):", err);
   }

--- a/src/front/lib/fetcher.test.ts
+++ b/src/front/lib/fetcher.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vite-plus/test";
+import { z } from "zod";
+import { ApiError, fetcher } from "./fetcher";
+
+const bookSchema = z.object({ id: z.string(), pageCount: z.number().int().positive() });
+
+/** A fetch that always answers with the given body and status. */
+function respondingWith(body: unknown, status = 200): typeof fetch {
+  return () =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+}
+
+describe("fetcher", () => {
+  it("returns the body when it matches the schema", async () => {
+    const book = await fetcher(
+      "/api/pdf/b1",
+      bookSchema,
+      undefined,
+      respondingWith({ id: "b1", pageCount: 209 }),
+    );
+
+    expect(book).toStrictEqual({ id: "b1", pageCount: 209 });
+  });
+
+  it("carries the server's own code and message when the request is refused", async () => {
+    const failed = fetcher(
+      "/api/pdf/b1",
+      bookSchema,
+      undefined,
+      respondingWith({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404),
+    );
+
+    await expect(failed).rejects.toThrow(ApiError);
+    const error = (await failed.catch((err: ApiError) => err)) as ApiError;
+    expect([error.message, error.code, error.status]).toStrictEqual([
+      "PDF not found",
+      "PDF_NOT_FOUND",
+      404,
+    ]);
+  });
+
+  it("falls back to the status when the refusal is not the API's error envelope", async () => {
+    const failed = fetcher("/api/pdf/b1", bookSchema, undefined, respondingWith("<html>", 502));
+
+    const error = (await failed.catch((err: ApiError) => err)) as ApiError;
+    expect([error.message, error.code, error.status]).toStrictEqual([
+      "request to /api/pdf/b1 failed with status 502",
+      "UNKNOWN",
+      502,
+    ]);
+  });
+
+  it("refuses a successful response whose body is not what the caller asked for", async () => {
+    // Without this the caller's type annotation is a wish: the old fetcher
+    // handed the body straight on, so pageCount could be a string at runtime.
+    const failed = fetcher(
+      "/api/pdf/b1",
+      bookSchema,
+      undefined,
+      respondingWith({ id: "b1", pageCount: "209" }),
+    );
+
+    const error = (await failed.catch((err: ApiError) => err)) as ApiError;
+    expect([error.message, error.code, error.status]).toStrictEqual([
+      "unexpected response from /api/pdf/b1",
+      "INVALID_RESPONSE",
+      200,
+    ]);
+  });
+});

--- a/src/front/lib/fetcher.test.ts
+++ b/src/front/lib/fetcher.test.ts
@@ -55,6 +55,30 @@ describe("fetcher", () => {
     ]);
   });
 
+  it("lets a request that never reached the server through as the failure fetch reported", async () => {
+    // Only failures the server described are ApiError. A connection that never
+    // produced a response has no code or status to report, and callers that
+    // handle an abort look at the original error's name.
+    const offline: typeof fetch = () => Promise.reject(new TypeError("Failed to fetch"));
+
+    const failed = fetcher("/api/pdf/b1", bookSchema, undefined, offline);
+
+    const error = (await failed.catch((err: unknown) => err)) as TypeError;
+    expect(error).toBeInstanceOf(TypeError);
+    expect(error).not.toBeInstanceOf(ApiError);
+    expect(error.message).toBe("Failed to fetch");
+  });
+
+  it("lets an aborted request through with the name callers check for", async () => {
+    const aborted: typeof fetch = () =>
+      Promise.reject(new DOMException("The operation was aborted.", "AbortError"));
+
+    const failed = fetcher("/api/pdf/b1", bookSchema, undefined, aborted);
+
+    const error = (await failed.catch((err: unknown) => err)) as DOMException;
+    expect([error.name, error.message]).toStrictEqual(["AbortError", "The operation was aborted."]);
+  });
+
   it("refuses a successful response whose body is not what the caller asked for", async () => {
     // Without this the caller's type annotation is a wish: the old fetcher
     // handed the body straight on, so pageCount could be a string at runtime.

--- a/src/front/lib/fetcher.ts
+++ b/src/front/lib/fetcher.ts
@@ -1,16 +1,66 @@
-export async function fetcher<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, init);
-  if (!res.ok) {
-    let message = `request to ${url} failed with status ${res.status}`;
-    try {
-      const body = await res.json();
-      if (body.error?.message) {
-        message = body.error.message;
-      }
-    } catch {
-      // ignore parse errors
-    }
-    throw new Error(message);
+import type { z } from "zod";
+import { errorEnvelopeSchema } from "../../shared/schemas/error";
+
+/**
+ * A request the API refused, or answered with something this client cannot
+ * read.
+ */
+export class ApiError extends Error {
+  /** The server's `error.code`, or `"UNKNOWN"` when it did not send one. */
+  readonly code: string;
+  /** Status of the response the error was read from. */
+  readonly status: number;
+
+  constructor(message: string, code: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.code = code;
+    this.status = status;
   }
-  return res.json();
+}
+
+/** Code reported when the response body is not this API's error envelope. */
+const UNKNOWN_ERROR_CODE = "UNKNOWN";
+
+/** Code reported when a successful response does not match the caller's schema. */
+const INVALID_RESPONSE_CODE = "INVALID_RESPONSE";
+
+/**
+ * Call the API and hand back a body that has been checked against `schema`.
+ *
+ * The schema is what makes the return type true: without it the caller's type
+ * annotation is only a wish, since `res.json()` is `any`. Anything the schema
+ * does not accept — including a refusal — leaves as an `ApiError`, so callers
+ * have one error type to read `code` and `message` off.
+ *
+ * `fetchFn` is injectable so a caller that already owns a fetch (tests, or the
+ * reader's own document loader) can pass it through.
+ */
+export async function fetcher<S extends z.ZodType>(
+  url: string,
+  schema: S,
+  init?: RequestInit,
+  fetchFn: typeof fetch = fetch,
+): Promise<z.output<S>> {
+  const res = await fetchFn(url, init);
+  const body = await res.json().catch(() => null);
+
+  if (!res.ok) {
+    const failure = errorEnvelopeSchema.safeParse(body);
+    if (failure.success) {
+      throw new ApiError(failure.data.error.message, failure.data.error.code, res.status);
+    }
+    throw new ApiError(
+      `request to ${url} failed with status ${res.status}`,
+      UNKNOWN_ERROR_CODE,
+      res.status,
+    );
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    throw new ApiError(`unexpected response from ${url}`, INVALID_RESPONSE_CODE, res.status);
+  }
+
+  return parsed.data;
 }

--- a/src/front/lib/selectionRects.ts
+++ b/src/front/lib/selectionRects.ts
@@ -1,9 +1,6 @@
-export interface SelectionRect {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}
+import type { SelectionRect } from "../../shared/schemas/selection";
+
+export type { SelectionRect } from "../../shared/schemas/selection";
 
 /** Two rects belong to the same line when their tops are within this share of a line's height. */
 const SAME_LINE_RATIO = 0.5;

--- a/src/front/pages/AppPage.tsx
+++ b/src/front/pages/AppPage.tsx
@@ -8,7 +8,6 @@ import {
   chatMessagesAtom,
   abortChatStreamAtom,
   type ActiveSelection,
-  type Citation,
 } from "../atoms/chatAtom";
 import { PdfViewer } from "../components/PdfViewer/PdfViewer";
 import { ChatArea } from "../components/ChatArea/ChatArea";
@@ -16,11 +15,14 @@ import { SettingsMenu } from "../components/SettingsMenu";
 import { useReadingLocation } from "../hooks/useReadingLocation";
 import { passageFromNavigation } from "../lib/textFragment";
 import { fetcher } from "../lib/fetcher";
+import { bookDetailSchema, locatedPageSchema } from "../../shared/schemas/book";
+import { chatHistorySchema } from "../../shared/schemas/chat";
 
 /** Asks the server which page a passage from a `#:~:text=` link is on. */
 async function locatePassage(pdfId: string, passage: string): Promise<number | null> {
-  const { pageNumber } = await fetcher<{ pageNumber: number | null }>(
+  const { pageNumber } = await fetcher(
     `/api/pdf/${pdfId}/locate?text=${encodeURIComponent(passage)}`,
+    locatedPageSchema,
   );
   return pageNumber;
 }
@@ -54,7 +56,7 @@ export function AppPage() {
     setPdfStatus("loading");
     setPdfError(null);
 
-    fetcher<{ id: string; fileName: string; pageCount: number }>(`/api/pdf/${pdfId}`)
+    fetcher(`/api/pdf/${pdfId}`, bookDetailSchema)
       .then((book) => {
         if (cancelled) return;
         setPdfDoc({ id: book.id, fileName: book.fileName, pageCount: book.pageCount });
@@ -93,26 +95,12 @@ export function AppPage() {
       if (!pdfDoc) return;
 
       try {
-        const data = await fetcher<{
-          selectionId: string;
-          messages: {
-            id: string;
-            role: string;
-            content: string;
-            citations?: Citation[];
-            createdAt: string;
-          }[];
-        }>(`/api/pdf/${pdfDoc.id}/selections/${selection.id}/chats`);
-
-        setChatMessages(
-          data.messages.map((m) => ({
-            id: m.id,
-            role: m.role as "user" | "assistant",
-            content: m.content,
-            citations: m.citations,
-            createdAt: m.createdAt,
-          })),
+        const data = await fetcher(
+          `/api/pdf/${pdfDoc.id}/selections/${selection.id}/chats`,
+          chatHistorySchema,
         );
+
+        setChatMessages(data.messages);
       } catch {
         setChatMessages([]);
       }

--- a/src/front/pages/ShelfPage.tsx
+++ b/src/front/pages/ShelfPage.tsx
@@ -3,15 +3,15 @@ import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router";
 import { FileSelector } from "../components/PdfViewer/FileSelector";
 import { fetcher } from "../lib/fetcher";
-import type { BookSummary } from "../../shared/schemas/book";
+import { bookDeletedSchema, bookListSchema, type BookSummary } from "../../shared/schemas/book";
 
 export type Book = BookSummary;
 
 /** Module-level so the effect below keeps a stable dependency. */
-const fetchBooks = () => fetcher<{ books: Book[] }>("/api/pdfs").then((data) => data.books);
+const fetchBooks = () => fetcher("/api/pdfs", bookListSchema).then((data) => data.books);
 
 const requestBookDeletion = (id: string) =>
-  fetcher<{ deleted: true }>(`/api/pdf/${id}`, { method: "DELETE" });
+  fetcher(`/api/pdf/${id}`, bookDeletedSchema, { method: "DELETE" });
 
 interface ShelfPageProps {
   loadBooks?: () => Promise<Book[]>;

--- a/src/front/pages/ShelfPage.tsx
+++ b/src/front/pages/ShelfPage.tsx
@@ -3,14 +3,9 @@ import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router";
 import { FileSelector } from "../components/PdfViewer/FileSelector";
 import { fetcher } from "../lib/fetcher";
+import type { BookSummary } from "../../shared/schemas/book";
 
-export interface Book {
-  id: string;
-  fileName: string;
-  pageCount: number;
-  updatedAt: string;
-  hasThumbnail: boolean;
-}
+export type Book = BookSummary;
 
 /** Module-level so the effect below keeps a stable dependency. */
 const fetchBooks = () => fetcher<{ books: Book[] }>("/api/pdfs").then((data) => data.books);

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -18,7 +18,12 @@ import {
   streamChatCompletion,
   streamResponseWithWebSearch,
 } from "../services/deepseekService";
-import { buildMessages, findPageNumber, parseCitations } from "../services/chatService";
+import {
+  buildMessages,
+  findPageNumber,
+  parseCitations,
+  readCitations,
+} from "../services/chatService";
 import { locateQuerySchema } from "../../shared/schemas/book";
 import { createSelectionRequestSchema } from "../../shared/schemas/selection";
 import { sendChatRequestSchema } from "../../shared/schemas/chat";
@@ -298,7 +303,7 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
             id: m.id,
             role: m.role,
             content: m.content,
-            citations: m.citations ? JSON.parse(m.citations) : null,
+            citations: readCitations(m.citations),
             createdAt: m.createdAt,
           })),
         });

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -60,13 +60,23 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
       .post("/pdf/open", async (c) => {
         const formData = await c.req.parseBody().catch(() => null);
         if (!formData) {
-          return c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid form body" } }, 400);
+          return c.json(
+            {
+              error: { code: "VALIDATION_ERROR" satisfies ErrorCode, message: "Invalid form body" },
+            },
+            400,
+          );
         }
 
         const file = formData.file;
         if (!file || !(file instanceof File)) {
           return c.json(
-            { error: { code: "VALIDATION_ERROR", message: "No PDF file provided" } },
+            {
+              error: {
+                code: "VALIDATION_ERROR" satisfies ErrorCode,
+                message: "No PDF file provided",
+              },
+            },
             400,
           );
         }
@@ -77,7 +87,12 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           typeof formData.pageCount === "string" ? parseInt(formData.pageCount, 10) : 0;
         if (!fullText || !Number.isFinite(pageCount) || pageCount <= 0) {
           return c.json(
-            { error: { code: "VALIDATION_ERROR", message: "Missing fullText or pageCount" } },
+            {
+              error: {
+                code: "VALIDATION_ERROR" satisfies ErrorCode,
+                message: "Missing fullText or pageCount",
+              },
+            },
             400,
           );
         }
@@ -111,7 +126,12 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
         } catch (err) {
           console.error("PDF open error:", err);
           return c.json(
-            { error: { code: "PDF_EXTRACT_FAILED", message: "Failed to process PDF" } },
+            {
+              error: {
+                code: "PDF_EXTRACT_FAILED" satisfies ErrorCode,
+                message: "Failed to process PDF",
+              },
+            },
             500,
           );
         }
@@ -127,13 +147,21 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           .where(eq(pdfs.id, c.req.param("pdfId")))
           .get();
         if (!pdf) {
-          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+          return c.json(
+            { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
+            404,
+          );
         }
 
         const object = await c.env.PDF_BUCKET.get(thumbnailObjectKey(pdf.fileHash));
         if (!object) {
           return c.json(
-            { error: { code: "THUMBNAIL_MISSING", message: "No cover stored for this book" } },
+            {
+              error: {
+                code: "THUMBNAIL_MISSING" satisfies ErrorCode,
+                message: "No cover stored for this book",
+              },
+            },
             404,
           );
         }
@@ -152,7 +180,10 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           .where(eq(pdfs.id, c.req.param("pdfId")))
           .get();
         if (!pdf) {
-          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+          return c.json(
+            { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
+            404,
+          );
         }
 
         if (c.req.header("Content-Type") !== THUMBNAIL_CONTENT_TYPE) {
@@ -169,7 +200,10 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
 
         const body = await c.req.arrayBuffer();
         if (body.byteLength === 0) {
-          return c.json({ error: { code: "VALIDATION_ERROR", message: "Empty thumbnail" } }, 400);
+          return c.json(
+            { error: { code: "VALIDATION_ERROR" satisfies ErrorCode, message: "Empty thumbnail" } },
+            400,
+          );
         }
         if (body.byteLength > MAX_THUMBNAIL_BYTES) {
           return c.json(
@@ -207,13 +241,21 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
         const d1Db = drizzle(c.env.DB);
         const pdf = await d1Db.select().from(pdfs).where(eq(pdfs.id, pdfId)).get();
         if (!pdf) {
-          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+          return c.json(
+            { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
+            404,
+          );
         }
 
         const object = await c.env.PDF_BUCKET.get(pdf.filePath);
         if (!object) {
           return c.json(
-            { error: { code: "PDF_FILE_MISSING", message: "PDF binary not found in storage" } },
+            {
+              error: {
+                code: "PDF_FILE_MISSING" satisfies ErrorCode,
+                message: "PDF binary not found in storage",
+              },
+            },
             404,
           );
         }
@@ -236,7 +278,10 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           .where(eq(pdfs.id, c.req.param("pdfId")))
           .get();
         if (!pdf) {
-          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+          return c.json(
+            { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
+            404,
+          );
         }
 
         return c.json({ pageNumber: findPageNumber(text, pdf.fullText, pdf.pageCount) ?? null });
@@ -246,7 +291,10 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
         const result = await getPdf(c.env.DB, c.env.PDF_BUCKET, pdfId);
 
         if (!result) {
-          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+          return c.json(
+            { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
+            404,
+          );
         }
 
         return c.json(result);
@@ -258,7 +306,10 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
         // Verify pdf exists
         const pdf = await d1Db.select().from(pdfs).where(eq(pdfs.id, pdfId)).get();
         if (!pdf) {
-          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+          return c.json(
+            { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
+            404,
+          );
         }
 
         // Validated, so positionData is already down to the shape the viewer
@@ -286,7 +337,12 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
         const sel = await d1Db.select().from(selections).where(eq(selections.id, selId)).get();
         if (!sel) {
           return c.json(
-            { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } },
+            {
+              error: {
+                code: "SELECTION_NOT_FOUND" satisfies ErrorCode,
+                message: "Selection not found",
+              },
+            },
             404,
           );
         }
@@ -318,7 +374,12 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
 
           if (!apiKey) {
             return c.json(
-              { error: { code: "CONFIG_ERROR", message: "DEEPSEEK_API_KEY not set" } },
+              {
+                error: {
+                  code: "CONFIG_ERROR" satisfies ErrorCode,
+                  message: "DEEPSEEK_API_KEY not set",
+                },
+              },
               500,
             );
           }
@@ -326,7 +387,12 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           const sel = await d1Db.select().from(selections).where(eq(selections.id, selId)).get();
           if (!sel) {
             return c.json(
-              { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } },
+              {
+                error: {
+                  code: "SELECTION_NOT_FOUND" satisfies ErrorCode,
+                  message: "Selection not found",
+                },
+              },
               404,
             );
           }
@@ -354,7 +420,10 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
             .get();
 
           if (!pdfRow) {
-            return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+            return c.json(
+              { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
+              404,
+            );
           }
 
           // Get chat history
@@ -488,7 +557,10 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
       .delete("/pdf/:pdfId", async (c) => {
         const deleted = await deletePdf(c.env.DB, c.env.PDF_BUCKET, c.req.param("pdfId"));
         if (!deleted) {
-          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+          return c.json(
+            { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
+            404,
+          );
         }
 
         return c.json({ deleted: true });

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -19,6 +19,7 @@ import {
   streamResponseWithWebSearch,
 } from "../services/deepseekService";
 import { buildMessages, findPageNumber, parseCitations } from "../services/chatService";
+import { locateQuerySchema } from "../../shared/schemas/book";
 import { createSelectionRequestSchema } from "../../shared/schemas/selection";
 import { sendChatRequestSchema } from "../../shared/schemas/chat";
 import type { ErrorCode, ErrorPayload } from "../../shared/schemas/error";
@@ -31,6 +32,17 @@ type Env = {
     DEEPSEEK_API_KEY: string;
   };
 };
+
+/** A cover is one page rendered 400px wide; nothing that big is one. */
+const MAX_THUMBNAIL_BYTES = 2 * 1024 * 1024;
+
+/** A WebP file is a RIFF container whose form type, at offset 8, is "WEBP". */
+function isWebp(body: ArrayBuffer): boolean {
+  if (body.byteLength < 12) return false;
+  const header = new Uint8Array(body, 0, 12);
+  const tag = (offset: number) => String.fromCharCode(...header.subarray(offset, offset + 4));
+  return tag(0) === "RIFF" && tag(8) === "WEBP";
+}
 
 /**
  * Build the PDF routes. Ids and timestamps come from the injected clock; the
@@ -138,9 +150,45 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
         }
 
+        if (c.req.header("Content-Type") !== THUMBNAIL_CONTENT_TYPE) {
+          return c.json(
+            {
+              error: {
+                code: "VALIDATION_ERROR" satisfies ErrorCode,
+                message: `Thumbnail must be sent as ${THUMBNAIL_CONTENT_TYPE}`,
+              },
+            },
+            400,
+          );
+        }
+
         const body = await c.req.arrayBuffer();
         if (body.byteLength === 0) {
           return c.json({ error: { code: "VALIDATION_ERROR", message: "Empty thumbnail" } }, 400);
+        }
+        if (body.byteLength > MAX_THUMBNAIL_BYTES) {
+          return c.json(
+            {
+              error: {
+                code: "VALIDATION_ERROR" satisfies ErrorCode,
+                message: `Thumbnail is larger than ${MAX_THUMBNAIL_BYTES} bytes`,
+              },
+            },
+            400,
+          );
+        }
+        // The bucket serves this back as image/webp, so what goes in has to be
+        // one: the endpoint is otherwise a way to store arbitrary bytes.
+        if (!isWebp(body)) {
+          return c.json(
+            {
+              error: {
+                code: "VALIDATION_ERROR" satisfies ErrorCode,
+                message: "Thumbnail is not a WebP image",
+              },
+            },
+            400,
+          );
         }
 
         await c.env.PDF_BUCKET.put(thumbnailObjectKey(pdf.fileHash), body, {
@@ -175,8 +223,8 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
       // Resolves a passage from a `#:~:text=` link to the page that holds it. The
       // browser cannot do this itself here: the page is only in the DOM once the
       // reader has jumped to it.
-      .get("/pdf/:pdfId/locate", async (c) => {
-        const text = c.req.query("text");
+      .get("/pdf/:pdfId/locate", validate("query", locateQuerySchema), async (c) => {
+        const { text } = c.req.valid("query");
         const pdf = await drizzle(c.env.DB)
           .select({ fullText: pdfs.fullText, pageCount: pdfs.pageCount })
           .from(pdfs)
@@ -184,9 +232,6 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           .get();
         if (!pdf) {
           return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-        }
-        if (!text) {
-          return c.json({ error: { code: "VALIDATION_ERROR", message: "Missing text" } }, 400);
         }
 
         return c.json({ pageNumber: findPageNumber(text, pdf.fullText, pdf.pageCount) ?? null });

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -20,6 +20,8 @@ import {
 } from "../services/deepseekService";
 import { buildMessages, findPageNumber, parseCitations } from "../services/chatService";
 import { createSelectionRequestSchema } from "../../shared/schemas/selection";
+import { sendChatRequestSchema } from "../../shared/schemas/chat";
+import type { ErrorCode, ErrorPayload } from "../../shared/schemas/error";
 import { validate } from "./validation";
 
 type Env = {
@@ -256,180 +258,183 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           })),
         });
       })
-      .post("/pdf/:pdfId/selections/:selId/chats", async (c) => {
-        const selId = c.req.param("selId");
-        const d1Db = drizzle(c.env.DB);
-        const apiKey = c.env.DEEPSEEK_API_KEY;
+      .post(
+        "/pdf/:pdfId/selections/:selId/chats",
+        validate("json", sendChatRequestSchema),
+        async (c) => {
+          const selId = c.req.param("selId");
+          const d1Db = drizzle(c.env.DB);
+          const apiKey = c.env.DEEPSEEK_API_KEY;
 
-        if (!apiKey) {
-          return c.json(
-            { error: { code: "CONFIG_ERROR", message: "DEEPSEEK_API_KEY not set" } },
-            500,
-          );
-        }
+          if (!apiKey) {
+            return c.json(
+              { error: { code: "CONFIG_ERROR", message: "DEEPSEEK_API_KEY not set" } },
+              500,
+            );
+          }
 
-        const sel = await d1Db.select().from(selections).where(eq(selections.id, selId)).get();
-        if (!sel) {
-          return c.json(
-            { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } },
-            404,
-          );
-        }
+          const sel = await d1Db.select().from(selections).where(eq(selections.id, selId)).get();
+          if (!sel) {
+            return c.json(
+              { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } },
+              404,
+            );
+          }
 
-        const body = await c.req.json().catch(() => null);
-        if (!body) {
-          return c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid JSON" } }, 400);
-        }
+          // useWebSearch takes a real boolean only: it used to be coerced with
+          // `!!`, so the string "false" turned web search on.
+          const { content, useWebSearch } = c.req.valid("json");
 
-        const { content, useWebSearch } = body as { content?: string; useWebSearch?: boolean };
-        if (!content || typeof content !== "string") {
-          return c.json({ error: { code: "VALIDATION_ERROR", message: "Missing content" } }, 400);
-        }
+          // Save user message
+          const userMsgId = idClock.newId();
+          const now = idClock.now();
+          await d1Db.insert(chatMessages).values({
+            id: userMsgId,
+            selectionId: selId,
+            role: "user",
+            content,
+            createdAt: now,
+          });
 
-        // Save user message
-        const userMsgId = idClock.newId();
-        const now = idClock.now();
-        await d1Db.insert(chatMessages).values({
-          id: userMsgId,
-          selectionId: selId,
-          role: "user",
-          content,
-          createdAt: now,
-        });
+          // Get PDF text for context
+          const pdfRow = await d1Db
+            .select({ fullText: pdfs.fullText, pageCount: pdfs.pageCount })
+            .from(pdfs)
+            .where(eq(pdfs.id, sel.pdfId))
+            .get();
 
-        // Get PDF text for context
-        const pdfRow = await d1Db
-          .select({ fullText: pdfs.fullText, pageCount: pdfs.pageCount })
-          .from(pdfs)
-          .where(eq(pdfs.id, sel.pdfId))
-          .get();
+          if (!pdfRow) {
+            return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
+          }
 
-        if (!pdfRow) {
-          return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
-        }
+          // Get chat history
+          const history = await d1Db
+            .select()
+            .from(chatMessages)
+            .where(eq(chatMessages.selectionId, selId))
+            .all();
 
-        // Get chat history
-        const history = await d1Db
-          .select()
-          .from(chatMessages)
-          .where(eq(chatMessages.selectionId, selId))
-          .all();
+          // Build system prompt
+          const fullText = pdfRow.fullText;
+          const systemPrompt = buildSystemPrompt(fullText, sel.selectedText, useWebSearch);
 
-        // Build system prompt
-        const fullText = pdfRow.fullText;
-        const systemPrompt = buildSystemPrompt(fullText, sel.selectedText, !!useWebSearch);
-        const doWebSearch = !!useWebSearch;
+          // Set up SSE streaming
+          const encoder = new TextEncoder();
+          let fullResponse = "";
+          // Leaving the chat cancels the response body. That only means "stop
+          // sending"; the answer is still read to the end and saved below, so
+          // reopening the highlight shows it.
+          let clientGone = false;
+          let finished!: Promise<void>;
 
-        // Set up SSE streaming
-        const encoder = new TextEncoder();
-        let fullResponse = "";
-        // Leaving the chat cancels the response body. That only means "stop
-        // sending"; the answer is still read to the end and saved below, so
-        // reopening the highlight shows it.
-        let clientGone = false;
-        let finished!: Promise<void>;
-
-        const stream = new ReadableStream({
-          start(controller) {
-            // Writing to a cancelled stream is allowed to throw, and a throw here
-            // would escape into the AI service's own catch and lose the answer
-            // before it is saved. Swallowing it is what keeps the save reachable.
-            const send = (payload: string) => {
-              if (clientGone) return;
-              try {
-                controller.enqueue(encoder.encode(payload));
-              } catch {
-                // A cancel can beat its own handler, so a refused write means the
-                // client is gone too
-                clientGone = true;
-              }
-            };
-            const closeStream = () => {
-              if (clientGone) return;
-              try {
-                controller.close();
-              } catch {
-                clientGone = true;
-              }
-            };
-
-            const callbacks = {
-              onToken(token: string) {
-                fullResponse += token;
-                send(`event: token\ndata: ${JSON.stringify({ content: token })}\n\n`);
-              },
-              async onDone(usage: { inputTokens: number; outputTokens: number }) {
-                // Parse citations with page number lookup for PDF citations
-                const citations = parseCitations(fullResponse, fullText, pdfRow.pageCount);
-
-                // Save the answer before telling the client about it, so a client
-                // that already left cannot stop the save
-                const assistantMsgId = idClock.newId();
-                await d1Db
-                  .insert(chatMessages)
-                  .values({
-                    id: assistantMsgId,
-                    selectionId: selId,
-                    role: "assistant",
-                    content: fullResponse,
-                    citations: JSON.stringify(citations),
-                    createdAt: idClock.now(),
-                  })
-                  .run()
-                  .catch((err: Error) => console.error("Failed to save assistant message:", err));
-
-                for (const citation of citations) {
-                  send(`event: citation\ndata: ${JSON.stringify(citation)}\n\n`);
+          const stream = new ReadableStream({
+            start(controller) {
+              // Writing to a cancelled stream is allowed to throw, and a throw here
+              // would escape into the AI service's own catch and lose the answer
+              // before it is saved. Swallowing it is what keeps the save reachable.
+              const send = (payload: string) => {
+                if (clientGone) return;
+                try {
+                  controller.enqueue(encoder.encode(payload));
+                } catch {
+                  // A cancel can beat its own handler, so a refused write means the
+                  // client is gone too
+                  clientGone = true;
                 }
-                send(
-                  `event: done\ndata: ${JSON.stringify({ messageId: assistantMsgId, usage })}\n\n`,
-                );
-                closeStream();
-              },
-              onError(err: Error) {
-                send(
-                  `event: error\ndata: ${JSON.stringify({ code: "AI_API_ERROR", message: err.message })}\n\n`,
-                );
-                closeStream();
-              },
-            };
+              };
+              const closeStream = () => {
+                if (clientGone) return;
+                try {
+                  controller.close();
+                } catch {
+                  clientGone = true;
+                }
+              };
 
-            finished = (async () => {
-              try {
-                if (doWebSearch) {
-                  await streamResponseWithWebSearch(apiKey, systemPrompt, content, callbacks);
-                } else {
-                  const messages = buildMessages(
-                    systemPrompt,
-                    history.map((h) => ({ role: h.role, content: h.content })),
-                    content,
+              const callbacks = {
+                onToken(token: string) {
+                  fullResponse += token;
+                  send(`event: token\ndata: ${JSON.stringify({ content: token })}\n\n`);
+                },
+                async onDone(usage: { inputTokens: number; outputTokens: number }) {
+                  // Parse citations with page number lookup for PDF citations
+                  const citations = parseCitations(fullResponse, fullText, pdfRow.pageCount);
+
+                  // Save the answer before telling the client about it, so a client
+                  // that already left cannot stop the save
+                  const assistantMsgId = idClock.newId();
+                  await d1Db
+                    .insert(chatMessages)
+                    .values({
+                      id: assistantMsgId,
+                      selectionId: selId,
+                      role: "assistant",
+                      content: fullResponse,
+                      citations: JSON.stringify(citations),
+                      createdAt: idClock.now(),
+                    })
+                    .run()
+                    .catch((err: Error) => console.error("Failed to save assistant message:", err));
+
+                  for (const citation of citations) {
+                    send(`event: citation\ndata: ${JSON.stringify(citation)}\n\n`);
+                  }
+                  send(
+                    `event: done\ndata: ${JSON.stringify({ messageId: assistantMsgId, usage })}\n\n`,
                   );
-                  await streamChatCompletion(apiKey, messages, callbacks);
+                  closeStream();
+                },
+                onError(err: Error) {
+                  send(
+                    `event: error\ndata: ${JSON.stringify({
+                      code: "AI_API_ERROR" satisfies ErrorCode,
+                      message: err.message,
+                    } satisfies ErrorPayload)}\n\n`,
+                  );
+                  closeStream();
+                },
+              };
+
+              finished = (async () => {
+                try {
+                  if (useWebSearch) {
+                    await streamResponseWithWebSearch(apiKey, systemPrompt, content, callbacks);
+                  } else {
+                    const messages = buildMessages(
+                      systemPrompt,
+                      history.map((h) => ({ role: h.role, content: h.content })),
+                      content,
+                    );
+                    await streamChatCompletion(apiKey, messages, callbacks);
+                  }
+                } catch (err) {
+                  send(
+                    `event: error\ndata: ${JSON.stringify({
+                      code: "AI_STREAM_ERROR" satisfies ErrorCode,
+                      message: String(err),
+                    } satisfies ErrorPayload)}\n\n`,
+                  );
+                  closeStream();
                 }
-              } catch (err) {
-                send(
-                  `event: error\ndata: ${JSON.stringify({ code: "AI_STREAM_ERROR", message: String(err) })}\n\n`,
-                );
-                closeStream();
-              }
-            })();
-          },
-          cancel() {
-            clientGone = true;
-          },
-        });
+              })();
+            },
+            cancel() {
+              clientGone = true;
+            },
+          });
 
-        // The save has to outlive the request the client just walked away from
-        c.executionCtx.waitUntil(finished);
+          // The save has to outlive the request the client just walked away from
+          c.executionCtx.waitUntil(finished);
 
-        return new Response(stream, {
-          headers: {
-            "Content-Type": "text/event-stream",
-            "Cache-Control": "no-cache",
-            Connection: "keep-alive",
-          },
-        });
-      })
+          return new Response(stream, {
+            headers: {
+              "Content-Type": "text/event-stream",
+              "Cache-Control": "no-cache",
+              Connection: "keep-alive",
+            },
+          });
+        },
+      )
       .delete("/pdf/:pdfId", async (c) => {
         const deleted = await deletePdf(c.env.DB, c.env.PDF_BUCKET, c.req.param("pdfId"));
         if (!deleted) {

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -19,6 +19,8 @@ import {
   streamResponseWithWebSearch,
 } from "../services/deepseekService";
 import { buildMessages, findPageNumber, parseCitations } from "../services/chatService";
+import { createSelectionRequestSchema } from "../../shared/schemas/selection";
+import { validate } from "./validation";
 
 type Env = {
   Bindings: {
@@ -197,7 +199,7 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
 
         return c.json(result);
       })
-      .post("/pdf/:pdfId/selections", async (c) => {
+      .post("/pdf/:pdfId/selections", validate("json", createSelectionRequestSchema), async (c) => {
         const pdfId = c.req.param("pdfId");
         const d1Db = drizzle(c.env.DB);
 
@@ -207,18 +209,10 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           return c.json({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404);
         }
 
-        const body = await c.req.json().catch(() => null);
-        if (!body) {
-          return c.json({ error: { code: "VALIDATION_ERROR", message: "Invalid JSON" } }, 400);
-        }
-
-        const { selectedText, pageNumber, positionData } = body;
-        if (!selectedText || !pageNumber || !positionData) {
-          return c.json(
-            { error: { code: "VALIDATION_ERROR", message: "Missing required fields" } },
-            400,
-          );
-        }
+        // Validated, so positionData is already down to the shape the viewer
+        // draws from: the measurement's other fields are stripped here rather
+        // than stored and read back as an unknown blob.
+        const { selectedText, pageNumber, positionData } = c.req.valid("json");
 
         const id = idClock.newId();
         const now = idClock.now();

--- a/src/server/routes/validation.ts
+++ b/src/server/routes/validation.ts
@@ -1,0 +1,49 @@
+import { zValidator } from "@hono/zod-validator";
+import type { ValidationTargets } from "hono";
+import type { ZodType } from "zod";
+import type { ErrorCode } from "../../shared/schemas/error";
+
+/** How each request part is named in the message a rejected request gets back. */
+const TARGET_LABEL: Partial<Record<keyof ValidationTargets, string>> = {
+  json: "request body",
+  param: "path parameter",
+  query: "query parameter",
+};
+
+/**
+ * `zValidator` answering with this API's error envelope.
+ *
+ * The stock handler replies with zod's own report, which nothing here can
+ * read: the client looks for `error.message`, so a rejected request would
+ * surface as the generic "request failed with status 400" instead of naming
+ * the field at fault.
+ *
+ * The message lists the offending paths rather than quoting zod's wording, so
+ * it stays the same across zod releases.
+ */
+export function validate<Target extends keyof ValidationTargets, S extends ZodType>(
+  target: Target,
+  schema: S,
+) {
+  return zValidator(target, schema, (result, c) => {
+    if (result.success) return;
+
+    const fields = [
+      ...new Set(
+        result.error.issues.map((issue) =>
+          issue.path.length > 0 ? issue.path.join(".") : "(root)",
+        ),
+      ),
+    ];
+
+    return c.json(
+      {
+        error: {
+          code: "VALIDATION_ERROR" satisfies ErrorCode,
+          message: `Invalid ${TARGET_LABEL[target] ?? target}: ${fields.join(", ")}`,
+        },
+      },
+      400,
+    );
+  });
+}

--- a/src/server/services/chatService.ts
+++ b/src/server/services/chatService.ts
@@ -1,6 +1,24 @@
-import type { Citation } from "../../shared/schemas/citation";
+import { citationSchema, type Citation } from "../../shared/schemas/citation";
 
 export type { Citation } from "../../shared/schemas/citation";
+
+/**
+ * The sources stored with an answer, or null when there are none to show.
+ *
+ * Forgiving on purpose, like the highlight geometry: an answer whose citations
+ * column cannot be read must not make the whole conversation unreadable, since
+ * the answer itself is still there to show.
+ */
+export function readCitations(stored: string | null): Citation[] | null {
+  if (!stored) return null;
+  try {
+    const parsed = citationSchema.array().safeParse(JSON.parse(stored));
+    if (parsed.success) return parsed.data;
+  } catch {
+    // Not even JSON — fall through and show the answer without sources
+  }
+  return null;
+}
 
 /**
  * A turn as the LLM is given it. Not the stored `ChatMessage`: this one also

--- a/src/server/services/chatService.ts
+++ b/src/server/services/chatService.ts
@@ -1,4 +1,12 @@
-export interface ChatMessage {
+import type { Citation } from "../../shared/schemas/citation";
+
+export type { Citation } from "../../shared/schemas/citation";
+
+/**
+ * A turn as the LLM is given it. Not the stored `ChatMessage`: this one also
+ * carries the `system` turn, which is built per request and never persisted.
+ */
+export interface LlmMessage {
   role: "system" | "user" | "assistant";
   content: string;
 }
@@ -10,20 +18,12 @@ export function buildMessages(
   systemPrompt: string,
   history: { role: string; content: string }[],
   userMessage: string,
-): ChatMessage[] {
+): LlmMessage[] {
   return [
     { role: "system", content: systemPrompt },
     ...history.map((m) => ({ role: m.role as "user" | "assistant", content: m.content })),
     { role: "user", content: userMessage },
   ];
-}
-
-export interface Citation {
-  id: string;
-  type: "pdf" | "web";
-  text: string;
-  pageNumber?: number;
-  url?: string;
 }
 
 /** pdfLoader が fullText に埋めるページ区切り。 */

--- a/src/server/services/deepseekService.test.ts
+++ b/src/server/services/deepseekService.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vite-plus/test";
+import { streamResponseWithWebSearch } from "./deepseekService";
+
+/** A Responses API answer made of the given SSE lines, served to the injected fetch. */
+function respondingWith(lines: string[]): typeof fetch {
+  return () =>
+    Promise.resolve(
+      new Response(new TextEncoder().encode(lines.map((line) => `${line}\n\n`).join("")), {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+    );
+}
+
+function sseData(payload: unknown): string {
+  return `data: ${JSON.stringify(payload)}`;
+}
+
+/** Run the web-search stream against a canned body and collect what it reported. */
+async function readWebSearchStream(lines: string[]) {
+  const tokens: string[] = [];
+  const errors: string[] = [];
+  let usage: { inputTokens: number; outputTokens: number } | null = null;
+
+  await streamResponseWithWebSearch(
+    "test-key",
+    "system prompt",
+    "Where do Workers run?",
+    {
+      onToken: (token) => tokens.push(token),
+      onDone: (reported) => {
+        usage = reported;
+      },
+      onError: (err) => errors.push(err.message),
+    },
+    undefined,
+    respondingWith(lines),
+  );
+
+  return { tokens, errors, usage };
+}
+
+describe("streamResponseWithWebSearch", () => {
+  it("delivers the text deltas of the stream and the token counts it ends with", async () => {
+    const { tokens, errors, usage } = await readWebSearchStream([
+      sseData({ type: "response.output_text.delta", delta: "Workers " }),
+      sseData({ type: "response.output_text.delta", delta: "run everywhere" }),
+      sseData({ type: "response.completed", usage: { input_tokens: 11, output_tokens: 2 } }),
+    ]);
+
+    expect(tokens).toStrictEqual(["Workers ", "run everywhere"]);
+    expect(usage).toStrictEqual({ inputTokens: 11, outputTokens: 2 });
+    expect(errors).toStrictEqual([]);
+  });
+
+  it("skips a delta that is not text instead of writing it into the answer", async () => {
+    // A non-string delta used to be concatenated as "[object Object]" and saved
+    // to D1 as part of the answer.
+    const { tokens, usage } = await readWebSearchStream([
+      sseData({ type: "response.output_text.delta", delta: { annotation: "web" } }),
+      sseData({ type: "response.output_text.delta", delta: "Workers run everywhere" }),
+      sseData({ type: "response.output_text.delta", delta: 42 }),
+      sseData({ type: "response.completed", usage: { input_tokens: 11, output_tokens: 2 } }),
+    ]);
+
+    expect(tokens).toStrictEqual(["Workers run everywhere"]);
+    expect(usage).toStrictEqual({ inputTokens: 11, outputTokens: 2 });
+  });
+
+  it("keeps reading the answer past an event whose shape it does not know", async () => {
+    const { tokens, usage } = await readWebSearchStream([
+      sseData({ type: "response.web_search_call.in_progress" }),
+      sseData({ type: "response.output_text.delta", delta: "Workers run everywhere" }),
+      "data: {not json",
+      sseData({ type: "response.completed", usage: { input_tokens: 11, output_tokens: 2 } }),
+    ]);
+
+    expect(tokens).toStrictEqual(["Workers run everywhere"]);
+    expect(usage).toStrictEqual({ inputTokens: 11, outputTokens: 2 });
+  });
+});

--- a/src/server/services/deepseekService.test.ts
+++ b/src/server/services/deepseekService.test.ts
@@ -41,7 +41,7 @@ async function readWebSearchStream(lines: string[]) {
 }
 
 describe("streamResponseWithWebSearch", () => {
-  it("delivers the text deltas of the stream and the token counts it ends with", async () => {
+  it("delivers the text deltas and the token counts when the stream completes normally", async () => {
     const { tokens, errors, usage } = await readWebSearchStream([
       sseData({ type: "response.output_text.delta", delta: "Workers " }),
       sseData({ type: "response.output_text.delta", delta: "run everywhere" }),
@@ -56,7 +56,7 @@ describe("streamResponseWithWebSearch", () => {
   it("skips a delta that is not text instead of writing it into the answer", async () => {
     // A non-string delta used to be concatenated as "[object Object]" and saved
     // to D1 as part of the answer.
-    const { tokens, usage } = await readWebSearchStream([
+    const { tokens, errors, usage } = await readWebSearchStream([
       sseData({ type: "response.output_text.delta", delta: { annotation: "web" } }),
       sseData({ type: "response.output_text.delta", delta: "Workers run everywhere" }),
       sseData({ type: "response.output_text.delta", delta: 42 }),
@@ -65,11 +65,25 @@ describe("streamResponseWithWebSearch", () => {
 
     expect(tokens).toStrictEqual(["Workers run everywhere"]);
     expect(usage).toStrictEqual({ inputTokens: 11, outputTokens: 2 });
+    // Silently skipped, not reported: a delta the reader has no use for is not
+    // a failure to show in the chat
+    expect(errors).toStrictEqual([]);
   });
 
-  it("keeps reading the answer past an event whose shape it does not know", async () => {
-    const { tokens, usage } = await readWebSearchStream([
+  it("keeps reading the answer past an event of a type it does not know", async () => {
+    const { tokens, errors, usage } = await readWebSearchStream([
       sseData({ type: "response.web_search_call.in_progress" }),
+      sseData({ type: "response.output_text.delta", delta: "Workers run everywhere" }),
+      sseData({ type: "response.completed", usage: { input_tokens: 11, output_tokens: 2 } }),
+    ]);
+
+    expect(tokens).toStrictEqual(["Workers run everywhere"]);
+    expect(usage).toStrictEqual({ inputTokens: 11, outputTokens: 2 });
+    expect(errors).toStrictEqual([]);
+  });
+
+  it("keeps reading the answer past a line that is not JSON at all", async () => {
+    const { tokens, errors, usage } = await readWebSearchStream([
       sseData({ type: "response.output_text.delta", delta: "Workers run everywhere" }),
       "data: {not json",
       sseData({ type: "response.completed", usage: { input_tokens: 11, output_tokens: 2 } }),
@@ -77,5 +91,6 @@ describe("streamResponseWithWebSearch", () => {
 
     expect(tokens).toStrictEqual(["Workers run everywhere"]);
     expect(usage).toStrictEqual({ inputTokens: 11, outputTokens: 2 });
+    expect(errors).toStrictEqual([]);
   });
 });

--- a/src/server/services/deepseekService.ts
+++ b/src/server/services/deepseekService.ts
@@ -1,5 +1,27 @@
 import OpenAI from "openai";
+import { z } from "zod";
 import type { LlmMessage } from "./chatService";
+
+/**
+ * The Responses API events this reader acts on.
+ *
+ * A `delta` is only ever appended to the answer when it really is text: the
+ * stream also carries deltas for annotations and tool calls, and one of those
+ * used to land in the saved answer as "[object Object]". Everything that does
+ * not match — including an empty delta — is skipped.
+ */
+const responseStreamEventSchema = z.discriminatedUnion("type", [
+  z.object({
+    type: z.literal("response.output_text.delta"),
+    delta: z.string().min(1),
+  }),
+  z.object({
+    type: z.literal("response.completed"),
+    usage: z
+      .object({ input_tokens: z.number().optional(), output_tokens: z.number().optional() })
+      .optional(),
+  }),
+]);
 
 interface StreamCallbacks {
   onToken: (token: string) => void;
@@ -152,25 +174,26 @@ export async function streamResponseWithWebSearch(
       buffer = lines.pop() || "";
 
       for (const line of lines) {
-        if (line.startsWith("data: ")) {
-          try {
-            const data = JSON.parse(line.slice(6));
+        if (!line.startsWith("data: ")) continue;
 
-            // Handle text delta
-            if (data.type === "response.output_text.delta" && data.delta) {
-              callbacks.onToken(data.delta);
-            }
+        let payload: unknown;
+        try {
+          payload = JSON.parse(line.slice(6));
+        } catch {
+          // Skip parse errors for partial chunks
+          continue;
+        }
 
-            // Handle completion
-            if (data.type === "response.completed" && data.usage) {
-              usage = {
-                inputTokens: data.usage.input_tokens ?? 0,
-                outputTokens: data.usage.output_tokens ?? 0,
-              };
-            }
-          } catch {
-            // Skip parse errors for partial chunks
-          }
+        const event = responseStreamEventSchema.safeParse(payload);
+        if (!event.success) continue;
+
+        if (event.data.type === "response.output_text.delta") {
+          callbacks.onToken(event.data.delta);
+        } else if (event.data.usage) {
+          usage = {
+            inputTokens: event.data.usage.input_tokens ?? 0,
+            outputTokens: event.data.usage.output_tokens ?? 0,
+          };
         }
       }
     }

--- a/src/server/services/deepseekService.ts
+++ b/src/server/services/deepseekService.ts
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import type { ChatMessage } from "./chatService";
+import type { LlmMessage } from "./chatService";
 
 interface StreamCallbacks {
   onToken: (token: string) => void;
@@ -57,7 +57,7 @@ The document states that Workers run on Cloudflare's global network[1].
  */
 export async function streamChatCompletion(
   apiKey: string,
-  messages: ChatMessage[],
+  messages: LlmMessage[],
   callbacks: StreamCallbacks,
   signal?: AbortSignal,
 ): Promise<void> {

--- a/src/server/services/pdfService.ts
+++ b/src/server/services/pdfService.ts
@@ -3,6 +3,7 @@ import { drizzle } from "drizzle-orm/d1";
 import { desc, eq } from "drizzle-orm";
 import { pdfs, selections } from "../db/schema";
 import type { BookSummary, PdfMetadata } from "../../shared/schemas/book";
+import { positionDataSchema, type PositionData } from "../../shared/schemas/selection";
 
 /**
  * R2 object key for a PDF, derived from its content hash.
@@ -155,6 +156,25 @@ export async function deletePdf(db: D1Database, bucket: R2Bucket, pdfId: string)
 }
 
 /**
+ * The geometry of a stored highlight.
+ *
+ * Deliberately forgiving, unlike the endpoint that writes it: rows predating
+ * the enforced shape carry the viewer's whole measurement, and one row that
+ * cannot be read must not take the book it belongs to down with it. Such a
+ * highlight is served without rects, so the book still opens and the passage
+ * stays in the list.
+ */
+function readPositionData(stored: string): PositionData {
+  try {
+    const parsed = positionDataSchema.safeParse(JSON.parse(stored));
+    if (parsed.success) return parsed.data;
+  } catch {
+    // Not even JSON — fall through to the empty geometry
+  }
+  return { rects: [] };
+}
+
+/**
  * Get a PDF record by id, including its selections.
  */
 export async function getPdf(db: D1Database, bucket: R2Bucket, pdfId: string) {
@@ -173,7 +193,7 @@ export async function getPdf(db: D1Database, bucket: R2Bucket, pdfId: string) {
       id: s.id,
       selectedText: s.selectedText,
       pageNumber: s.pageNumber,
-      positionData: JSON.parse(s.positionData),
+      positionData: readPositionData(s.positionData),
       color: s.color,
       createdAt: s.createdAt,
     })),

--- a/src/server/services/pdfService.ts
+++ b/src/server/services/pdfService.ts
@@ -2,6 +2,7 @@ import { ulid } from "ulid";
 import { drizzle } from "drizzle-orm/d1";
 import { desc, eq } from "drizzle-orm";
 import { pdfs, selections } from "../db/schema";
+import type { BookSummary, PdfMetadata } from "../../shared/schemas/book";
 
 /**
  * R2 object key for a PDF, derived from its content hash.
@@ -33,12 +34,7 @@ export const systemIdClock: IdClock = {
   now: () => new Date().toISOString(),
 };
 
-export interface PdfMetadata {
-  id: string;
-  fileName: string;
-  pageCount: number;
-  fullText: string;
-}
+export type { PdfMetadata } from "../../shared/schemas/book";
 
 interface OpenPdfInput {
   fileName: string;
@@ -49,13 +45,7 @@ interface OpenPdfInput {
   thumbnail?: ArrayBuffer;
 }
 
-export interface BookSummary {
-  id: string;
-  fileName: string;
-  pageCount: number;
-  updatedAt: string;
-  hasThumbnail: boolean;
-}
+export type { BookSummary } from "../../shared/schemas/book";
 
 /**
  * List every stored book, most recently opened first, for the shelf view.

--- a/src/shared/schemas/book.ts
+++ b/src/shared/schemas/book.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { selectionHighlightSchema } from "./selection";
+
+/** A book as the shelf shows it. */
+export const bookSummarySchema = z.object({
+  id: z.string(),
+  fileName: z.string(),
+  pageCount: z.number().int().positive(),
+  updatedAt: z.string(),
+  hasThumbnail: z.boolean(),
+});
+
+export type BookSummary = z.infer<typeof bookSummarySchema>;
+
+export const bookListSchema = z.object({ books: z.array(bookSummarySchema) });
+
+/** What opening a PDF returns: the metadata the reader needs to render it. */
+export const pdfMetadataSchema = z.object({
+  id: z.string(),
+  fileName: z.string(),
+  pageCount: z.number().int().positive(),
+  fullText: z.string(),
+});
+
+export type PdfMetadata = z.infer<typeof pdfMetadataSchema>;
+
+/** A book with the highlights made in it. */
+export const bookDetailSchema = z.object({
+  id: z.string(),
+  fileName: z.string(),
+  pageCount: z.number().int().positive(),
+  hasThumbnail: z.boolean(),
+  selections: z.array(selectionHighlightSchema),
+});
+
+export type BookDetail = z.infer<typeof bookDetailSchema>;
+
+/** Where a passage quoted from a `#:~:text=` link lives, or null if nowhere. */
+export const locatedPageSchema = z.object({
+  pageNumber: z.number().int().positive().nullable(),
+});
+
+export const bookDeletedSchema = z.object({ deleted: z.literal(true) });
+
+export const thumbnailStoredSchema = z.object({ stored: z.literal(true) });

--- a/src/shared/schemas/book.ts
+++ b/src/shared/schemas/book.ts
@@ -35,6 +35,17 @@ export const bookDetailSchema = z.object({
 
 export type BookDetail = z.infer<typeof bookDetailSchema>;
 
+/**
+ * Longest passage `/locate` will look for. A quoted passage is a sentence or
+ * two; beyond this the request is not a lookup, and each one scans the whole
+ * book character by character.
+ */
+export const MAX_LOCATE_TEXT_LENGTH = 2000;
+
+export const locateQuerySchema = z.object({
+  text: z.string().min(1).max(MAX_LOCATE_TEXT_LENGTH),
+});
+
 /** Where a passage quoted from a `#:~:text=` link lives, or null if nowhere. */
 export const locatedPageSchema = z.object({
   pageNumber: z.number().int().positive().nullable(),

--- a/src/shared/schemas/chat.ts
+++ b/src/shared/schemas/chat.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { citationSchema } from "./citation";
+
+/** Who wrote a message in a stored conversation. */
+export const chatRoleSchema = z.enum(["user", "assistant"]);
+
+export type ChatRole = z.infer<typeof chatRoleSchema>;
+
+/** A message of the conversation hanging off one highlight. */
+export const chatMessageSchema = z.object({
+  id: z.string(),
+  role: chatRoleSchema,
+  content: z.string(),
+  // Questions carry none, and answers written before citations existed carry
+  // the null the endpoint substitutes for a missing column.
+  citations: z.array(citationSchema).nullish(),
+  createdAt: z.string(),
+});
+
+export type ChatMessage = z.infer<typeof chatMessageSchema>;
+
+export const chatHistorySchema = z.object({
+  selectionId: z.string(),
+  messages: z.array(chatMessageSchema),
+});
+
+/** What the reader sends to ask a question about a highlight. */
+export const sendChatRequestSchema = z.object({
+  content: z.string().min(1),
+  // Only a real boolean: the string "false" used to be coerced to true.
+  useWebSearch: z.boolean().optional().default(false),
+});
+
+export type SendChatRequest = z.infer<typeof sendChatRequestSchema>;

--- a/src/shared/schemas/citation.ts
+++ b/src/shared/schemas/citation.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+/**
+ * A source the assistant named in its `## Sources` section. PDF citations carry
+ * the page the passage was found on; web citations carry the page's URL.
+ */
+export const citationSchema = z.object({
+  id: z.string(),
+  type: z.enum(["pdf", "web"]),
+  text: z.string(),
+  pageNumber: z.number().int().positive().optional(),
+  url: z.string().optional(),
+});
+
+export type Citation = z.infer<typeof citationSchema>;

--- a/src/shared/schemas/error.ts
+++ b/src/shared/schemas/error.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+/**
+ * Every reason the API refuses or fails a request. Producers pin themselves to
+ * this union with `satisfies`, so a typo in a thrown code is a build error.
+ */
+export const ERROR_CODES = [
+  "VALIDATION_ERROR",
+  "PDF_NOT_FOUND",
+  "PDF_FILE_MISSING",
+  "PDF_EXTRACT_FAILED",
+  "THUMBNAIL_MISSING",
+  "SELECTION_NOT_FOUND",
+  "CONFIG_ERROR",
+  "AI_API_ERROR",
+  "AI_STREAM_ERROR",
+] as const;
+
+export type ErrorCode = (typeof ERROR_CODES)[number];
+
+/**
+ * The body of a failure, in both transports it travels over: a JSON response
+ * with a 4xx/5xx status, and an `event: error` block of the chat stream.
+ *
+ * `code` stays `z.string()` on the wire on purpose — a reader must survive a
+ * code a newer server added, and the reader has nothing useful to do with an
+ * unknown one beyond passing it on.
+ */
+export const errorPayloadSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+});
+
+export type ErrorPayload = z.infer<typeof errorPayloadSchema>;
+
+/** How a failure is wrapped when it travels as an HTTP response body. */
+export const errorEnvelopeSchema = z.object({
+  error: errorPayloadSchema,
+});
+
+export type ErrorEnvelope = z.infer<typeof errorEnvelopeSchema>;

--- a/src/shared/schemas/selection.ts
+++ b/src/shared/schemas/selection.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+/** One line of a highlight, in the page's own pixels. */
+export const selectionRectSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number(),
+  height: z.number(),
+});
+
+export type SelectionRect = z.infer<typeof selectionRectSchema>;
+
+/**
+ * The stored geometry of a highlight, and the only shape the viewer draws from.
+ *
+ * Unknown keys are stripped rather than rejected: the viewer sends its whole
+ * measurement object (which also carries the text offsets it used to find the
+ * passage), and rows written before this shape existed carry those extras too.
+ */
+export const positionDataSchema = z.object({
+  rects: z.array(selectionRectSchema),
+  /** Page width the rects were measured at, so they can be rescaled later.
+   * Missing on records stored before the viewer could be resized. */
+  pageWidth: z.number().positive().optional(),
+});
+
+export type PositionData = z.infer<typeof positionDataSchema>;
+
+/** A highlight of the open book, as the viewer draws it and the list shows it. */
+export const selectionHighlightSchema = z.object({
+  id: z.string(),
+  selectedText: z.string(),
+  pageNumber: z.number().int().positive(),
+  positionData: positionDataSchema,
+  color: z.string(),
+  createdAt: z.string(),
+});
+
+export type SelectionHighlight = z.infer<typeof selectionHighlightSchema>;
+
+/** What the viewer sends when the reader highlights a passage. */
+export const createSelectionRequestSchema = z.object({
+  selectedText: z.string().min(1),
+  pageNumber: z.number().int().positive(),
+  positionData: positionDataSchema,
+});
+
+export type CreateSelectionRequest = z.infer<typeof createSelectionRequestSchema>;
+
+/** The highlight as it comes back from its own creation, before it has a colour. */
+export const createdSelectionSchema = z.object({
+  id: z.string(),
+  selectedText: z.string(),
+  pageNumber: z.number().int().positive(),
+  positionData: positionDataSchema,
+  createdAt: z.string(),
+});
+
+export type CreatedSelection = z.infer<typeof createdSelectionSchema>;
+
+export const selectionDeletedSchema = z.object({ deleted: z.literal(true) });

--- a/src/shared/schemas/sse.ts
+++ b/src/shared/schemas/sse.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { citationSchema } from "./citation";
+import { errorPayloadSchema } from "./error";
+
+export const chatTokenSchema = z.object({ content: z.string() });
+
+export const chatDoneSchema = z.object({
+  messageId: z.string(),
+  // Absent when the upstream stream ended without reporting its token counts.
+  usage: z.object({ inputTokens: z.number(), outputTokens: z.number() }).optional(),
+});
+
+/**
+ * The events the answer stream is made of.
+ *
+ * The event name is the discriminator, so a failure travels here as a bare
+ * `{ code, message }` rather than the `{ error: … }` envelope an HTTP response
+ * body uses — there is nothing to disambiguate it from.
+ */
+export const chatSseEventSchema = z.discriminatedUnion("event", [
+  z.object({ event: z.literal("token"), data: chatTokenSchema }),
+  z.object({ event: z.literal("citation"), data: citationSchema }),
+  z.object({ event: z.literal("done"), data: chatDoneSchema }),
+  z.object({ event: z.literal("error"), data: errorPayloadSchema }),
+]);
+
+export type ChatSseEvent = z.infer<typeof chatSseEventSchema>;

--- a/src/test/streamingFetchStub.ts
+++ b/src/test/streamingFetchStub.ts
@@ -15,6 +15,15 @@ export function doneEvent(messageId: string): string {
   return `event: done\ndata: ${JSON.stringify({ messageId })}\n\n`;
 }
 
+/** A citation block, with the payload left to the caller so it can be malformed. */
+export function citationEvent(citation: unknown): string {
+  return `event: citation\ndata: ${JSON.stringify(citation)}\n\n`;
+}
+
+export function errorEvent(code: string, message: string): string {
+  return `event: error\ndata: ${JSON.stringify({ code, message })}\n\n`;
+}
+
 export function streamingFetchStub() {
   const encoder = new TextEncoder();
   const calls: ChatCall[] = [];

--- a/test/worker/chat.test.ts
+++ b/test/worker/chat.test.ts
@@ -314,6 +314,32 @@ describe("POST /api/pdf/:pdfId/selections/:selId/chats", () => {
     expect(await readChatHistory(pdfId, selectionId)).toStrictEqual([]);
   });
 
+  it("still serves a conversation holding an answer whose stored citations cannot be read", async () => {
+    const { pdfId, selectionId } = await createSelection("chat-broken-citations");
+    await env.DB.prepare(
+      "INSERT INTO chat_messages (id, selection_id, role, content, citations, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+      .bind(
+        "chat-broken-citations-answer",
+        selectionId,
+        "assistant",
+        "エッジで動きます",
+        "{not json",
+        "2026-01-01T00:00:00Z",
+      )
+      .run();
+
+    expect(await readChatHistory(pdfId, selectionId)).toStrictEqual([
+      {
+        id: "chat-broken-citations-answer",
+        role: "assistant",
+        content: "エッジで動きます",
+        citations: null,
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ]);
+  });
+
   it("leaves web search off when the request does not mention it", async () => {
     const { pdfId, selectionId } = await createSelection("chat-websearch-default");
     const calledUrls: string[] = [];

--- a/test/worker/chat.test.ts
+++ b/test/worker/chat.test.ts
@@ -359,8 +359,8 @@ describe("POST /api/pdf/:pdfId/selections/:selId/chats", () => {
     expect(response.status).toBe(200);
     const events = parseSse(await response.text());
 
-    expect(calledUrls).toEqual(["https://api.deepseek.com/chat/completions"]);
-    expect(events.map((e) => e.event)).toEqual(["token", "done"]);
-    expect(events[0].data).toEqual({ content: "Everywhere" });
+    expect(calledUrls).toStrictEqual(["https://api.deepseek.com/chat/completions"]);
+    expect(events.map((e) => e.event)).toStrictEqual(["token", "done"]);
+    expect(events[0].data).toStrictEqual({ content: "Everywhere" });
   });
 });

--- a/test/worker/chat.test.ts
+++ b/test/worker/chat.test.ts
@@ -38,10 +38,11 @@ async function createSelection(tag: string): Promise<{ pdfId: string; selectionI
 
   const selectionResponse = await SELF.fetch(`https://example.com/api/pdf/${pdfId}/selections`, {
     method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
       selectedText: HIGHLIGHTED_PASSAGE,
       pageNumber: 1,
-      positionData: { startIndex: 0, endIndex: 1, rects: [] },
+      positionData: { rects: [] },
     }),
   });
   const { id: selectionId } = (await selectionResponse.json()) as { id: string };
@@ -130,6 +131,7 @@ async function postChat(
 ): Promise<Response> {
   return SELF.fetch(`https://example.com/api/pdf/${pdfId}/selections/${selectionId}/chats`, {
     method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
   });
 }

--- a/test/worker/chat.test.ts
+++ b/test/worker/chat.test.ts
@@ -115,11 +115,18 @@ interface StoredMessage {
   createdAt: string;
 }
 
-/** The conversation as it was saved, which is what a reopened chat shows. */
+/**
+ * The conversation as it was saved, which is what a reopened chat shows.
+ *
+ * The status is asserted here so that a conversation which fails to load shows
+ * up as "expected 500 to be 200" rather than as a JSON parse error on the
+ * words "Internal Server Error".
+ */
 async function readChatHistory(pdfId: string, selectionId: string): Promise<StoredMessage[]> {
   const response = await SELF.fetch(
     `https://example.com/api/pdf/${pdfId}/selections/${selectionId}/chats`,
   );
+  expect(response.status).toBe(200);
   const { messages } = (await response.json()) as { messages: StoredMessage[] };
   return messages;
 }

--- a/test/worker/chat.test.ts
+++ b/test/worker/chat.test.ts
@@ -124,11 +124,7 @@ async function readChatHistory(pdfId: string, selectionId: string): Promise<Stor
   return messages;
 }
 
-async function postChat(
-  pdfId: string,
-  selectionId: string,
-  payload: { content: string; useWebSearch: boolean },
-): Promise<Response> {
+async function postChat(pdfId: string, selectionId: string, payload: unknown): Promise<Response> {
   return SELF.fetch(`https://example.com/api/pdf/${pdfId}/selections/${selectionId}/chats`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -288,5 +284,57 @@ describe("POST /api/pdf/:pdfId/selections/:selId/chats", () => {
     const events = parseSse(await response.text());
     expect(events.map((e) => e.event)).toEqual(["error"]);
     expect(events[0].data).toEqual({ code: "AI_API_ERROR", message: expect.any(String) });
+  });
+
+  it('rejects a useWebSearch sent as the string "false" instead of reading it as on', async () => {
+    const { pdfId, selectionId } = await createSelection("chat-websearch-string");
+
+    const response = await postChat(pdfId, selectionId, {
+      content: "Where do Workers run?",
+      useWebSearch: "false",
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toStrictEqual({
+      error: { code: "VALIDATION_ERROR", message: "Invalid request body: useWebSearch" },
+    });
+    // The question is not stored either, so a rejected ask leaves no trace
+    expect(await readChatHistory(pdfId, selectionId)).toStrictEqual([]);
+  });
+
+  it("rejects an empty question rather than asking the model about nothing", async () => {
+    const { pdfId, selectionId } = await createSelection("chat-empty-content");
+
+    const response = await postChat(pdfId, selectionId, { content: "", useWebSearch: false });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toStrictEqual({
+      error: { code: "VALIDATION_ERROR", message: "Invalid request body: content" },
+    });
+    expect(await readChatHistory(pdfId, selectionId)).toStrictEqual([]);
+  });
+
+  it("leaves web search off when the request does not mention it", async () => {
+    const { pdfId, selectionId } = await createSelection("chat-websearch-default");
+    const calledUrls: string[] = [];
+
+    server.use(
+      http.post("https://api.deepseek.com/chat/completions", ({ request }) => {
+        calledUrls.push(request.url);
+        return new HttpResponse(chatCompletionsSse(["Everywhere"]), {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    );
+
+    const response = await postChat(pdfId, selectionId, { content: "Where do Workers run?" });
+
+    expect(response.status).toBe(200);
+    const events = parseSse(await response.text());
+
+    expect(calledUrls).toEqual(["https://api.deepseek.com/chat/completions"]);
+    expect(events.map((e) => e.event)).toEqual(["token", "done"]);
+    expect(events[0].data).toEqual({ content: "Everywhere" });
   });
 });

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -62,7 +62,10 @@ interface PdfResponse {
   selections?: unknown[];
 }
 
-const FAKE_WEBP = new Uint8Array([0x52, 0x49, 0x46, 0x46, 0x00, 0x57, 0x45, 0x42, 0x50]);
+/** The 12-byte RIFF/WEBP header a cover has to start with, and nothing more. */
+const FAKE_WEBP = new Uint8Array([
+  0x52, 0x49, 0x46, 0x46, 0x0c, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+]);
 
 /** The content hash a book is stored under, which its R2 keys are derived from. */
 async function storedFileHash(pdfId: string): Promise<string> {
@@ -311,6 +314,44 @@ describe("PDF thumbnails", () => {
     expect(new Uint8Array(await getResponse.arrayBuffer())).toEqual(FAKE_WEBP);
   });
 
+  it("refuses a cover that is not a WebP image", async () => {
+    const book = await uploadBook({ tag: "thumb-not-webp", fileName: "not-webp.pdf" });
+    const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
+
+    const putResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`, {
+      method: "PUT",
+      headers: { "Content-Type": "image/webp" },
+      body: png,
+    });
+
+    expect(putResponse.status).toBe(400);
+    expect(await putResponse.json()).toStrictEqual({
+      error: { code: "VALIDATION_ERROR", message: "Thumbnail is not a WebP image" },
+    });
+    // Nothing was stored, so the shelf still falls back to the placeholder
+    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`);
+    expect(getResponse.status).toBe(404);
+  });
+
+  it("refuses a cover far larger than a rendered page", async () => {
+    const book = await uploadBook({ tag: "thumb-too-big", fileName: "too-big.pdf" });
+    const oversized = new Uint8Array(2 * 1024 * 1024 + 1);
+    oversized.set(FAKE_WEBP, 0);
+
+    const putResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`, {
+      method: "PUT",
+      headers: { "Content-Type": "image/webp" },
+      body: oversized,
+    });
+
+    expect(putResponse.status).toBe(400);
+    expect(await putResponse.json()).toStrictEqual({
+      error: { code: "VALIDATION_ERROR", message: "Thumbnail is larger than 2097152 bytes" },
+    });
+    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`);
+    expect(getResponse.status).toBe(404);
+  });
+
   it("returns 404 when putting a thumbnail for an unknown book", async () => {
     const response = await SELF.fetch("https://example.com/api/pdf/does-not-exist/thumbnail", {
       method: "PUT",
@@ -442,7 +483,20 @@ describe("GET /api/pdf/:pdfId/locate", () => {
 
     expect(response.status).toBe(400);
     expect(await response.json()).toStrictEqual({
-      error: { code: "VALIDATION_ERROR", message: "Missing text" },
+      error: { code: "VALIDATION_ERROR", message: "Invalid query parameter: text" },
+    });
+  });
+
+  it("refuses a passage longer than any quotable one instead of scanning the book for it", async () => {
+    const book = await uploadBook({ tag: "locate-long", fileName: "locate-long.pdf" });
+
+    const response = await SELF.fetch(
+      `https://example.com/api/pdf/${book.id}/locate?text=${"あ".repeat(2001)}`,
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toStrictEqual({
+      error: { code: "VALIDATION_ERROR", message: "Invalid query parameter: text" },
     });
   });
 

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -333,6 +333,23 @@ describe("PDF thumbnails", () => {
     expect(getResponse.status).toBe(404);
   });
 
+  it("stores a cover of exactly the size limit", async () => {
+    const book = await uploadBook({ tag: "thumb-at-limit", fileName: "at-limit.pdf" });
+    const atLimit = new Uint8Array(2 * 1024 * 1024);
+    atLimit.set(FAKE_WEBP, 0);
+
+    const putResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`, {
+      method: "PUT",
+      headers: { "Content-Type": "image/webp" },
+      body: atLimit,
+    });
+
+    expect(putResponse.status).toBe(200);
+    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`);
+    expect(getResponse.status).toBe(200);
+    expect((await getResponse.arrayBuffer()).byteLength).toBe(2 * 1024 * 1024);
+  });
+
   it("refuses a cover far larger than a rendered page", async () => {
     const book = await uploadBook({ tag: "thumb-too-big", fileName: "too-big.pdf" });
     const oversized = new Uint8Array(2 * 1024 * 1024 + 1);
@@ -487,6 +504,22 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     });
   });
 
+  it("looks up a passage of exactly the length limit", async () => {
+    const passage = "あ".repeat(2000);
+    const book = await uploadBook({
+      tag: "locate-at-limit",
+      fileName: "locate-at-limit.pdf",
+      pages: ["まえがき", passage],
+    });
+
+    const response = await SELF.fetch(
+      `https://example.com/api/pdf/${book.id}/locate?text=${encodeURIComponent(passage)}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toStrictEqual({ pageNumber: 2 });
+  });
+
   it("refuses a passage longer than any quotable one instead of scanning the book for it", async () => {
     const book = await uploadBook({ tag: "locate-long", fileName: "locate-long.pdf" });
 
@@ -519,9 +552,16 @@ async function postSelection(pdfId: string, body: unknown): Promise<Response> {
   });
 }
 
-/** The highlights of a book, as the viewer receives them. */
+/**
+ * The highlights of a book, as the viewer receives them.
+ *
+ * The status is asserted here so that a book which fails to open shows up as
+ * "expected 500 to be 200" rather than as a JSON parse error on the words
+ * "Internal Server Error".
+ */
 async function readSelections(pdfId: string): Promise<Record<string, unknown>[]> {
   const response = await SELF.fetch(`https://example.com/api/pdf/${pdfId}`);
+  expect(response.status).toBe(200);
   const { selections } = (await response.json()) as { selections: Record<string, unknown>[] };
   return selections;
 }

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -456,6 +456,136 @@ describe("GET /api/pdf/:pdfId/locate", () => {
   });
 });
 
+/** Post a highlight the way the viewer does, with the body left to the caller. */
+async function postSelection(pdfId: string, body: unknown): Promise<Response> {
+  return SELF.fetch(`https://example.com/api/pdf/${pdfId}/selections`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/** The highlights of a book, as the viewer receives them. */
+async function readSelections(pdfId: string): Promise<Record<string, unknown>[]> {
+  const response = await SELF.fetch(`https://example.com/api/pdf/${pdfId}`);
+  const { selections } = (await response.json()) as { selections: Record<string, unknown>[] };
+  return selections;
+}
+
+describe("POST /api/pdf/:pdfId/selections", () => {
+  it("rejects a pageNumber sent as a string instead of storing it in the integer column", async () => {
+    const book = await uploadBook({ tag: "sel-page-string", fileName: "sel-page-string.pdf" });
+
+    const response = await postSelection(book.id, {
+      selectedText: "Workers",
+      pageNumber: "3",
+      positionData: { rects: [] },
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toStrictEqual({
+      error: { code: "VALIDATION_ERROR", message: "Invalid request body: pageNumber" },
+    });
+    expect(await readSelections(book.id)).toStrictEqual([]);
+  });
+
+  it("rejects positionData that carries no rects, which the viewer cannot draw", async () => {
+    const book = await uploadBook({ tag: "sel-no-rects", fileName: "sel-no-rects.pdf" });
+
+    const response = await postSelection(book.id, {
+      selectedText: "Workers",
+      pageNumber: 1,
+      positionData: { pageWidth: 600 },
+    });
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toStrictEqual({
+      error: {
+        code: "VALIDATION_ERROR",
+        message: "Invalid request body: positionData.rects",
+      },
+    });
+    expect(await readSelections(book.id)).toStrictEqual([]);
+  });
+
+  it("keeps only rects and pageWidth when the viewer posts its whole measurement", async () => {
+    const book = await uploadBook({ tag: "sel-strip", fileName: "sel-strip.pdf" });
+    const rects = [{ x: 40, y: 40, width: 160, height: 24 }];
+
+    const response = await postSelection(book.id, {
+      selectedText: "Workers",
+      pageNumber: 2,
+      positionData: { startIndex: 0, endIndex: 7, pageNumber: 2, rects, pageWidth: 600 },
+    });
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toStrictEqual({
+      id: expect.any(String),
+      selectedText: "Workers",
+      pageNumber: 2,
+      positionData: { rects, pageWidth: 600 },
+      createdAt: expect.any(String),
+    });
+    expect(await readSelections(book.id)).toStrictEqual([
+      {
+        id: expect.any(String),
+        selectedText: "Workers",
+        pageNumber: 2,
+        positionData: { rects, pageWidth: 600 },
+        color: "#FFEB3B",
+        createdAt: expect.any(String),
+      },
+    ]);
+  });
+});
+
+describe("GET /api/pdf/:pdfId highlight geometry", () => {
+  it("still serves a book whose stored positionData cannot be read", async () => {
+    const book = await uploadBook({ tag: "sel-unreadable", fileName: "sel-unreadable.pdf" });
+    // Written straight to D1: the endpoint refuses to store either of these
+    // shapes now, but rows like them predate that.
+    await env.DB.prepare(
+      "INSERT INTO selections (id, pdf_id, selected_text, page_number, position_data, color, created_at) VALUES (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?)",
+    )
+      .bind(
+        "sel-legacy-shape",
+        book.id,
+        "旧い形のハイライト",
+        1,
+        JSON.stringify({ startIndex: 0, endIndex: 1, pageNumber: 1, rects: [], pageWidth: 900 }),
+        "#FFEB3B",
+        "2026-01-01T00:00:00Z",
+        "sel-broken-json",
+        book.id,
+        "壊れたハイライト",
+        2,
+        "{not json",
+        "#FF9800",
+        "2026-01-02T00:00:00Z",
+      )
+      .run();
+
+    expect(await readSelections(book.id)).toStrictEqual([
+      {
+        id: "sel-legacy-shape",
+        selectedText: "旧い形のハイライト",
+        pageNumber: 1,
+        positionData: { rects: [], pageWidth: 900 },
+        color: "#FFEB3B",
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "sel-broken-json",
+        selectedText: "壊れたハイライト",
+        pageNumber: 2,
+        positionData: { rects: [] },
+        color: "#FF9800",
+        createdAt: "2026-01-02T00:00:00Z",
+      },
+    ]);
+  });
+});
+
 /** An IdClock that always hands out the same id and timestamp. */
 function fixedIdClock(id: string, now: string): IdClock {
   return { newId: () => id, now: () => now };


### PR DESCRIPTION
Closes #7

## 概要

外部入力を無検証・手書きチェックで受けていた 6 経路に zod を通し、front と server で二重定義されていた型を `src/shared/schemas/` に集約した。`@hono/zod-validator` 0.9.0 を追加 (peer は `zod: ^3.25.0 || ^4.0.0` で本リポジトリの zod 4.4.3 を満たすことを確認済み)。

| 経路 | 変更 |
| --- | --- |
| 選択範囲の保存・読み出し | `validate("json", ...)` で厳格に検証。読み出しは `safeParse` + フォールバック |
| チャット送信ボディ | `content` / `useWebSearch` を検証。文字列 `"false"` は 400 |
| DeepSeek Web 検索の SSE | 非 string の `delta` を本文に混入させない |
| `fetcher` | `fetcher(url, schema, init?, fetchFn?)` にして `ApiError` を throw |
| クライアントの SSE イベント | `token` / `citation` / `done` / `error` の discriminated union で `safeParse` |
| localStorage のキーバインド設定 | 起動時の読み出しと別タブからの storage イベントの両方を検証 |

## 既存バグを 2 件発見して修正した

`positionData` の読み出しを検証する過程で判明した。**保存済みの選択範囲が 1 行でも JSON として壊れていると、その本の取得 API 全体が 500 を返して本が開けなくなる**。同じ穴が `chat_messages.citations` にもあった。

D1 にレガシー形式の行と壊れた JSON の行を直接 INSERT する worker テストで再現を固定してある (修正前は実際に 500 で落ちる)。書き込み側は strict、読み出し側は `safeParse` + フォールバックという非対称にしてあり、**読み出しを strict にすると既存の本が開けなくなる**ので戻さないこと。

## 挙動の変更 (仕様に明示されていなかった選択)

**入力検証がリソース存在確認より先に走るようになった。** `validate()` は Hono の middleware なのでハンドラ本体より前に実行される。そのため「入力が不正 **かつ** 対象が存在しない」を同時に満たすリクエストは 404 ではなく 400 を返す。

| リクエスト | 変更前 | 変更後 |
| --- | --- | --- |
| 存在しない ID の locate + `text` 無し | 404 `PDF_NOT_FOUND` | 400 `VALIDATION_ERROR` |
| 存在しない ID の selections POST + 不正ボディ | 404 `PDF_NOT_FOUND` | 400 `VALIDATION_ERROR` |
| chats POST + 不正ボディ | 500 `CONFIG_ERROR` / 404 | 400 `VALIDATION_ERROR` |

正しいボディ・正しいクエリで存在しない ID を叩いた場合は従来どおり 404 が返ることを実測で確認済みで、**正常なクライアントが踏む経路のステータスは変わっていない**。

その他の挙動変更:

- エラーメッセージが 3 箇所変わった (`"Missing required fields"` → `"Invalid request body: pageNumber"` など)。文言は zod のレポートではなく違反フィールドのパスを自前で組み立てているので、zod の更新では変わらない
- selections POST のレスポンスが送信値のエコーではなく strip 後の正準形になった (返した値と保存された値が一致するようになる)
- `deepseekService` で `try` の範囲を `JSON.parse` だけに狭めた副作用として、`onToken` が投げた例外が握り潰されなくなった。現在の唯一の呼び出し元は内部に try/catch を持つので実害はない
- 別タブが不正な値を書いた場合、キーバインドは現在値の維持ではなく既定値 (vim) に戻る。新しいセッションで開いたときの挙動と揃えるため

## スコープ外にしたもの

- **`pdfId` / `selId` の ULID 形式検証** (issue 項目 8): ID は D1 のバインドパラメータにしか渡らず注入面が無い。唯一の観測可能な変化が 404 → 400 で、古いブックマークや削除済みの本を開いた読者への表示がむしろ悪化する
- `POST /api/pdf/open` の multipart フォーム検証は手書きのまま (issue の対応内容に含まれていないため)
- `catch {}` の握りつぶしと `useChatStream` のストリーム開始前エラー (`new Error("HTTP " + status)` で code/message を捨てる) は #8 の担当

## テスト

jsdom **123 → 140** (+17)、worker **26 → 39** (+13)。新規テストファイルは `fetcher.test.ts` / `settingsAtom.test.ts` / `deepseekService.test.ts`。

| ゲート | 結果 |
| --- | --- |
| `vp check` | pass |
| `pnpm test` (jsdom) | 140 passed |
| `pnpm run test:worker` | 39 passed |
| `pnpm run test:e2e` | 21 passed |
| `vp build` | pass |

## レビュー

review-tdd / review-quality を fresh context で実施し、いずれも high/medium ゼロ。review-tdd は 10 通りの変異を実際にコードへ当ててテストが落ちることを確認している。low 指摘のうち 5 件をこの PR で修正した (別タブ経由の localStorage 検証漏れ、worker テストヘルパーの status assert、`fetcher` のネットワーク断の契約テスト、上限ちょうどの境界値テスト 2 件、CLAUDE.md のテストランナー表の実態反映)。

## 申し送り (後続 issue)

- 互換 re-export が 3 箇所残っている (`ShelfPage` の `Book`、`chatAtom` の 3 型、`selectionRects` の `SelectionRect`) → #5 で該当ファイルを触るときに import 元を shared へ寄せる
- `fetcher` の `fetchFn` が第 4 位置引数なので DI 時に `init` へ `undefined` を挟む必要がある → #5 で呼び出し形が増えるならオプション 1 つに畳む
- ストリーム開始前の失敗が `error.code` / `error.message` を捨てている → #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)