### PR TITLE
✨ feat: データ取得を useEffect + fetch から SWR へ移行する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,12 @@ echo 'DEEPSEEK_API_KEY=dummy' > .dev.vars
 `// oxlint-disable-next-line no-restricted-imports -- <理由>` を付けて理由を明記する運用にしている。
 新しく足すときも同じように理由を書くこと（既存10ファイルが手本）。
 
+**データ取得は理由にならない**。`useEffect` + `fetch` は SWR へ移してある（下記
+「状態管理とルーティング」）。残っている 10 ファイルはすべて外部システムとの同期
+——pdf.js の描画・`destroy` を伴うドキュメント構築、`document` / `window` / `ResizeObserver`
+の購読、URL や jotai ストアという React の外にある状態への書き戻し——であり、
+新しく足す `useEffect` もそのいずれかに当てはまるはず。
+
 ## アーキテクチャ
 
 ### PDF の処理はブラウザ側で行う（重要）
@@ -181,12 +187,34 @@ PDF 引用は `fullText` 内の位置からページ番号を割り出してジ�
 
 ### 状態管理とルーティング
 
-Jotai の atom（`src/front/atoms/`）。`swr` / `neverthrow` はテンプレート由来の
-未使用依存で、現在どこからも import していない。
+**サーバから来たものは SWR、クライアントだけの状態は Jotai の atom**（`src/front/atoms/`）。
+`neverthrow` はテンプレート由来の未使用依存で、現在どこからも import していない。
 
-- `/` … 本棚（`ShelfPage`）
-- `/books/:pdfId` … リーダー（`AppPage`）。URL から `pdfDocAtom` を復元するので
+- `/` … 本棚（`ShelfPage`）。一覧は `useSWR("/api/pdfs")`
+- `/books/:pdfId` … リーダー（`AppPage`）。本は `useBook(pdfId)` で読むので
   リロード・直リンクでも開ける
+
+SWR の使い方で押さえるところ:
+
+- **ルートの `SWRConfig`**（`src/front/main.tsx`）で `revalidateOnFocus` を切っている。
+  ローカル単一ユーザーのアプリでデータは自分の操作でしか変わらず、focus 復帰の再検証は
+  Playwright のフォーカス往復で E2E を非決定にするだけ
+- **本のキーは `src/front/hooks/useBook.ts` の `bookKey(pdfId)`（= `/api/pdf/:pdfId`）1 本**。
+  リーダー（`AppPage`）・ビューア・チャットパネルが同じキーを共有するので本の読み取りは
+  1 回で済み、ハイライトの追加も全員に同時に映る。ハイライト一覧は
+  `useHighlights` がこのエントリの `selections` から導出する（色のパレット補完込み）ので、
+  **専用の atom を作らないこと**——SWR のキャッシュ自体が共有のグローバル state で、
+  atom と二重管理すると必ずずれる
+- **アップロード時のキャッシュ先充填**: `FileSelector` が `POST /api/pdf/open` の結果を
+  `mutate(bookKey(id), ..., { revalidate: false })` で先に書く。遷移先の
+  `AppPage` がキャッシュヒットで即座に開くため。**atom への反映を `onSuccess` に
+  依存させないこと**——キャッシュヒット時は発火しない
+- **リーダーの state は本ごとに作り直す**: `AppPage` が `pdfId` を key にした jotai
+  `Provider` を張る。開いているチャット・選択・ページはどれも 1 冊に属するので、
+  個別に reset する代わりに store ごと捨てる。本自体は store の外（SWR）にあるので残る
+- **テストは `src/test/swrTestCache.tsx` の `SwrTestCache` で包む**。SWR の既定キャッシュは
+  モジュールレベルの singleton なので、包まないとテストが互いのキャッシュを見て
+  実行順に依存する。`seed` を渡すとそのキーをサーバの代わりに使う
 
 キーバインド（Vim / Emacs）は `src/front/lib/keybindings.ts` の `resolveAction` に
 DOM 非依存の純粋関数として実装。`gg` や `C-c t` の2ストロークは `pending` プレフィックスで表現し、

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,16 +52,31 @@ echo 'DEEPSEEK_API_KEY=dummy' > .dev.vars
 このアプリは canvas 描画・DOM 購読・pdf.js の命令的 API が本質なので使う場面が多いが、
 ルールは**残したまま**、使う側が import 行に
 `// oxlint-disable-next-line no-restricted-imports -- <理由>` を付けて理由を明記する運用にしている。
-新しく足すときも同じように理由を書くこと（既存9ファイルが手本）。
+新しく足すときも同じように理由を書くこと。
 
-**データ取得は理由にならない**。`useEffect` + `fetch` は SWR へ移してある（下記
-「状態管理とルーティング」）。残っている 9 ファイルはすべて外部システムとの同期
-——pdf.js の描画・`destroy` を伴うドキュメント構築、`document` / `window` / `ResizeObserver`
-の購読、URL への書き戻し——であり、新しく足す `useEffect` もそのいずれかに当てはまるはず。
+現在 9 ファイルに理由コメントがあり、内訳は次の 4 つしかない。新しく足す `useEffect` も
+このどれかに当てはまるはずで、当てはまらないなら書き方を疑うこと:
+
+| 用途                                            | ファイル                                                                                                                                            |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| pdf.js という命令的ライブラリの呼び出しと後始末 | `PdfPage.tsx`（`RenderTask` / `TextLayer`）、`usePdfDocument.ts`（バイナリ取得とドキュメント構築）、`usePdfOutline.ts`（`getOutline` と dest 解決） |
+| `document` / `window` / `ResizeObserver` の購読 | `useKeyboardShortcuts.ts`、`SettingsMenu.tsx`、`SelectionPopover.tsx`、`PdfViewer.tsx`                                                              |
+| DOM への命令的な書き込み（スクロール位置）      | `ChatMessageList.tsx`（最下部へ追随）、`PdfViewer.tsx`（ページ遷移時のリセット）                                                                    |
+| URL という React の外の状態への同期             | `useReadingLocation.ts`                                                                                                                             |
+
+**データ取得は理由にならない**。一覧・本・ハイライト・引用箇所のページ解決は SWR へ
+移してある（下記「状態管理とルーティング」）。
 
 **SWR が持っているものを atom へ写すのも理由にならない**。写した瞬間に同じデータが
 2 箇所に載り、更新のたびに 1 レンダー遅れる。読み手が少ないなら props で配る
 （`AppPage` → `PdfViewer` / `ChatArea` の `book` がその形）。
+
+これと紛らわしいものが 1 つだけある。`useReadingLocation.ts` は
+`useSWRImmutable` が解いた「引用箇所のページ番号」を `currentPageAtom` に書く。これは
+写しではない: `currentPageAtom` は「読者が今どのページにいるか」というクライアント状態で、
+キーボード・ページ送りボタン・目次・URL も書き込む。取得結果はその状態を**一度だけ動かす
+きっかけ**であって、サーバのデータを atom に常駐させているわけではない。
+**サーバの値がそのまま atom に載り続けるなら写し（禁止）、一度きりの入力なら可**。
 
 ## アーキテクチャ
 
@@ -190,17 +205,29 @@ PDF 引用は `fullText` 内の位置からページ番号を割り出してジ�
 
 ### 状態管理とルーティング
 
-**サーバから来たものは SWR、クライアントだけの状態は Jotai の atom**（`src/front/atoms/`）。
-両方に同じものを載せないこと。`neverthrow` はテンプレート由来の未使用依存で、現在
-どこからも import していない。
+**画面に出しっぱなしにするサーバのデータは SWR、クライアントだけの状態は Jotai の atom**
+（`src/front/atoms/`）。両方に同じものを載せないこと。`neverthrow` はテンプレート由来の
+未使用依存で、現在どこからも import していない。
 
 - `/` … 本棚（`ShelfPage`）。一覧は `useSWR("/api/pdfs")`
 - `/books/:pdfId` … リーダー（`AppPage`）。本は `useBook(pdfId)` で読むので
   リロード・直リンクでも開ける。読んだ本は `PdfViewer` / `ChatArea` へ **props で**
   渡す（atom に写さない。読み手はこの 2 つだけなので prop drilling にならない）
 
+**チャットだけは SWR に載っていない**。`chatMessagesAtom` が持ち、履歴の読み込みは
+`AppPage` の `handleSelectionClick` が生の `fetcher` を呼ぶ。理由は、同じ状態を SSE の
+ストリームがトークンごとに書き換えるため（`useChatStream`）——キャッシュに載せると
+再検証が流れてきた回答を上書きしうる。**「データ取得はすべて SWR」ではない**。
+イベントハンドラ起点の 1 回きりの取得（履歴・選択の作成・アップロード）は生の `fetcher`
+で書く。
+
 SWR の使い方で押さえるところ:
 
+- **fetcher は必ず `src/front/lib/fetcher.ts` の `fetcher` を通す**（上記
+  「外部入力のバリデーション（zod）」）。`useSWR(key, () => fetch(...).then(r => r.json()))`
+  のように生 `fetch` を渡すとスキーマ検証を素通りし、`ApiError` / `INVALID_RESPONSE`
+  の防護が消える。現在の SWR 呼び出しは全て `fetcher` 経由（PDF バイナリの取得だけは
+  JSON ではないので `usePdfDocument` が生の fetch を使うが、これは SWR ではない）
 - **ルートの `SWRConfig`**（`src/front/main.tsx`）で `revalidateOnFocus` を切っている。
   ローカル単一ユーザーのアプリでデータは自分の操作でしか変わらず、focus 復帰の再検証は
   Playwright のフォーカス往復で E2E を非決定にするだけ
@@ -210,19 +237,29 @@ SWR の使い方で押さえるところ:
   `useHighlights` がこのエントリの `selections` から導出する（色のパレット補完込み）ので、
   **専用の atom を作らないこと**——SWR のキャッシュ自体が共有のグローバル state で、
   atom と二重管理すると必ずずれる
+- **本は props、ハイライトは購読**という線引きは意図的。本の見出し（id / fileName /
+  pageCount）は開いている間変わらないので props で足りる。ハイライトは `PdfViewer` が
+  足して `ChatArea` が一覧する——兄弟どうしが同じ更新を見る必要があるので、
+  `BookReader` へ持ち上げず同じキーの購読で共有する
 - **アップロード時のキャッシュ先充填**: `FileSelector` が `POST /api/pdf/open` の結果を
   `mutate(bookKey(id), ..., { revalidate: false })` で先に書く。遷移先の
-  `AppPage` がキャッシュヒットで即座に開くため。**atom への反映を `onSuccess` に
-  依存させないこと**——キャッシュヒット時は発火しない
+  `AppPage` がキャッシュヒットで即座に開くため。先充填の `selections` は空・
+  `hasThumbnail` は推定値なので、**マウント時の再検証を止めないこと**——
+  既にハイライトのある本を開き直したとき、一覧が空のまま固定される
 - **リーダーの state は本ごとに作り直す**: `AppPage` が `pdfId` を key にした jotai
   `Provider` を張る。開いているチャット・選択・ページはどれも 1 冊に属するので、
   個別に reset する代わりに store ごと捨てる。本自体は store の外（SWR）にあるので残る。
   **本をまたいで残したい設定は store に置けない**——`atomWithStorage` +
   `{ getOnInit: true }` で localStorage に持たせる（`settingsAtom.ts` の
   `keybindingModeAtom` / `useWebSearchAtom` がその形）
-- **テストは `src/test/swrTestCache.tsx` の `SwrTestCache` で包む**。SWR の既定キャッシュは
-  モジュールレベルの singleton なので、包まないとテストが互いのキャッシュを見て
-  実行順に依存する。`seed` を渡すとそのキーをサーバの代わりに使う
+- **テストの差し替え口は 2 つある**。取得そのものを差し替えるなら DI 引数——
+  `useBook(pdfId, loadBook)` / `useHighlights(pdfId, loadBook)` /
+  `ShelfPage({ loadBooks, deleteBook })` / `FileSelector({ extract })` がその口。
+  キャッシュの中身を用意したいなら `src/test/swrTestCache.tsx` の `SwrTestCache` で包む
+  （SWR の既定キャッシュはモジュールレベルの singleton なので、包まないとテストが互いの
+  キャッシュを見て実行順に依存する。`seed` を渡すとそのキーをサーバの代わりに使う）。
+  例外は**書き込まれたキャッシュの中身を検証したいとき**で、`Map` への参照が要るため
+  `FileSelector.test.tsx` は自前の `Map` を `SWRConfig` へ直接渡している
 
 キーバインド（Vim / Emacs）は `src/front/lib/keybindings.ts` の `resolveAction` に
 DOM 非依存の純粋関数として実装。`gg` や `C-c t` の2ストロークは `pending` プレフィックスで表現し、

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,13 +52,16 @@ echo 'DEEPSEEK_API_KEY=dummy' > .dev.vars
 このアプリは canvas 描画・DOM 購読・pdf.js の命令的 API が本質なので使う場面が多いが、
 ルールは**残したまま**、使う側が import 行に
 `// oxlint-disable-next-line no-restricted-imports -- <理由>` を付けて理由を明記する運用にしている。
-新しく足すときも同じように理由を書くこと（既存10ファイルが手本）。
+新しく足すときも同じように理由を書くこと（既存9ファイルが手本）。
 
 **データ取得は理由にならない**。`useEffect` + `fetch` は SWR へ移してある（下記
-「状態管理とルーティング」）。残っている 10 ファイルはすべて外部システムとの同期
+「状態管理とルーティング」）。残っている 9 ファイルはすべて外部システムとの同期
 ——pdf.js の描画・`destroy` を伴うドキュメント構築、`document` / `window` / `ResizeObserver`
-の購読、URL や jotai ストアという React の外にある状態への書き戻し——であり、
-新しく足す `useEffect` もそのいずれかに当てはまるはず。
+の購読、URL への書き戻し——であり、新しく足す `useEffect` もそのいずれかに当てはまるはず。
+
+**SWR が持っているものを atom へ写すのも理由にならない**。写した瞬間に同じデータが
+2 箇所に載り、更新のたびに 1 レンダー遅れる。読み手が少ないなら props で配る
+（`AppPage` → `PdfViewer` / `ChatArea` の `book` がその形）。
 
 ## アーキテクチャ
 
@@ -188,11 +191,13 @@ PDF 引用は `fullText` 内の位置からページ番号を割り出してジ�
 ### 状態管理とルーティング
 
 **サーバから来たものは SWR、クライアントだけの状態は Jotai の atom**（`src/front/atoms/`）。
-`neverthrow` はテンプレート由来の未使用依存で、現在どこからも import していない。
+両方に同じものを載せないこと。`neverthrow` はテンプレート由来の未使用依存で、現在
+どこからも import していない。
 
 - `/` … 本棚（`ShelfPage`）。一覧は `useSWR("/api/pdfs")`
 - `/books/:pdfId` … リーダー（`AppPage`）。本は `useBook(pdfId)` で読むので
-  リロード・直リンクでも開ける
+  リロード・直リンクでも開ける。読んだ本は `PdfViewer` / `ChatArea` へ **props で**
+  渡す（atom に写さない。読み手はこの 2 つだけなので prop drilling にならない）
 
 SWR の使い方で押さえるところ:
 
@@ -211,7 +216,10 @@ SWR の使い方で押さえるところ:
   依存させないこと**——キャッシュヒット時は発火しない
 - **リーダーの state は本ごとに作り直す**: `AppPage` が `pdfId` を key にした jotai
   `Provider` を張る。開いているチャット・選択・ページはどれも 1 冊に属するので、
-  個別に reset する代わりに store ごと捨てる。本自体は store の外（SWR）にあるので残る
+  個別に reset する代わりに store ごと捨てる。本自体は store の外（SWR）にあるので残る。
+  **本をまたいで残したい設定は store に置けない**——`atomWithStorage` +
+  `{ getOnInit: true }` で localStorage に持たせる（`settingsAtom.ts` の
+  `keybindingModeAtom` / `useWebSearchAtom` がその形）
 - **テストは `src/test/swrTestCache.tsx` の `SwrTestCache` で包む**。SWR の既定キャッシュは
   モジュールレベルの singleton なので、包まないとテストが互いのキャッシュを見て
   実行順に依存する。`seed` を渡すとそのキーをサーバの代わりに使う

--- a/src/front/atoms/chatAtom.ts
+++ b/src/front/atoms/chatAtom.ts
@@ -1,6 +1,5 @@
 import { atom } from "jotai";
 import type { ChatMessage } from "../../shared/schemas/chat";
-import type { SelectionHighlight } from "../../shared/schemas/selection";
 
 /** The highlighted passage the current conversation is about. */
 export interface ActiveSelection {
@@ -10,8 +9,6 @@ export interface ActiveSelection {
 }
 
 export const activeSelectionAtom = atom<ActiveSelection | null>(null);
-// Shared so the chat panel can list the same highlights the viewer draws.
-export const selectionsAtom = atom<SelectionHighlight[]>([]);
 export const chatMessagesAtom = atom<ChatMessage[]>([]);
 export const streamingContentAtom = atom<string>("");
 export const isStreamingAtom = atom<boolean>(false);

--- a/src/front/atoms/chatAtom.ts
+++ b/src/front/atoms/chatAtom.ts
@@ -2,10 +2,6 @@ import { atom } from "jotai";
 import type { ChatMessage } from "../../shared/schemas/chat";
 import type { SelectionHighlight } from "../../shared/schemas/selection";
 
-export type { ChatMessage } from "../../shared/schemas/chat";
-export type { Citation } from "../../shared/schemas/citation";
-export type { SelectionHighlight } from "../../shared/schemas/selection";
-
 /** The highlighted passage the current conversation is about. */
 export interface ActiveSelection {
   id: string;

--- a/src/front/atoms/chatAtom.ts
+++ b/src/front/atoms/chatAtom.ts
@@ -12,9 +12,6 @@ export const activeSelectionAtom = atom<ActiveSelection | null>(null);
 export const chatMessagesAtom = atom<ChatMessage[]>([]);
 export const streamingContentAtom = atom<string>("");
 export const isStreamingAtom = atom<boolean>(false);
-// Web search is on by default: the assistant should fall back to the web when
-// the document alone cannot answer the question.
-export const useWebSearchAtom = atom<boolean>(true);
 
 /** Shared, so leaving a chat can stop an answer any of the panels started. */
 export const chatAbortControllerAtom = atom<AbortController | null>(null);

--- a/src/front/atoms/pdfAtom.ts
+++ b/src/front/atoms/pdfAtom.ts
@@ -1,16 +1,5 @@
 import { atom } from "jotai";
 
-export interface PdfDoc {
-  id: string;
-  fileName: string;
-  pageCount: number;
-}
-
-export type PdfStatus = "idle" | "loading" | "ready" | "error";
-
-export const pdfDocAtom = atom<PdfDoc | null>(null);
-export const pdfStatusAtom = atom<PdfStatus>("idle");
-export const pdfErrorAtom = atom<string | null>(null);
 export const currentPageAtom = atom<number>(1);
 /** Rendered page size, plus the page's intrinsic width at scale 1. */
 export const pageViewportAtom = atom<{ width: number; height: number; baseWidth: number }>({

--- a/src/front/atoms/settingsAtom.test.ts
+++ b/src/front/atoms/settingsAtom.test.ts
@@ -2,6 +2,21 @@ import { describe, it, expect, vi, afterEach } from "vite-plus/test";
 import { createStore } from "jotai";
 
 const STORAGE_KEY = "chatbook:keybindings";
+const WEB_SEARCH_KEY = "chatbook:web-search";
+
+/**
+ * Whether the assistant would search the web, given what the last session left
+ * in storage. The reader builds a fresh jotai store for every book it opens, so
+ * a setting that only lived in the store would go back to its default each
+ * time; this is the same question asked of a brand new store.
+ */
+async function restoredWebSearch(stored: string) {
+  localStorage.clear();
+  localStorage.setItem(WEB_SEARCH_KEY, stored);
+  vi.resetModules();
+  const { useWebSearchAtom } = await import("./settingsAtom");
+  return createStore().get(useWebSearchAtom);
+}
 
 /**
  * The mode the reader starts a session with, given what the last one left in
@@ -91,5 +106,25 @@ describe("keybindingModeAtom", () => {
 
     expect(session.mode()).toBe("vim");
     session.unmount();
+  });
+});
+
+describe("useWebSearchAtom", () => {
+  it.each([
+    { holds: "the setting turned off in a previous session", stored: "false", starts: false },
+    { holds: "the setting turned back on", stored: "true", starts: true },
+    { holds: "nothing this reader wrote", stored: JSON.stringify("yes"), starts: true },
+  ])("starts $starts when storage holds $holds", async ({ stored, starts }) => {
+    const useWebSearch = await restoredWebSearch(stored);
+
+    expect(useWebSearch).toBe(starts);
+  });
+
+  it("is on for a reader who has never touched the setting", async () => {
+    localStorage.clear();
+    vi.resetModules();
+    const { useWebSearchAtom } = await import("./settingsAtom");
+
+    expect(createStore().get(useWebSearchAtom)).toBe(true);
   });
 });

--- a/src/front/atoms/settingsAtom.ts
+++ b/src/front/atoms/settingsAtom.ts
@@ -4,24 +4,15 @@ import type { KeybindingMode } from "../lib/keybindings";
 
 const keybindingModeSchema = z.enum(["none", "vim", "emacs"]);
 
-const jsonStorage = createJSONStorage<KeybindingMode>(() => localStorage);
-
-/** Anything that is not one of the modes is treated as nothing stored. */
-function asMode(value: unknown, fallback: KeybindingMode): KeybindingMode {
-  const parsed = keybindingModeSchema.safeParse(value);
-  return parsed.success ? parsed.data : fallback;
-}
-
-/** Present whenever the environment can report another tab's writes. */
-const subscribeToStorage = jsonStorage.subscribe;
-
 /**
- * localStorage as a source of modes, with anything else treated as absent.
+ * localStorage as a source of settings, with anything the schema rejects
+ * treated as absent.
  *
  * The stored value is outside this app's control — an older release, another
- * tab, or the devtools can leave a string that is not a mode. `resolveAction`
- * has no default branch, so such a value makes it return undefined and the
- * shortcut hook throws while destructuring it, on the first key pressed.
+ * tab, or the devtools can leave something else there. For the keybinding mode
+ * the damage is concrete: `resolveAction` has no default branch, so an unknown
+ * mode makes it return undefined and the shortcut hook throws while
+ * destructuring it, on the first key pressed.
  *
  * **Both ways in have to be checked.** A value read at startup arrives through
  * `getItem`, but a value another tab writes arrives through `subscribe`, which
@@ -32,20 +23,47 @@ const subscribeToStorage = jsonStorage.subscribe;
  * which is both marked unstable and has that same gap: it replaces `getItem`
  * alone.
  */
-const keybindingModeStorage = {
-  ...jsonStorage,
-  getItem: (key: string, initialValue: KeybindingMode): KeybindingMode =>
-    asMode(jsonStorage.getItem(key, initialValue), initialValue),
-  subscribe: subscribeToStorage
-    ? (key: string, callback: (value: KeybindingMode) => void, initialValue: KeybindingMode) =>
-        subscribeToStorage(key, (value) => callback(asMode(value, initialValue)), initialValue)
-    : undefined,
-};
+function validatedStorage<T>(schema: z.ZodType<T>) {
+  const jsonStorage = createJSONStorage<T>(() => localStorage);
+  const accept = (value: unknown, fallback: T): T => {
+    const parsed = schema.safeParse(value);
+    return parsed.success ? parsed.data : fallback;
+  };
+
+  /** Present whenever the environment can report another tab's writes. */
+  const subscribeToStorage = jsonStorage.subscribe;
+
+  return {
+    ...jsonStorage,
+    getItem: (key: string, initialValue: T): T =>
+      accept(jsonStorage.getItem(key, initialValue), initialValue),
+    subscribe: subscribeToStorage
+      ? (key: string, callback: (value: T) => void, initialValue: T) =>
+          subscribeToStorage(key, (value) => callback(accept(value, initialValue)), initialValue)
+      : undefined,
+  };
+}
 
 /** Persisted so the reader keeps the chosen bindings across sessions. */
 export const keybindingModeAtom = atomWithStorage<KeybindingMode>(
   "chatbook:keybindings",
   "vim",
-  keybindingModeStorage,
+  validatedStorage(keybindingModeSchema),
+  { getOnInit: true },
+);
+
+/**
+ * Whether the assistant may search the web, on by default: it should fall back
+ * to the web when the document alone cannot answer the question.
+ *
+ * Persisted rather than held in the store because the reader builds a fresh
+ * jotai store per book. A setting kept only in the store would go back to its
+ * default on every book change and on every trip through the shelf, which is
+ * not what a setting sat next to the keybindings in the same menu should do.
+ */
+export const useWebSearchAtom = atomWithStorage<boolean>(
+  "chatbook:web-search",
+  true,
+  validatedStorage(z.boolean()),
   { getOnInit: true },
 );

--- a/src/front/components/ChatArea/ChatArea.test.tsx
+++ b/src/front/components/ChatArea/ChatArea.test.tsx
@@ -10,8 +10,8 @@ import {
   isStreamingAtom,
   selectionsAtom,
   type ActiveSelection,
-  type SelectionHighlight,
 } from "../../atoms/chatAtom";
+import type { SelectionHighlight } from "../../../shared/schemas/selection";
 import { pdfDocAtom } from "../../atoms/pdfAtom";
 
 const SELECTED_TEXT = "エッジはサーバーレス実行基盤で、実行単位をまたいでメモリを共有できません。";

--- a/src/front/components/ChatArea/ChatArea.test.tsx
+++ b/src/front/components/ChatArea/ChatArea.test.tsx
@@ -12,7 +12,6 @@ import {
 } from "../../atoms/chatAtom";
 import type { SelectionHighlight } from "../../../shared/schemas/selection";
 import type { BookDetail } from "../../../shared/schemas/book";
-import { pdfDocAtom } from "../../atoms/pdfAtom";
 import { bookKey } from "../../hooks/useBook";
 import { SwrTestCache } from "../../../test/swrTestCache";
 
@@ -49,7 +48,6 @@ const BOOK: BookDetail = {
 function renderChat(options: { activeSelection?: ActiveSelection | null } = {}) {
   const { activeSelection = { id: "s1", selectedText: SELECTED_TEXT, pageNumber: 42 } } = options;
   const store = createStore();
-  store.set(pdfDocAtom, { id: BOOK.id, fileName: BOOK.fileName, pageCount: BOOK.pageCount });
   store.set(activeSelectionAtom, activeSelection);
 
   const opened: ActiveSelection[] = [];
@@ -58,7 +56,7 @@ function renderChat(options: { activeSelection?: ActiveSelection | null } = {}) 
     // one the viewer draws from.
     <SwrTestCache seed={{ [bookKey(BOOK.id)]: BOOK }}>
       <Provider store={store}>
-        <ChatArea onSelectionClick={(selection) => opened.push(selection)} />
+        <ChatArea book={BOOK} onSelectionClick={(selection) => opened.push(selection)} />
       </Provider>
     </SwrTestCache>,
   );

--- a/src/front/components/ChatArea/ChatArea.test.tsx
+++ b/src/front/components/ChatArea/ChatArea.test.tsx
@@ -8,11 +8,13 @@ import {
   activeSelectionAtom,
   chatAbortControllerAtom,
   isStreamingAtom,
-  selectionsAtom,
   type ActiveSelection,
 } from "../../atoms/chatAtom";
 import type { SelectionHighlight } from "../../../shared/schemas/selection";
+import type { BookDetail } from "../../../shared/schemas/book";
 import { pdfDocAtom } from "../../atoms/pdfAtom";
+import { bookKey } from "../../hooks/useHighlights";
+import { SwrTestCache } from "../../../test/swrTestCache";
 
 const SELECTED_TEXT = "エッジはサーバーレス実行基盤で、実行単位をまたいでメモリを共有できません。";
 const OTHER_TEXT = "Durable Objects は単一のインスタンスに処理を集約します。";
@@ -36,18 +38,29 @@ const HIGHLIGHTS: SelectionHighlight[] = [
   },
 ];
 
+const BOOK: BookDetail = {
+  id: "p1",
+  fileName: "Cloudflare Workers.pdf",
+  pageCount: 209,
+  hasThumbnail: true,
+  selections: HIGHLIGHTS,
+};
+
 function renderChat(options: { activeSelection?: ActiveSelection | null } = {}) {
   const { activeSelection = { id: "s1", selectedText: SELECTED_TEXT, pageNumber: 42 } } = options;
   const store = createStore();
-  store.set(pdfDocAtom, { id: "p1", fileName: "Cloudflare Workers.pdf", pageCount: 209 });
+  store.set(pdfDocAtom, { id: BOOK.id, fileName: BOOK.fileName, pageCount: BOOK.pageCount });
   store.set(activeSelectionAtom, activeSelection);
-  store.set(selectionsAtom, HIGHLIGHTS);
 
   const opened: ActiveSelection[] = [];
   render(
-    <Provider store={store}>
-      <ChatArea onSelectionClick={(selection) => opened.push(selection)} />
-    </Provider>,
+    // The highlights the panel lists come from the book's cache entry, the same
+    // one the viewer draws from.
+    <SwrTestCache seed={{ [bookKey(BOOK.id)]: BOOK }}>
+      <Provider store={store}>
+        <ChatArea onSelectionClick={(selection) => opened.push(selection)} />
+      </Provider>
+    </SwrTestCache>,
   );
   return { store, opened };
 }

--- a/src/front/components/ChatArea/ChatArea.test.tsx
+++ b/src/front/components/ChatArea/ChatArea.test.tsx
@@ -13,7 +13,7 @@ import {
 import type { SelectionHighlight } from "../../../shared/schemas/selection";
 import type { BookDetail } from "../../../shared/schemas/book";
 import { pdfDocAtom } from "../../atoms/pdfAtom";
-import { bookKey } from "../../hooks/useHighlights";
+import { bookKey } from "../../hooks/useBook";
 import { SwrTestCache } from "../../../test/swrTestCache";
 
 const SELECTED_TEXT = "エッジはサーバーレス実行基盤で、実行単位をまたいでメモリを共有できません。";

--- a/src/front/components/ChatArea/ChatArea.tsx
+++ b/src/front/components/ChatArea/ChatArea.tsx
@@ -5,7 +5,6 @@ import {
   isStreamingAtom,
   useWebSearchAtom,
   activeSelectionAtom,
-  selectionsAtom,
   abortChatStreamAtom,
   type ActiveSelection,
 } from "../../atoms/chatAtom";
@@ -14,6 +13,7 @@ import { ChatMessageList } from "./ChatMessageList";
 import { ChatInput } from "./ChatInput";
 import { HighlightListPanel } from "./HighlightListPanel";
 import { useChatStream } from "../../hooks/useChatStream";
+import { useHighlights } from "../../hooks/useHighlights";
 
 interface ChatAreaProps {
   onSelectionClick: (selection: ActiveSelection) => void;
@@ -22,7 +22,7 @@ interface ChatAreaProps {
 export function ChatArea({ onSelectionClick }: ChatAreaProps) {
   const pdfDoc = useAtomValue(pdfDocAtom);
   const [activeSelection, setActiveSelection] = useAtom(activeSelectionAtom);
-  const selections = useAtomValue(selectionsAtom);
+  const { highlights } = useHighlights(pdfDoc?.id);
   const messages = useAtomValue(chatMessagesAtom);
   const streamingContent = useAtomValue(streamingContentAtom);
   const isStreaming = useAtomValue(isStreamingAtom);
@@ -45,7 +45,7 @@ export function ChatArea({ onSelectionClick }: ChatAreaProps) {
   }
 
   if (!activeSelection) {
-    return <HighlightListPanel highlights={selections} onSelect={onSelectionClick} />;
+    return <HighlightListPanel highlights={highlights} onSelect={onSelectionClick} />;
   }
 
   return (

--- a/src/front/components/ChatArea/ChatArea.tsx
+++ b/src/front/components/ChatArea/ChatArea.tsx
@@ -8,7 +8,7 @@ import {
   abortChatStreamAtom,
   type ActiveSelection,
 } from "../../atoms/chatAtom";
-import { pdfDocAtom } from "../../atoms/pdfAtom";
+import type { BookDetail } from "../../../shared/schemas/book";
 import { ChatMessageList } from "./ChatMessageList";
 import { ChatInput } from "./ChatInput";
 import { HighlightListPanel } from "./HighlightListPanel";
@@ -16,13 +16,14 @@ import { useChatStream } from "../../hooks/useChatStream";
 import { useHighlights } from "../../hooks/useHighlights";
 
 interface ChatAreaProps {
+  /** The book being read, or nothing while it is still being read in. */
+  book: BookDetail | undefined;
   onSelectionClick: (selection: ActiveSelection) => void;
 }
 
-export function ChatArea({ onSelectionClick }: ChatAreaProps) {
-  const pdfDoc = useAtomValue(pdfDocAtom);
+export function ChatArea({ book, onSelectionClick }: ChatAreaProps) {
   const [activeSelection, setActiveSelection] = useAtom(activeSelectionAtom);
-  const { highlights } = useHighlights(pdfDoc?.id);
+  const { highlights } = useHighlights(book?.id);
   const messages = useAtomValue(chatMessagesAtom);
   const streamingContent = useAtomValue(streamingContentAtom);
   const isStreaming = useAtomValue(isStreamingAtom);
@@ -32,11 +33,11 @@ export function ChatArea({ onSelectionClick }: ChatAreaProps) {
   const { sendMessage } = useChatStream();
 
   const handleSend = async (content: string) => {
-    if (!pdfDoc || !activeSelection) return;
-    await sendMessage(pdfDoc.id, activeSelection.id, content, useWebSearch);
+    if (!book || !activeSelection) return;
+    await sendMessage(book.id, activeSelection.id, content, useWebSearch);
   };
 
-  if (!pdfDoc) {
+  if (!book) {
     return (
       <div className="flex items-center justify-center h-full bg-white">
         <p className="text-gray-400 text-sm">PDFを開いてテキストを選択してください</p>

--- a/src/front/components/ChatArea/ChatArea.tsx
+++ b/src/front/components/ChatArea/ChatArea.tsx
@@ -3,7 +3,6 @@ import {
   chatMessagesAtom,
   streamingContentAtom,
   isStreamingAtom,
-  useWebSearchAtom,
   activeSelectionAtom,
   abortChatStreamAtom,
   type ActiveSelection,
@@ -12,6 +11,7 @@ import type { BookDetail } from "../../../shared/schemas/book";
 import { ChatMessageList } from "./ChatMessageList";
 import { ChatInput } from "./ChatInput";
 import { HighlightListPanel } from "./HighlightListPanel";
+import { useWebSearchAtom } from "../../atoms/settingsAtom";
 import { useChatStream } from "../../hooks/useChatStream";
 import { useHighlights } from "../../hooks/useHighlights";
 

--- a/src/front/components/ChatArea/ChatMessageBubble.test.tsx
+++ b/src/front/components/ChatArea/ChatMessageBubble.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import { ChatMessageBubble } from "./ChatMessageBubble";
-import type { ChatMessage } from "../../atoms/chatAtom";
+import type { ChatMessage } from "../../../shared/schemas/chat";
 
 function message(overrides: Partial<ChatMessage> = {}): ChatMessage {
   return {

--- a/src/front/components/ChatArea/ChatMessageBubble.tsx
+++ b/src/front/components/ChatArea/ChatMessageBubble.tsx
@@ -1,7 +1,7 @@
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeHighlight from "rehype-highlight";
-import type { ChatMessage } from "../../atoms/chatAtom";
+import type { ChatMessage } from "../../../shared/schemas/chat";
 import { CitationBadge } from "./CitationBadge";
 import { stripSources } from "../../lib/stripSources";
 

--- a/src/front/components/ChatArea/ChatMessageList.test.tsx
+++ b/src/front/components/ChatArea/ChatMessageList.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import { ChatMessageList } from "./ChatMessageList";
-import type { ChatMessage } from "../../atoms/chatAtom";
+import type { ChatMessage } from "../../../shared/schemas/chat";
 
 const question: ChatMessage = {
   id: "m1",

--- a/src/front/components/ChatArea/ChatMessageList.tsx
+++ b/src/front/components/ChatArea/ChatMessageList.tsx
@@ -1,6 +1,6 @@
 // oxlint-disable-next-line no-restricted-imports -- 新着メッセージとストリーム更新に追随して最下部へスクロールするために必要
 import { useEffect, useRef } from "react";
-import type { ChatMessage } from "../../atoms/chatAtom";
+import type { ChatMessage } from "../../../shared/schemas/chat";
 import { ChatMessageBubble } from "./ChatMessageBubble";
 
 interface ChatMessageListProps {

--- a/src/front/components/ChatArea/CitationBadge.test.tsx
+++ b/src/front/components/ChatArea/CitationBadge.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { Provider, createStore } from "jotai";
 import { CitationBadge } from "./CitationBadge";
 import { currentPageAtom } from "../../atoms/pdfAtom";
-import type { Citation } from "../../atoms/chatAtom";
+import type { Citation } from "../../../shared/schemas/citation";
 
 function renderBadge(citation: Citation) {
   const store = createStore();

--- a/src/front/components/ChatArea/CitationBadge.tsx
+++ b/src/front/components/ChatArea/CitationBadge.tsx
@@ -1,5 +1,5 @@
 import { useSetAtom } from "jotai";
-import type { Citation } from "../../atoms/chatAtom";
+import type { Citation } from "../../../shared/schemas/citation";
 import { currentPageAtom } from "../../atoms/pdfAtom";
 
 interface CitationBadgeProps {

--- a/src/front/components/PdfViewer/FileSelector.test.tsx
+++ b/src/front/components/PdfViewer/FileSelector.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, afterEach, vi } from "vite-plus/test";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SWRConfig, type Cache } from "swr";
+import { FileSelector } from "./FileSelector";
+import { bookKey } from "../../hooks/useBook";
+import type { ExtractedPdfData } from "../../lib/pdfLoader";
+import type { BookDetail } from "../../../shared/schemas/book";
+
+const PDF_ID = "01JBOOK";
+const FILE_NAME = "Cloudflare Workers.pdf";
+const PAGE_COUNT = 209;
+
+const COVER = new Blob(["webp bytes"], { type: "image/webp" });
+
+const FULL_TEXT = "エッジはサーバーレス実行基盤です。";
+
+function extraction(thumbnail: Blob | null): ExtractedPdfData {
+  return {
+    fileName: FILE_NAME,
+    fileHash: "sha256-of-the-file",
+    fullText: FULL_TEXT,
+    pageCount: PAGE_COUNT,
+    fileContentBase64: "",
+    thumbnail,
+  };
+}
+
+/** Answers the upload the way the API does, and records what it was sent. */
+function uploadStub() {
+  const uploads: { url: string; method: string }[] = [];
+  const fetchFn = (url: string, init?: RequestInit) => {
+    uploads.push({ url, method: init?.method ?? "GET" });
+    const body = {
+      id: PDF_ID,
+      fileName: FILE_NAME,
+      pageCount: PAGE_COUNT,
+      fullText: FULL_TEXT,
+    };
+    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+  };
+  return { uploads, fetchFn };
+}
+
+async function chooseAPdf(thumbnail: Blob | null) {
+  const { uploads, fetchFn } = uploadStub();
+  vi.stubGlobal("fetch", fetchFn);
+
+  // The cache is built here rather than inside the provider so the test can
+  // read what the upload filed in it.
+  const cache: Cache = new Map();
+  const opened: string[] = [];
+
+  const { container } = render(
+    <SWRConfig value={{ provider: () => cache }}>
+      <FileSelector
+        onOpened={(id) => opened.push(id)}
+        extract={async () => extraction(thumbnail)}
+      />
+    </SWRConfig>,
+  );
+
+  // The button is the affordance a reader sees; the input it clicks is hidden
+  // and carries no name of its own, so it is reached by type.
+  expect(screen.getByRole("button", { name: "PDFを開く" })).toBeInTheDocument();
+  await userEvent.upload(
+    container.querySelector<HTMLInputElement>('input[type="file"]')!,
+    new File(["%PDF-1.7"], FILE_NAME, { type: "application/pdf" }),
+  );
+
+  return { cache, opened, uploads };
+}
+
+describe("FileSelector", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("files the uploaded book under the key the reader opens it by", async () => {
+    const { cache, opened } = await chooseAPdf(COVER);
+
+    await waitFor(() => expect(opened).toStrictEqual([PDF_ID]));
+    expect(cache.get(bookKey(PDF_ID))?.data).toStrictEqual({
+      id: PDF_ID,
+      fileName: FILE_NAME,
+      pageCount: PAGE_COUNT,
+      hasThumbnail: true,
+      selections: [],
+    } satisfies BookDetail);
+  });
+
+  it("records that a book whose cover could not be rendered has none", async () => {
+    const { cache, opened } = await chooseAPdf(null);
+
+    await waitFor(() => expect(opened).toStrictEqual([PDF_ID]));
+    expect(cache.get(bookKey(PDF_ID))?.data).toStrictEqual({
+      id: PDF_ID,
+      fileName: FILE_NAME,
+      pageCount: PAGE_COUNT,
+      hasThumbnail: false,
+      selections: [],
+    } satisfies BookDetail);
+  });
+
+  it("sends the chosen file to the endpoint that stores books", async () => {
+    const { uploads } = await chooseAPdf(COVER);
+
+    await waitFor(() => expect(uploads).toStrictEqual([{ url: "/api/pdf/open", method: "POST" }]));
+  });
+});

--- a/src/front/components/PdfViewer/FileSelector.tsx
+++ b/src/front/components/PdfViewer/FileSelector.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 import { useSWRConfig } from "swr";
-import { extractPdfData } from "../../lib/pdfLoader";
+import { extractPdfData, type ExtractedPdfData } from "../../lib/pdfLoader";
 import { fetcher } from "../../lib/fetcher";
 import { bookKey } from "../../hooks/useBook";
 import { pdfMetadataSchema, type BookDetail } from "../../../shared/schemas/book";
@@ -10,9 +10,16 @@ interface FileSelectorProps {
   onOpened?: (pdfId: string) => void;
   label?: string;
   className?: string;
+  /** Reads the text and cover out of the chosen file; injectable for tests. */
+  extract?: (file: File) => Promise<ExtractedPdfData>;
 }
 
-export function FileSelector({ onOpened, label = "PDFを開く", className }: FileSelectorProps) {
+export function FileSelector({
+  onOpened,
+  label = "PDFを開く",
+  className,
+  extract = extractPdfData,
+}: FileSelectorProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const { mutate } = useSWRConfig();
 
@@ -22,7 +29,7 @@ export function FileSelector({ onOpened, label = "PDFを開く", className }: Fi
 
     try {
       // Extract text and render the cover client-side (pdf.js)
-      const extracted = await extractPdfData(file);
+      const extracted = await extract(file);
 
       // Send as multipart/form-data (avoids base64 overhead)
       const formData = new FormData();
@@ -41,8 +48,12 @@ export function FileSelector({ onOpened, label = "PDFを開く", className }: Fi
       // The upload already answered with everything the reader needs to open
       // the book, so hand it to the cache the reader reads from. Without this
       // the reader would show an empty viewer while it asked for the very
-      // thing that was just sent. A fresh highlight list is right: the book
-      // was uploaded, not annotated.
+      // thing that was just sent.
+      //
+      // The highlight list starts empty because the upload does not report
+      // one. Opening a book that was annotated before therefore shows its
+      // highlights a moment late, when the reader's own read of the book
+      // lands on top of this entry.
       const opened: BookDetail = {
         id: result.id,
         fileName: result.fileName,

--- a/src/front/components/PdfViewer/FileSelector.tsx
+++ b/src/front/components/PdfViewer/FileSelector.tsx
@@ -1,9 +1,9 @@
 import { useRef } from "react";
-import { useAtom } from "jotai";
-import { pdfDocAtom, pdfStatusAtom, pdfErrorAtom } from "../../atoms/pdfAtom";
+import { useSWRConfig } from "swr";
 import { extractPdfData } from "../../lib/pdfLoader";
 import { fetcher } from "../../lib/fetcher";
-import { pdfMetadataSchema } from "../../../shared/schemas/book";
+import { bookKey } from "../../hooks/useBook";
+import { pdfMetadataSchema, type BookDetail } from "../../../shared/schemas/book";
 
 interface FileSelectorProps {
   /** Called with the book id once the upload finished, so the caller can navigate. */
@@ -14,16 +14,11 @@ interface FileSelectorProps {
 
 export function FileSelector({ onOpened, label = "PDFを開く", className }: FileSelectorProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [, setPdfDoc] = useAtom(pdfDocAtom);
-  const [, setPdfStatus] = useAtom(pdfStatusAtom);
-  const [, setPdfError] = useAtom(pdfErrorAtom);
+  const { mutate } = useSWRConfig();
 
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-
-    setPdfStatus("loading");
-    setPdfError(null);
 
     try {
       // Extract text and render the cover client-side (pdf.js)
@@ -43,16 +38,23 @@ export function FileSelector({ onOpened, label = "PDFを開く", className }: Fi
         body: formData,
       });
 
-      setPdfDoc({
+      // The upload already answered with everything the reader needs to open
+      // the book, so hand it to the cache the reader reads from. Without this
+      // the reader would show an empty viewer while it asked for the very
+      // thing that was just sent. A fresh highlight list is right: the book
+      // was uploaded, not annotated.
+      const opened: BookDetail = {
         id: result.id,
         fileName: result.fileName,
         pageCount: result.pageCount,
-      });
-      setPdfStatus("ready");
+        hasThumbnail: extracted.thumbnail !== null,
+        selections: [],
+      };
+      await mutate(bookKey(result.id), opened, { revalidate: false });
+
       onOpened?.(result.id);
     } catch (err) {
-      setPdfError(err instanceof Error ? err.message : "Failed to load PDF");
-      setPdfStatus("error");
+      console.error("Failed to open the PDF:", err);
     } finally {
       // Allow selecting the same file again
       e.target.value = "";

--- a/src/front/components/PdfViewer/PdfViewer.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.tsx
@@ -15,14 +15,14 @@ import {
   selectionsAtom,
   useWebSearchAtom,
   type ActiveSelection,
-  type SelectionHighlight,
 } from "../../atoms/chatAtom";
+import type { SelectionRect, SelectionHighlight } from "../../../shared/schemas/selection";
 import { PdfPage } from "./PdfPage";
 import { PdfOutline } from "./PdfOutline";
 import { SelectionPopover } from "./SelectionPopover";
 import { HighlightOverlay } from "./HighlightOverlay";
 import { getSelectionFromTextLayer } from "../../lib/pdfTextMatcher";
-import { selectionOnPage, type PageSelection, type SelectionRect } from "../../lib/selectionRects";
+import { selectionOnPage, type PageSelection } from "../../lib/selectionRects";
 import { usePdfDocument } from "../../hooks/usePdfDocument";
 import { usePdfOutline } from "../../hooks/usePdfOutline";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";

--- a/src/front/components/PdfViewer/PdfViewer.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.tsx
@@ -2,12 +2,7 @@
 import { useRef, useState, useCallback, useEffect } from "react";
 import { useAtomValue, useAtom } from "jotai";
 import { currentPageAtom, pageViewportAtom, outlineOpenAtom } from "../../atoms/pdfAtom";
-import {
-  activeSelectionAtom,
-  chatMessagesAtom,
-  useWebSearchAtom,
-  type ActiveSelection,
-} from "../../atoms/chatAtom";
+import { activeSelectionAtom, chatMessagesAtom, type ActiveSelection } from "../../atoms/chatAtom";
 import type { SelectionRect } from "../../../shared/schemas/selection";
 import type { BookDetail } from "../../../shared/schemas/book";
 import { PdfPage } from "./PdfPage";
@@ -19,6 +14,7 @@ import { selectionOnPage, type PageSelection } from "../../lib/selectionRects";
 import { usePdfDocument } from "../../hooks/usePdfDocument";
 import { usePdfOutline } from "../../hooks/usePdfOutline";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
+import { useWebSearchAtom } from "../../atoms/settingsAtom";
 import { useChatStream } from "../../hooks/useChatStream";
 import { useHighlights } from "../../hooks/useHighlights";
 import type { ViewerAction } from "../../lib/keybindings";

--- a/src/front/components/PdfViewer/PdfViewer.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.tsx
@@ -1,14 +1,7 @@
 // oxlint-disable-next-line no-restricted-imports -- 表示幅の ResizeObserver 購読、ページ遷移時のスクロール位置リセット、document への selectionchange 購読に必要
 import { useRef, useState, useCallback, useEffect } from "react";
 import { useAtomValue, useAtom } from "jotai";
-import {
-  pdfDocAtom,
-  pdfStatusAtom,
-  pdfErrorAtom,
-  currentPageAtom,
-  pageViewportAtom,
-  outlineOpenAtom,
-} from "../../atoms/pdfAtom";
+import { currentPageAtom, pageViewportAtom, outlineOpenAtom } from "../../atoms/pdfAtom";
 import {
   activeSelectionAtom,
   chatMessagesAtom,
@@ -16,6 +9,7 @@ import {
   type ActiveSelection,
 } from "../../atoms/chatAtom";
 import type { SelectionRect } from "../../../shared/schemas/selection";
+import type { BookDetail } from "../../../shared/schemas/book";
 import { PdfPage } from "./PdfPage";
 import { PdfOutline } from "./PdfOutline";
 import { SelectionPopover } from "./SelectionPopover";
@@ -32,16 +26,17 @@ import { fetcher } from "../../lib/fetcher";
 import { createdSelectionSchema } from "../../../shared/schemas/selection";
 
 interface PdfViewerProps {
+  /** The book being read, or nothing while it is still being read in. */
+  book: BookDetail | undefined;
+  /** Why the book could not be read, if it could not. */
+  bookError: Error | undefined;
   onSelectionClick: (selection: ActiveSelection) => void;
 }
 
 /** How far j/k move the page, in pixels. A few lines, like vim's line scroll. */
 const SCROLL_STEP = 80;
 
-export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
-  const pdfDoc = useAtomValue(pdfDocAtom);
-  const status = useAtomValue(pdfStatusAtom);
-  const error = useAtomValue(pdfErrorAtom);
+export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps) {
   const [currentPage, setCurrentPage] = useAtom(currentPageAtom);
   const [, setActiveSelection] = useAtom(activeSelectionAtom);
   const [, setChatMessages] = useAtom(chatMessagesAtom);
@@ -67,12 +62,12 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
 
   const [outlineOpen, setOutlineOpen] = useAtom(outlineOpenAtom);
 
-  const { highlights, addHighlight } = useHighlights(pdfDoc?.id);
-  const { pdfDocument } = usePdfDocument(pdfDoc);
+  const { highlights, addHighlight } = useHighlights(book?.id);
+  const { pdfDocument } = usePdfDocument(book);
   const { outline } = usePdfOutline(pdfDocument);
   const { sendMessage } = useChatStream();
 
-  const pageCount = pdfDoc?.pageCount ?? 1;
+  const pageCount = book?.pageCount ?? 1;
   const handleShortcut = useCallback(
     (action: ViewerAction) => {
       switch (action) {
@@ -204,25 +199,21 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
 
   const handlePopoverSubmit = useCallback(
     async (question: string) => {
-      if (!popoverState || !pdfDoc) return;
+      if (!popoverState || !book) return;
       setPopoverState(null);
 
       try {
-        const selection = await fetcher(
-          `/api/pdf/${pdfDoc.id}/selections`,
-          createdSelectionSchema,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              selectedText: popoverState.selectedText,
-              pageNumber: popoverState.selectionPosition.pageNumber,
-              // The rest of the measurement (the text offsets the passage was
-              // found at) is stripped by the endpoint.
-              positionData: popoverState.selectionPosition,
-            }),
-          },
-        );
+        const selection = await fetcher(`/api/pdf/${book.id}/selections`, createdSelectionSchema, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            selectedText: popoverState.selectedText,
+            pageNumber: popoverState.selectionPosition.pageNumber,
+            // The rest of the measurement (the text offsets the passage was
+            // found at) is stripped by the endpoint.
+            positionData: popoverState.selectionPosition,
+          }),
+        });
 
         addHighlight(selection);
 
@@ -235,14 +226,14 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
           pageNumber: selection.pageNumber,
         });
         setChatMessages([]);
-        await sendMessage(pdfDoc.id, selection.id, question, useWebSearch);
+        await sendMessage(book.id, selection.id, question, useWebSearch);
       } catch (err) {
         console.error("Failed to create selection:", err);
       }
     },
     [
       popoverState,
-      pdfDoc,
+      book,
       addHighlight,
       useWebSearch,
       setActiveSelection,
@@ -275,23 +266,17 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
 
   return (
     <div className="flex flex-col h-full bg-gray-100" onMouseUp={handleMouseUp}>
-      {status === "loading" && (
+      {bookError ? (
+        <div className="flex items-center justify-center flex-1">
+          <div className="text-red-500 text-lg">エラーが発生しました: {bookError.message}</div>
+        </div>
+      ) : null}
+
+      {!book && !bookError ? (
         <div className="flex items-center justify-center flex-1">
           <div className="text-gray-500 text-lg">PDFを読み込み中...</div>
         </div>
-      )}
-
-      {status === "error" && (
-        <div className="flex items-center justify-center flex-1">
-          <div className="text-red-500 text-lg">エラーが発生しました: {error}</div>
-        </div>
-      )}
-
-      {status === "idle" && !pdfDoc && (
-        <div className="flex items-center justify-center flex-1">
-          <div className="text-gray-400 text-lg">PDFファイルを選択してください</div>
-        </div>
-      )}
+      ) : null}
 
       {pdfDocument && (
         <div className="flex min-h-0 flex-1">
@@ -346,7 +331,7 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
               )}
             </div>
 
-            {pdfDoc && (
+            {book && (
               <div className="flex items-center justify-center gap-4 py-4">
                 <button
                   type="button"
@@ -365,12 +350,12 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
                   前へ
                 </button>
                 <span className="text-sm text-gray-600">
-                  {currentPage} / {pdfDoc.pageCount}
+                  {currentPage} / {book.pageCount}
                 </span>
                 <button
                   type="button"
-                  onClick={() => setCurrentPage(Math.min(pdfDoc.pageCount, currentPage + 1))}
-                  disabled={currentPage >= pdfDoc.pageCount}
+                  onClick={() => setCurrentPage(Math.min(book.pageCount, currentPage + 1))}
+                  disabled={currentPage >= book.pageCount}
                   className="px-3 py-1 bg-white border rounded disabled:opacity-30 cursor-pointer"
                 >
                   次へ

--- a/src/front/components/PdfViewer/PdfViewer.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.tsx
@@ -1,4 +1,4 @@
-// oxlint-disable-next-line no-restricted-imports -- 本の切り替えに合わせたハイライト読み直し、表示幅の ResizeObserver 購読、ページ遷移時のスクロール位置リセットに必要
+// oxlint-disable-next-line no-restricted-imports -- 表示幅の ResizeObserver 購読、ページ遷移時のスクロール位置リセット、document への selectionchange 購読に必要
 import { useRef, useState, useCallback, useEffect } from "react";
 import { useAtomValue, useAtom } from "jotai";
 import {
@@ -12,11 +12,10 @@ import {
 import {
   activeSelectionAtom,
   chatMessagesAtom,
-  selectionsAtom,
   useWebSearchAtom,
   type ActiveSelection,
 } from "../../atoms/chatAtom";
-import type { SelectionRect, SelectionHighlight } from "../../../shared/schemas/selection";
+import type { SelectionRect } from "../../../shared/schemas/selection";
 import { PdfPage } from "./PdfPage";
 import { PdfOutline } from "./PdfOutline";
 import { SelectionPopover } from "./SelectionPopover";
@@ -30,35 +29,14 @@ import { useChatStream } from "../../hooks/useChatStream";
 import { useHighlights } from "../../hooks/useHighlights";
 import type { ViewerAction } from "../../lib/keybindings";
 import { fetcher } from "../../lib/fetcher";
-import { bookDetailSchema } from "../../../shared/schemas/book";
 import { createdSelectionSchema } from "../../../shared/schemas/selection";
 
 interface PdfViewerProps {
   onSelectionClick: (selection: ActiveSelection) => void;
 }
 
-const HIGHLIGHT_COLORS = [
-  "#FFEB3B",
-  "#FF9800",
-  "#4CAF50",
-  "#2196F3",
-  "#9C27B0",
-  "#F44336",
-  "#00BCD4",
-  "#FF5722",
-];
-
 /** How far j/k move the page, in pixels. A few lines, like vim's line scroll. */
 const SCROLL_STEP = 80;
-
-/** Books saved before highlights carried a colour fall back to the palette. */
-async function loadSelections(pdfId: string): Promise<SelectionHighlight[]> {
-  const data = await fetcher(`/api/pdf/${pdfId}`, bookDetailSchema);
-  return data.selections.map((selection, i) => ({
-    ...selection,
-    color: selection.color || HIGHLIGHT_COLORS[i % HIGHLIGHT_COLORS.length],
-  }));
-}
 
 export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
   const pdfDoc = useAtomValue(pdfDocAtom);
@@ -84,13 +62,12 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
     };
   } | null>(null);
 
-  const [highlights, setHighlights] = useAtom(selectionsAtom);
   const [contentWidth, setContentWidth] = useState(0);
   const [liveSelection, setLiveSelection] = useState<PageSelection | null>(null);
 
   const [outlineOpen, setOutlineOpen] = useAtom(outlineOpenAtom);
 
-  useHighlights(pdfDoc, loadSelections);
+  const { highlights, addHighlight } = useHighlights(pdfDoc?.id);
   const { pdfDocument } = usePdfDocument(pdfDoc);
   const { outline } = usePdfOutline(pdfDocument);
   const { sendMessage } = useChatStream();
@@ -247,19 +224,7 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
           },
         );
 
-        // Add highlight
-        const colorIdx = highlights.length % HIGHLIGHT_COLORS.length;
-        setHighlights((prev) => [
-          ...prev,
-          {
-            id: selection.id,
-            selectedText: selection.selectedText,
-            pageNumber: selection.pageNumber,
-            positionData: selection.positionData,
-            color: HIGHLIGHT_COLORS[colorIdx],
-            createdAt: selection.createdAt,
-          },
-        ]);
+        addHighlight(selection);
 
         // Open the chat for this selection, then stream the answer into it.
         // Going through sendMessage is what shows the question immediately and
@@ -278,7 +243,7 @@ export function PdfViewer({ onSelectionClick }: PdfViewerProps) {
     [
       popoverState,
       pdfDoc,
-      highlights.length,
+      addHighlight,
       useWebSearch,
       setActiveSelection,
       setChatMessages,

--- a/src/front/components/SettingsMenu.test.tsx
+++ b/src/front/components/SettingsMenu.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider, createStore } from "jotai";
 import { SettingsMenu } from "./SettingsMenu";
-import { useWebSearchAtom } from "../atoms/chatAtom";
+import { useWebSearchAtom } from "../atoms/settingsAtom";
 
 function renderMenu() {
   const store = createStore();

--- a/src/front/components/SettingsMenu.tsx
+++ b/src/front/components/SettingsMenu.tsx
@@ -2,7 +2,7 @@
 import { useState, useRef, useEffect } from "react";
 import { useAtom } from "jotai";
 import { keybindingModeAtom } from "../atoms/settingsAtom";
-import { useWebSearchAtom } from "../atoms/chatAtom";
+import { useWebSearchAtom } from "../atoms/settingsAtom";
 import { KEYBINDING_HELP, type KeybindingMode } from "../lib/keybindings";
 
 const MODE_LABELS: Record<KeybindingMode, string> = {

--- a/src/front/hooks/useBook.ts
+++ b/src/front/hooks/useBook.ts
@@ -1,0 +1,23 @@
+import useSWR from "swr";
+import { fetcher } from "../lib/fetcher";
+import { bookDetailSchema, type BookDetail } from "../../shared/schemas/book";
+
+/** Reads one book and the highlights made in it. */
+export type LoadBook = (pdfId: string) => Promise<BookDetail>;
+
+/**
+ * Cache key of one book.
+ *
+ * The reader, the viewer and the chat panel all address this key, so the book
+ * is read once however many of them are on screen, a highlight added to it
+ * shows in all of them at once, and an upload can fill it in advance so that
+ * opening the book it just wrote does not wait for a round trip.
+ */
+export const bookKey = (pdfId: string) => `/api/pdf/${pdfId}`;
+
+export const fetchBook: LoadBook = (pdfId) => fetcher(bookKey(pdfId), bookDetailSchema);
+
+/** The book with the given id, or nothing at all while no book is open. */
+export function useBook(pdfId: string | undefined, loadBook: LoadBook = fetchBook) {
+  return useSWR(pdfId ? bookKey(pdfId) : null, () => loadBook(pdfId!));
+}

--- a/src/front/hooks/useBook.ts
+++ b/src/front/hooks/useBook.ts
@@ -13,11 +13,18 @@ export type LoadBook = (pdfId: string) => Promise<BookDetail>;
  * shows in all of them at once, and an upload can fill it in advance so that
  * opening the book it just wrote does not wait for a round trip.
  */
-export const bookKey = (pdfId: string) => `/api/pdf/${pdfId}`;
+const BOOK_PATH = "/api/pdf/";
+
+export const bookKey = (pdfId: string) => `${BOOK_PATH}${pdfId}`;
+
+/** The inverse of `bookKey`, so the fetcher reads the id off the key it is given. */
+const bookIdFromKey = (key: string) => key.slice(BOOK_PATH.length);
 
 export const fetchBook: LoadBook = (pdfId) => fetcher(bookKey(pdfId), bookDetailSchema);
 
 /** The book with the given id, or nothing at all while no book is open. */
 export function useBook(pdfId: string | undefined, loadBook: LoadBook = fetchBook) {
-  return useSWR(pdfId ? bookKey(pdfId) : null, () => loadBook(pdfId!));
+  // The id comes back out of the key rather than off the closure, so what is
+  // fetched cannot drift from what the result is filed under.
+  return useSWR(pdfId ? bookKey(pdfId) : null, (key: string) => loadBook(bookIdFromKey(key)));
 }

--- a/src/front/hooks/useChatStream.test.tsx
+++ b/src/front/hooks/useChatStream.test.tsx
@@ -18,7 +18,7 @@ import {
   tokenEvent,
 } from "../../test/streamingFetchStub";
 import { ApiError } from "../lib/fetcher";
-import type { Citation } from "../atoms/chatAtom";
+import type { Citation } from "../../shared/schemas/citation";
 
 const QUESTION = "Durable Objects とは?";
 

--- a/src/front/hooks/useChatStream.ts
+++ b/src/front/hooks/useChatStream.ts
@@ -6,11 +6,11 @@ import {
   isStreamingAtom,
   chatAbortControllerAtom,
   abortChatStreamAtom,
-  type ChatMessage,
-  type Citation,
 } from "../atoms/chatAtom";
 import { createSseParser } from "../lib/sseParser";
 import { ApiError } from "../lib/fetcher";
+import type { ChatMessage } from "../../shared/schemas/chat";
+import type { Citation } from "../../shared/schemas/citation";
 import { chatSseEventSchema } from "../../shared/schemas/sse";
 
 /** fetch reports an abort with a DOMException, which does not extend Error. */

--- a/src/front/hooks/useHighlights.test.tsx
+++ b/src/front/hooks/useHighlights.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vite-plus/test";
 import { renderHook, act } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { useHighlights, type LoadBook } from "./useHighlights";
+import { useHighlights } from "./useHighlights";
+import type { LoadBook } from "./useBook";
 import { SwrTestCache } from "../../test/swrTestCache";
 import type { BookDetail } from "../../shared/schemas/book";
 import type { CreatedSelection, SelectionHighlight } from "../../shared/schemas/selection";

--- a/src/front/hooks/useHighlights.test.tsx
+++ b/src/front/hooks/useHighlights.test.tsx
@@ -3,7 +3,8 @@ import { renderHook, act } from "@testing-library/react";
 import { Provider, createStore } from "jotai";
 import type { ReactNode } from "react";
 import { useHighlights, type LoadSelections } from "./useHighlights";
-import { selectionsAtom, type SelectionHighlight } from "../atoms/chatAtom";
+import { selectionsAtom } from "../atoms/chatAtom";
+import type { SelectionHighlight } from "../../shared/schemas/selection";
 import type { PdfDoc } from "../atoms/pdfAtom";
 
 const BOOK_A: PdfDoc = { id: "bookA", fileName: "Workers.pdf", pageCount: 209 };

--- a/src/front/hooks/useHighlights.test.tsx
+++ b/src/front/hooks/useHighlights.test.tsx
@@ -1,95 +1,172 @@
 import { describe, it, expect } from "vite-plus/test";
 import { renderHook, act } from "@testing-library/react";
-import { Provider, createStore } from "jotai";
 import type { ReactNode } from "react";
-import { useHighlights, type LoadSelections } from "./useHighlights";
-import { selectionsAtom } from "../atoms/chatAtom";
-import type { SelectionHighlight } from "../../shared/schemas/selection";
-import type { PdfDoc } from "../atoms/pdfAtom";
+import { useHighlights, type LoadBook } from "./useHighlights";
+import { SwrTestCache } from "../../test/swrTestCache";
+import type { BookDetail } from "../../shared/schemas/book";
+import type { CreatedSelection, SelectionHighlight } from "../../shared/schemas/selection";
 
-const BOOK_A: PdfDoc = { id: "bookA", fileName: "Workers.pdf", pageCount: 209 };
-const BOOK_B: PdfDoc = { id: "bookB", fileName: "Durable Objects.pdf", pageCount: 120 };
+const BOOK_A_ID = "bookA";
+const BOOK_B_ID = "bookB";
 
-function highlight(id: string, selectedText: string): SelectionHighlight {
+function highlight(overrides: Partial<SelectionHighlight> = {}): SelectionHighlight {
   return {
-    id,
-    selectedText,
+    id: "a1",
+    selectedText: "エッジはサーバーレス実行基盤です。",
     pageNumber: 1,
     positionData: { rects: [{ x: 0, y: 0, width: 10, height: 10 }] },
     color: "#FFEB3B",
     createdAt: "2026-08-01T10:00:00.000Z",
+    ...overrides,
   };
 }
 
-const A_HIGHLIGHTS = [highlight("a1", "エッジはサーバーレス実行基盤です。")];
-const B_HIGHLIGHTS = [highlight("b1", "Durable Objects は処理を集約します。")];
+function book(id: string, selections: SelectionHighlight[]): BookDetail {
+  return { id, fileName: `${id}.pdf`, pageCount: 209, hasThumbnail: true, selections };
+}
+
+const A_HIGHLIGHTS = [highlight()];
+const B_HIGHLIGHTS = [
+  highlight({ id: "b1", selectedText: "Durable Objects は処理を集約します。", color: "#2196F3" }),
+];
 
 /** A loader the test finishes by hand, so the window before it lands is observable. */
 function pausableLoader() {
-  const pending = new Map<string, (highlights: SelectionHighlight[]) => void>();
-  const load: LoadSelections = (pdfId) =>
-    new Promise((resolve) => {
+  const pending = new Map<string, (book: BookDetail) => void>();
+  const calls: string[] = [];
+  const load: LoadBook = (pdfId) => {
+    calls.push(pdfId);
+    return new Promise((resolve) => {
       pending.set(pdfId, resolve);
     });
+  };
 
   return {
     load,
-    finish: async (pdfId: string, highlights: SelectionHighlight[]) => {
+    calls,
+    finish: async (pdfId: string, selections: SelectionHighlight[]) => {
       await act(async () => {
-        pending.get(pdfId)!(highlights);
+        pending.get(pdfId)!(book(pdfId, selections));
       });
     },
   };
 }
 
-function renderForBook(book: PdfDoc, load: LoadSelections) {
-  const store = createStore();
+function renderForBook(pdfId: string, load: LoadBook) {
   const wrapper = ({ children }: { children: ReactNode }) => (
-    <Provider store={store}>{children}</Provider>
+    <SwrTestCache>{children}</SwrTestCache>
   );
 
-  const view = renderHook(({ pdfDoc }: { pdfDoc: PdfDoc }) => useHighlights(pdfDoc, load), {
+  return renderHook(({ id }: { id: string }) => useHighlights(id, load), {
     wrapper,
-    initialProps: { pdfDoc: book },
+    initialProps: { id: pdfId },
   });
-  return { store, view };
 }
 
 describe("useHighlights", () => {
-  it("shares the highlights of the book that is open", async () => {
+  it("shows the highlights of the book that is open", async () => {
     const { load, finish } = pausableLoader();
-    const { store } = renderForBook(BOOK_A, load);
+    const view = renderForBook(BOOK_A_ID, load);
 
-    await finish(BOOK_A.id, A_HIGHLIGHTS);
+    await finish(BOOK_A_ID, A_HIGHLIGHTS);
 
-    expect(store.get(selectionsAtom)).toEqual(A_HIGHLIGHTS);
+    expect(view.result.current.highlights).toStrictEqual(A_HIGHLIGHTS);
   });
 
   it("ignores a book's highlights that land after the reader moved on", async () => {
     const { load, finish } = pausableLoader();
-    const { store, view } = renderForBook(BOOK_A, load);
+    const view = renderForBook(BOOK_A_ID, load);
 
-    view.rerender({ pdfDoc: BOOK_B });
-    await finish(BOOK_A.id, A_HIGHLIGHTS);
+    view.rerender({ id: BOOK_B_ID });
+    await finish(BOOK_A_ID, A_HIGHLIGHTS);
 
-    expect(store.get(selectionsAtom)).toEqual([]);
+    expect(view.result.current.highlights).toStrictEqual([]);
 
-    await finish(BOOK_B.id, B_HIGHLIGHTS);
+    await finish(BOOK_B_ID, B_HIGHLIGHTS);
 
-    expect(store.get(selectionsAtom)).toEqual(B_HIGHLIGHTS);
+    expect(view.result.current.highlights).toStrictEqual(B_HIGHLIGHTS);
   });
 
   it("drops the previous book's highlights while the next book is still loading", async () => {
     const { load, finish } = pausableLoader();
-    const { store, view } = renderForBook(BOOK_A, load);
-    await finish(BOOK_A.id, A_HIGHLIGHTS);
+    const view = renderForBook(BOOK_A_ID, load);
+    await finish(BOOK_A_ID, A_HIGHLIGHTS);
 
-    view.rerender({ pdfDoc: BOOK_B });
+    view.rerender({ id: BOOK_B_ID });
 
-    expect(store.get(selectionsAtom)).toEqual([]);
+    expect(view.result.current.highlights).toStrictEqual([]);
 
-    await finish(BOOK_B.id, B_HIGHLIGHTS);
+    await finish(BOOK_B_ID, B_HIGHLIGHTS);
 
-    expect(store.get(selectionsAtom)).toEqual(B_HIGHLIGHTS);
+    expect(view.result.current.highlights).toStrictEqual(B_HIGHLIGHTS);
+  });
+
+  it("reads the book once when the viewer and the chat panel both ask for its highlights", async () => {
+    const { load, calls, finish } = pausableLoader();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SwrTestCache>{children}</SwrTestCache>
+    );
+    const view = renderHook(
+      () => ({ viewer: useHighlights(BOOK_A_ID, load), panel: useHighlights(BOOK_A_ID, load) }),
+      { wrapper },
+    );
+
+    await finish(BOOK_A_ID, A_HIGHLIGHTS);
+
+    expect(calls).toStrictEqual([BOOK_A_ID]);
+    expect(view.result.current.viewer.highlights).toStrictEqual(A_HIGHLIGHTS);
+    expect(view.result.current.panel.highlights).toStrictEqual(A_HIGHLIGHTS);
+  });
+
+  it("shows a highlight the viewer just made to the chat panel without re-reading the book", async () => {
+    const { load, calls, finish } = pausableLoader();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SwrTestCache>{children}</SwrTestCache>
+    );
+    const view = renderHook(
+      () => ({ viewer: useHighlights(BOOK_A_ID, load), panel: useHighlights(BOOK_A_ID, load) }),
+      { wrapper },
+    );
+    await finish(BOOK_A_ID, A_HIGHLIGHTS);
+
+    const created: CreatedSelection = {
+      id: "a2",
+      selectedText: "Workers はリクエストごとに分離されます。",
+      pageNumber: 12,
+      positionData: { rects: [] },
+      createdAt: "2026-08-03T10:00:00.000Z",
+    };
+    await act(async () => {
+      view.result.current.viewer.addHighlight(created);
+    });
+
+    expect(view.result.current.panel.highlights).toStrictEqual([
+      ...A_HIGHLIGHTS,
+      { ...created, color: "#FF9800" },
+    ]);
+    expect(calls).toStrictEqual([BOOK_A_ID]);
+  });
+
+  it("gives a highlight saved before colours existed one from the palette", async () => {
+    const { load, finish } = pausableLoader();
+    const view = renderForBook(BOOK_A_ID, load);
+
+    await finish(BOOK_A_ID, [highlight({ color: "" }), highlight({ id: "a2", color: "" })]);
+
+    expect(view.result.current.highlights.map((h) => h.color)).toStrictEqual([
+      "#FFEB3B",
+      "#FF9800",
+    ]);
+  });
+
+  it("has no highlights to show before a book is open", () => {
+    const { load, calls } = pausableLoader();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SwrTestCache>{children}</SwrTestCache>
+    );
+    const view = renderHook(() => useHighlights(undefined, load), { wrapper });
+
+    expect(view.result.current.highlights).toStrictEqual([]);
+    expect(calls).toStrictEqual([]);
   });
 });

--- a/src/front/hooks/useHighlights.ts
+++ b/src/front/hooks/useHighlights.ts
@@ -1,29 +1,63 @@
-// oxlint-disable-next-line no-restricted-imports -- 開いている本に合わせてハイライトを読み直すために必要
-import { useEffect } from "react";
-import { useSetAtom } from "jotai";
-import { selectionsAtom } from "../atoms/chatAtom";
-import type { SelectionHighlight } from "../../shared/schemas/selection";
-import type { PdfDoc } from "../atoms/pdfAtom";
+import { useCallback, useMemo } from "react";
+import useSWR from "swr";
+import { fetcher } from "../lib/fetcher";
+import { bookDetailSchema, type BookDetail } from "../../shared/schemas/book";
+import type { CreatedSelection, SelectionHighlight } from "../../shared/schemas/selection";
 
-export type LoadSelections = (pdfId: string) => Promise<SelectionHighlight[]>;
+/** Reads one book and the highlights made in it. */
+export type LoadBook = (pdfId: string) => Promise<BookDetail>;
 
-/** Keeps the shared highlights in step with the book currently open. */
-export function useHighlights(pdfDoc: PdfDoc | null, loadSelections: LoadSelections) {
-  const setSelections = useSetAtom(selectionsAtom);
+/**
+ * Cache key of one book. The reader, the viewer and the chat panel all address
+ * this key, so a book is read once however many of them are on screen, and a
+ * highlight added to it shows up in all of them at once.
+ */
+export const bookKey = (pdfId: string) => `/api/pdf/${pdfId}`;
 
-  useEffect(() => {
-    if (!pdfDoc) return;
-    let cancelled = false;
-    // The atom outlives the viewer, so drop the previous book's highlights
-    // instead of showing them over the new one until the load lands.
-    setSelections([]);
-    loadSelections(pdfDoc.id)
-      .then((highlights) => {
-        if (!cancelled) setSelections(highlights);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [pdfDoc, loadSelections, setSelections]);
+export const fetchBook: LoadBook = (pdfId) => fetcher(bookKey(pdfId), bookDetailSchema);
+
+/** Books saved before highlights carried a colour fall back to the palette. */
+const HIGHLIGHT_COLORS = [
+  "#FFEB3B",
+  "#FF9800",
+  "#4CAF50",
+  "#2196F3",
+  "#9C27B0",
+  "#F44336",
+  "#00BCD4",
+  "#FF5722",
+];
+
+const NO_HIGHLIGHTS: SelectionHighlight[] = [];
+
+/** The highlights of the book currently open, and a way to add one. */
+export function useHighlights(pdfId: string | undefined, loadBook: LoadBook = fetchBook) {
+  const { data, mutate } = useSWR(pdfId ? bookKey(pdfId) : null, () => loadBook(pdfId!));
+
+  const highlights = useMemo(
+    () =>
+      data?.selections.map((selection, i) => ({
+        ...selection,
+        color: selection.color || HIGHLIGHT_COLORS[i % HIGHLIGHT_COLORS.length],
+      })) ?? NO_HIGHLIGHTS,
+    [data],
+  );
+
+  /**
+   * Show a highlight the moment it is made. The server has just stored it, so
+   * re-reading the book would only confirm what was sent; the colour is left
+   * for the palette to fill in by position, as it is for every other highlight.
+   */
+  const addHighlight = useCallback(
+    (selection: CreatedSelection) => {
+      void mutate(
+        (book) =>
+          book ? { ...book, selections: [...book.selections, { ...selection, color: "" }] } : book,
+        { revalidate: false },
+      );
+    },
+    [mutate],
+  );
+
+  return { highlights, addHighlight };
 }

--- a/src/front/hooks/useHighlights.ts
+++ b/src/front/hooks/useHighlights.ts
@@ -1,7 +1,8 @@
 // oxlint-disable-next-line no-restricted-imports -- 開いている本に合わせてハイライトを読み直すために必要
 import { useEffect } from "react";
 import { useSetAtom } from "jotai";
-import { selectionsAtom, type SelectionHighlight } from "../atoms/chatAtom";
+import { selectionsAtom } from "../atoms/chatAtom";
+import type { SelectionHighlight } from "../../shared/schemas/selection";
 import type { PdfDoc } from "../atoms/pdfAtom";
 
 export type LoadSelections = (pdfId: string) => Promise<SelectionHighlight[]>;

--- a/src/front/hooks/useHighlights.ts
+++ b/src/front/hooks/useHighlights.ts
@@ -1,20 +1,6 @@
 import { useCallback, useMemo } from "react";
-import useSWR from "swr";
-import { fetcher } from "../lib/fetcher";
-import { bookDetailSchema, type BookDetail } from "../../shared/schemas/book";
+import { useBook, fetchBook, type LoadBook } from "./useBook";
 import type { CreatedSelection, SelectionHighlight } from "../../shared/schemas/selection";
-
-/** Reads one book and the highlights made in it. */
-export type LoadBook = (pdfId: string) => Promise<BookDetail>;
-
-/**
- * Cache key of one book. The reader, the viewer and the chat panel all address
- * this key, so a book is read once however many of them are on screen, and a
- * highlight added to it shows up in all of them at once.
- */
-export const bookKey = (pdfId: string) => `/api/pdf/${pdfId}`;
-
-export const fetchBook: LoadBook = (pdfId) => fetcher(bookKey(pdfId), bookDetailSchema);
 
 /** Books saved before highlights carried a colour fall back to the palette. */
 const HIGHLIGHT_COLORS = [
@@ -32,7 +18,7 @@ const NO_HIGHLIGHTS: SelectionHighlight[] = [];
 
 /** The highlights of the book currently open, and a way to add one. */
 export function useHighlights(pdfId: string | undefined, loadBook: LoadBook = fetchBook) {
-  const { data, mutate } = useSWR(pdfId ? bookKey(pdfId) : null, () => loadBook(pdfId!));
+  const { data, mutate } = useBook(pdfId, loadBook);
 
   const highlights = useMemo(
     () =>

--- a/src/front/hooks/usePdfDocument.test.ts
+++ b/src/front/hooks/usePdfDocument.test.ts
@@ -4,28 +4,60 @@ import { storeCoverIfMissing } from "./usePdfDocument";
 
 const PDF_ID = "01JBOOK";
 
-/** Records what the backfill asked of the API, and answers as the book says. */
-function apiStub(hasThumbnail: boolean) {
-  const calls: { url: string; method: string }[] = [];
+/** Records what the backfill asked of the API. */
+function apiStub() {
+  const calls: { url: string; method: string; body: unknown }[] = [];
   const fetchFn = (url: string, init?: RequestInit) => {
-    calls.push({ url, method: init?.method ?? "GET" });
-    const body = url.endsWith("/thumbnail")
-      ? { stored: true }
-      : { id: PDF_ID, fileName: "Workers.pdf", pageCount: 209, hasThumbnail, selections: [] };
-    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+    calls.push({ url, method: init?.method ?? "GET", body: init?.body });
+    return Promise.resolve(new Response(JSON.stringify({ stored: true }), { status: 200 }));
   };
   return { calls, fetchFn: fetchFn as unknown as typeof fetch };
 }
 
-/** The document is never rendered on the path this test takes. */
+/** The document is only ever handed to the renderer, never read here. */
 const UNRENDERED_DOC = {} as pdfjsTypes.PDFDocumentProxy;
 
+const COVER = new Blob(["webp bytes"], { type: "image/webp" });
+
+const HAS_COVER = true;
+const HAS_NO_COVER = false;
+
 describe("storeCoverIfMissing", () => {
+  it("renders the cover and stores it when the book has none", async () => {
+    const { calls, fetchFn } = apiStub();
+
+    await storeCoverIfMissing(PDF_ID, UNRENDERED_DOC, HAS_NO_COVER, fetchFn, async () => COVER);
+
+    expect(calls).toStrictEqual([
+      { url: `/api/pdf/${PDF_ID}/thumbnail`, method: "PUT", body: COVER },
+    ]);
+  });
+
+  it("hands the renderer the document the reader already has open", async () => {
+    const { fetchFn } = apiStub();
+    const rendered: pdfjsTypes.PDFDocumentProxy[] = [];
+
+    await storeCoverIfMissing(PDF_ID, UNRENDERED_DOC, HAS_NO_COVER, fetchFn, async (doc) => {
+      rendered.push(doc);
+      return COVER;
+    });
+
+    expect(rendered).toStrictEqual([UNRENDERED_DOC]);
+  });
+
   it("leaves a book that already has a cover as it is", async () => {
-    const { calls, fetchFn } = apiStub(true);
+    const { calls, fetchFn } = apiStub();
 
-    await storeCoverIfMissing(PDF_ID, UNRENDERED_DOC, fetchFn);
+    await storeCoverIfMissing(PDF_ID, UNRENDERED_DOC, HAS_COVER, fetchFn, async () => COVER);
 
-    expect(calls).toStrictEqual([{ url: `/api/pdf/${PDF_ID}`, method: "GET" }]);
+    expect(calls).toStrictEqual([]);
+  });
+
+  it("stores nothing when the cover cannot be rendered", async () => {
+    const { calls, fetchFn } = apiStub();
+
+    await storeCoverIfMissing(PDF_ID, UNRENDERED_DOC, HAS_NO_COVER, fetchFn, async () => null);
+
+    expect(calls).toStrictEqual([]);
   });
 });

--- a/src/front/hooks/usePdfDocument.test.ts
+++ b/src/front/hooks/usePdfDocument.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vite-plus/test";
+import type * as pdfjsTypes from "pdfjs-dist";
+import { storeCoverIfMissing } from "./usePdfDocument";
+
+const PDF_ID = "01JBOOK";
+
+/** Records what the backfill asked of the API, and answers as the book says. */
+function apiStub(hasThumbnail: boolean) {
+  const calls: { url: string; method: string }[] = [];
+  const fetchFn = (url: string, init?: RequestInit) => {
+    calls.push({ url, method: init?.method ?? "GET" });
+    const body = url.endsWith("/thumbnail")
+      ? { stored: true }
+      : { id: PDF_ID, fileName: "Workers.pdf", pageCount: 209, hasThumbnail, selections: [] };
+    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+  };
+  return { calls, fetchFn: fetchFn as unknown as typeof fetch };
+}
+
+/** The document is never rendered on the path this test takes. */
+const UNRENDERED_DOC = {} as pdfjsTypes.PDFDocumentProxy;
+
+describe("storeCoverIfMissing", () => {
+  it("leaves a book that already has a cover as it is", async () => {
+    const { calls, fetchFn } = apiStub(true);
+
+    await storeCoverIfMissing(PDF_ID, UNRENDERED_DOC, fetchFn);
+
+    expect(calls).toStrictEqual([{ url: `/api/pdf/${PDF_ID}`, method: "GET" }]);
+  });
+});

--- a/src/front/hooks/usePdfDocument.ts
+++ b/src/front/hooks/usePdfDocument.ts
@@ -2,11 +2,10 @@
 import { useState, useEffect, useRef } from "react";
 import useSWRMutation from "swr/mutation";
 import type * as pdfjsTypes from "pdfjs-dist";
-import type { PdfDoc } from "../atoms/pdfAtom";
 import { pdfjsLib, PDFJS_ASSET_OPTIONS } from "../lib/pdfjsConfig";
 import { renderCoverThumbnail } from "../lib/pdfLoader";
 import { fetcher } from "../lib/fetcher";
-import { bookDetailSchema, thumbnailStoredSchema } from "../../shared/schemas/book";
+import { thumbnailStoredSchema, type BookDetail } from "../../shared/schemas/book";
 
 /** Where a book's cover is written, and the key the write is tracked under. */
 const coverKey = (pdfId: string) => `/api/pdf/${pdfId}/thumbnail`;
@@ -16,19 +15,21 @@ const coverKey = (pdfId: string) => `/api/pdf/${pdfId}/thumbnail`;
  * already holds the rendered document, so generate the cover here and store it
  * once; otherwise those books would stay blank on the shelf forever.
  *
- * A book that already has a cover is left alone, so this costs one read for
- * every book but a write only for the ones that predate covers.
+ * Whether the book has one is passed in rather than read here: the caller is
+ * already holding the book, and asking for it again would be a second request
+ * for something this app has in hand.
  */
 export async function storeCoverIfMissing(
   pdfId: string,
   doc: pdfjsTypes.PDFDocumentProxy,
+  hasThumbnail: boolean,
   fetchFn: typeof fetch,
+  renderCover: (doc: pdfjsTypes.PDFDocumentProxy) => Promise<Blob | null> = renderCoverThumbnail,
 ) {
-  try {
-    const book = await fetcher(`/api/pdf/${pdfId}`, bookDetailSchema, undefined, fetchFn);
-    if (book.hasThumbnail) return;
+  if (hasThumbnail) return;
 
-    const thumbnail = await renderCoverThumbnail(doc);
+  try {
+    const thumbnail = await renderCover(doc);
     if (!thumbnail) return;
 
     await fetcher(
@@ -50,29 +51,38 @@ export async function storeCoverIfMissing(
  * Load the pdfjs-dist PDFDocumentProxy for the given book by fetching the
  * stored PDF binary from the API.
  */
-export function usePdfDocument(pdfDoc: PdfDoc | null, fetchFn: typeof fetch = fetch) {
+export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fetch = fetch) {
   const [pdfDocument, setPdfDocument] = useState<pdfjsTypes.PDFDocumentProxy | null>(null);
   const loadingRef = useRef<string | null>(null);
 
-  // Storing a cover is a write, so it is triggered from the document being
-  // ready rather than being an effect of its own.
+  // Storing a cover is a write, so it goes through a mutation rather than an
+  // effect of its own. It is still triggered from the effect below because the
+  // event it answers to is pdf.js finishing the document — there is no reader
+  // action behind it.
   const { trigger: backfillCover } = useSWRMutation(
-    pdfDoc ? coverKey(pdfDoc.id) : null,
-    (_key: string, { arg }: { arg: { pdfId: string; doc: pdfjsTypes.PDFDocumentProxy } }) =>
-      storeCoverIfMissing(arg.pdfId, arg.doc, fetchFn),
+    book ? coverKey(book.id) : null,
+    (
+      _key: string,
+      {
+        arg,
+      }: {
+        arg: { pdfId: string; doc: pdfjsTypes.PDFDocumentProxy; hasThumbnail: boolean };
+      },
+    ) => storeCoverIfMissing(arg.pdfId, arg.doc, arg.hasThumbnail, fetchFn),
   );
 
   useEffect(() => {
-    if (!pdfDoc) {
+    if (!book) {
       setPdfDocument(null);
       return;
     }
 
     // Don't reload if already loaded for this doc id
-    if (loadingRef.current === pdfDoc.id && pdfDocument) return;
-    loadingRef.current = pdfDoc.id;
+    if (loadingRef.current === book.id && pdfDocument) return;
+    loadingRef.current = book.id;
 
-    const pdfId = pdfDoc.id;
+    const pdfId = book.id;
+    const hasThumbnail = book.hasThumbnail;
     let cancelled = false;
 
     async function loadPdf() {
@@ -92,7 +102,7 @@ export function usePdfDocument(pdfDoc: PdfDoc | null, fetchFn: typeof fetch = fe
         if (cancelled) return;
 
         setPdfDocument(doc);
-        void backfillCover({ pdfId, doc });
+        void backfillCover({ pdfId, doc, hasThumbnail });
       } catch (err) {
         console.error("Failed to load PDF for rendering:", err);
       }
@@ -104,7 +114,7 @@ export function usePdfDocument(pdfDoc: PdfDoc | null, fetchFn: typeof fetch = fe
     return () => {
       cancelled = true;
     };
-  }, [pdfDoc?.id]);
+  }, [book?.id]);
 
   return { pdfDocument };
 }

--- a/src/front/hooks/usePdfDocument.ts
+++ b/src/front/hooks/usePdfDocument.ts
@@ -1,5 +1,6 @@
 // oxlint-disable-next-line no-restricted-imports -- PDF バイナリを取得して pdf.js のドキュメントを構築する初期化処理に必要
 import { useState, useEffect, useRef } from "react";
+import useSWRMutation from "swr/mutation";
 import type * as pdfjsTypes from "pdfjs-dist";
 import type { PdfDoc } from "../atoms/pdfAtom";
 import { pdfjsLib, PDFJS_ASSET_OPTIONS } from "../lib/pdfjsConfig";
@@ -7,12 +8,18 @@ import { renderCoverThumbnail } from "../lib/pdfLoader";
 import { fetcher } from "../lib/fetcher";
 import { bookDetailSchema, thumbnailStoredSchema } from "../../shared/schemas/book";
 
+/** Where a book's cover is written, and the key the write is tracked under. */
+const coverKey = (pdfId: string) => `/api/pdf/${pdfId}/thumbnail`;
+
 /**
  * Books opened before covers existed have no thumbnail in storage. The reader
  * already holds the rendered document, so generate the cover here and store it
  * once; otherwise those books would stay blank on the shelf forever.
+ *
+ * A book that already has a cover is left alone, so this costs one read for
+ * every book but a write only for the ones that predate covers.
  */
-async function backfillCover(
+export async function storeCoverIfMissing(
   pdfId: string,
   doc: pdfjsTypes.PDFDocumentProxy,
   fetchFn: typeof fetch,
@@ -25,7 +32,7 @@ async function backfillCover(
     if (!thumbnail) return;
 
     await fetcher(
-      `/api/pdf/${pdfId}/thumbnail`,
+      coverKey(pdfId),
       thumbnailStoredSchema,
       {
         method: "PUT",
@@ -46,6 +53,14 @@ async function backfillCover(
 export function usePdfDocument(pdfDoc: PdfDoc | null, fetchFn: typeof fetch = fetch) {
   const [pdfDocument, setPdfDocument] = useState<pdfjsTypes.PDFDocumentProxy | null>(null);
   const loadingRef = useRef<string | null>(null);
+
+  // Storing a cover is a write, so it is triggered from the document being
+  // ready rather than being an effect of its own.
+  const { trigger: backfillCover } = useSWRMutation(
+    pdfDoc ? coverKey(pdfDoc.id) : null,
+    (_key: string, { arg }: { arg: { pdfId: string; doc: pdfjsTypes.PDFDocumentProxy } }) =>
+      storeCoverIfMissing(arg.pdfId, arg.doc, fetchFn),
+  );
 
   useEffect(() => {
     if (!pdfDoc) {
@@ -77,7 +92,7 @@ export function usePdfDocument(pdfDoc: PdfDoc | null, fetchFn: typeof fetch = fe
         if (cancelled) return;
 
         setPdfDocument(doc);
-        void backfillCover(pdfId, doc, fetchFn);
+        void backfillCover({ pdfId, doc });
       } catch (err) {
         console.error("Failed to load PDF for rendering:", err);
       }

--- a/src/front/hooks/useReadingLocation.test.tsx
+++ b/src/front/hooks/useReadingLocation.test.tsx
@@ -5,6 +5,7 @@ import { Provider, createStore, useSetAtom } from "jotai";
 import type { ReactNode } from "react";
 import { useReadingLocation, type LocatePassage } from "./useReadingLocation";
 import { currentPageAtom } from "../atoms/pdfAtom";
+import { SwrTestCache } from "../../test/swrTestCache";
 
 const PDF_ID = "01JBOOK";
 
@@ -28,9 +29,11 @@ function renderAt(
   // page 20" apart from "bounced through page 1 first"
   const visited: string[] = [];
   const wrapper = ({ children }: { children: ReactNode }) => (
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[url]}>{children}</MemoryRouter>
-    </Provider>
+    <SwrTestCache>
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[url]}>{children}</MemoryRouter>
+      </Provider>
+    </SwrTestCache>
   );
 
   return {

--- a/src/front/hooks/useReadingLocation.ts
+++ b/src/front/hooks/useReadingLocation.ts
@@ -1,7 +1,8 @@
-// oxlint-disable-next-line no-restricted-imports -- 読書位置を URL (外部状態) へ同期するために必要
+// oxlint-disable-next-line no-restricted-imports -- 読書位置を URL (外部状態) へ同期し、SWR が解決したページを共有ストアへ反映するために必要
 import { useEffect, useRef } from "react";
 import { useAtom } from "jotai";
 import { useSearchParams } from "react-router";
+import useSWRImmutable from "swr/immutable";
 import { currentPageAtom } from "../atoms/pdfAtom";
 
 /** Resolves a quoted passage to the page it appears on, or null if absent. */
@@ -76,18 +77,14 @@ export function useReadingLocation(
     setSearchParamsRef.current(next, { replace: true });
   }, [currentPage]);
 
+  // Where a passage sits in a book cannot change while the book is open, so
+  // this is asked once per link and never revalidated.
+  const { data: linkedPage } = useSWRImmutable(
+    pdfId && linkedPassage ? [pdfId, "locate", linkedPassage] : null,
+    () => locatePassage(pdfId!, linkedPassage!),
+  );
+
   useEffect(() => {
-    if (!pdfId || !linkedPassage) return;
-
-    let cancelled = false;
-    locatePassage(pdfId, linkedPassage)
-      .then((page) => {
-        if (!cancelled && page) setCurrentPage(page);
-      })
-      .catch(() => {});
-
-    return () => {
-      cancelled = true;
-    };
-  }, [pdfId, linkedPassage, locatePassage, setCurrentPage]);
+    if (linkedPage) setCurrentPage(linkedPage);
+  }, [linkedPage, setCurrentPage]);
 }

--- a/src/front/lib/selectionRects.ts
+++ b/src/front/lib/selectionRects.ts
@@ -1,7 +1,5 @@
 import type { SelectionRect } from "../../shared/schemas/selection";
 
-export type { SelectionRect } from "../../shared/schemas/selection";
-
 /** Two rects belong to the same line when their tops are within this share of a line's height. */
 const SAME_LINE_RATIO = 0.5;
 

--- a/src/front/main.tsx
+++ b/src/front/main.tsx
@@ -1,11 +1,23 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { RouterProvider } from "react-router";
+import { SWRConfig } from "swr";
 import "../index.css";
 import { router } from "./routes";
 
+/**
+ * Nothing here changes behind the reader's back: the app is local, single-user,
+ * and every book, highlight and message it shows was put there by this same
+ * tab. Re-fetching on window focus would therefore never bring anything new —
+ * it would only make what is on screen depend on when the window was clicked,
+ * which is exactly what makes a browser test flaky.
+ */
+const swrOptions = { revalidateOnFocus: false };
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <SWRConfig value={swrOptions}>
+      <RouterProvider router={router} />
+    </SWRConfig>
   </StrictMode>,
 );

--- a/src/front/pages/AppPage.test.tsx
+++ b/src/front/pages/AppPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useNavigate } from "react-router";
+import { SWRConfig } from "swr";
 import { AppPage } from "./AppPage";
 import { bookKey } from "../hooks/useBook";
 import { SwrTestCache } from "../../test/swrTestCache";
@@ -38,13 +39,18 @@ const BOOK_B: BookDetail = {
   selections: [highlight("b1", B_PASSAGE)],
 };
 
+/** The book's own endpoint, as opposed to the binary or a chat under it. */
+const isBookRequest = (url: string) => /^\/api\/pdf\/[^/]+$/.test(url);
+
 /**
- * Answers the two requests the reader makes on its own: the PDF binary (which
- * jsdom cannot render anyway) and the chat history of a highlight that is
- * opened. Every request it saw is recorded, so a test can show that the book
- * itself was never asked for.
+ * Answers the requests the reader makes on its own: the PDF binary (which jsdom
+ * cannot render anyway) and the chat history of a highlight that is opened.
+ *
+ * `holdTheBook` leaves the request for the book itself hanging forever. That is
+ * how a test shows the reader opened the book without waiting for the server:
+ * anything on screen got there from the cache, because nothing else can arrive.
  */
-function readerFetchStub() {
+function readerFetchStub({ holdTheBook = false } = {}) {
   const urls: string[] = [];
   // Every caller here reaches the network through `fetcher`, which is only
   // ever handed a url string.
@@ -52,6 +58,9 @@ function readerFetchStub() {
     urls.push(url);
     if (url.endsWith("/chats")) {
       return Promise.resolve(new Response(JSON.stringify({ messages: [] }), { status: 200 }));
+    }
+    if (holdTheBook && isBookRequest(url)) {
+      return new Promise<Response>(() => {});
     }
     return Promise.resolve(new Response(null, { status: 404 }));
   };
@@ -68,18 +77,26 @@ function OpenOtherBook({ pdfId }: { pdfId: string }) {
   );
 }
 
-function renderReader(pdfId: string, seed: Record<string, unknown>) {
-  const { urls, fetchFn } = readerFetchStub();
+function renderReader(
+  pdfId: string,
+  seed: Record<string, unknown>,
+  options: { holdTheBook?: boolean } = {},
+) {
+  const { urls, fetchFn } = readerFetchStub(options);
   vi.stubGlobal("fetch", fetchFn);
 
   render(
     <SwrTestCache seed={seed}>
-      <MemoryRouter initialEntries={[`/books/${pdfId}`]}>
-        <OpenOtherBook pdfId={BOOK_B.id} />
-        <Routes>
-          <Route path="/books/:pdfId" element={<AppPage />} />
-        </Routes>
-      </MemoryRouter>
+      {/* Seeded entries are revalidated on mount here, as they are in the app.
+          What the reader shows before that lands is what these tests are about. */}
+      <SWRConfig value={{ revalidateIfStale: true }}>
+        <MemoryRouter initialEntries={[`/books/${pdfId}`]}>
+          <OpenOtherBook pdfId={BOOK_B.id} />
+          <Routes>
+            <Route path="/books/:pdfId" element={<AppPage />} />
+          </Routes>
+        </MemoryRouter>
+      </SWRConfig>
     </SwrTestCache>,
   );
   return { urls };
@@ -90,11 +107,13 @@ describe("AppPage", () => {
     vi.unstubAllGlobals();
   });
 
-  it("opens the book from the cache the upload filled instead of asking for it again", async () => {
-    const { urls } = renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A });
+  it("opens a book already in the cache without waiting for the server", async () => {
+    // Nothing will answer for the book, so anything on screen came from the
+    // entry the upload filed under this key
+    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A }, { holdTheBook: true });
 
-    expect(await screen.findByText(BOOK_A.fileName)).toBeInTheDocument();
-    expect(urls).toStrictEqual([`/api/pdf/${BOOK_A.id}/file`]);
+    expect(screen.getByText(BOOK_A.fileName)).toBeInTheDocument();
+    expect(screen.getByText(A_PASSAGE)).toBeInTheDocument();
   });
 
   it("leaves the chat of the book being read behind when another book is opened", async () => {

--- a/src/front/pages/AppPage.test.tsx
+++ b/src/front/pages/AppPage.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, afterEach, vi } from "vite-plus/test";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router";
+import { AppPage } from "./AppPage";
+import { bookKey } from "../hooks/useBook";
+import { SwrTestCache } from "../../test/swrTestCache";
+import type { BookDetail } from "../../shared/schemas/book";
+import type { SelectionHighlight } from "../../shared/schemas/selection";
+
+const A_PASSAGE = "エッジはサーバーレス実行基盤で、実行単位をまたいでメモリを共有できません。";
+const B_PASSAGE = "Durable Objects は単一のインスタンスに処理を集約します。";
+
+function highlight(id: string, selectedText: string): SelectionHighlight {
+  return {
+    id,
+    selectedText,
+    pageNumber: 1,
+    positionData: { rects: [] },
+    color: "#FFEB3B",
+    createdAt: "2026-08-01T10:00:00.000Z",
+  };
+}
+
+const BOOK_A: BookDetail = {
+  id: "bookA",
+  fileName: "Cloudflare Workers.pdf",
+  pageCount: 209,
+  hasThumbnail: true,
+  selections: [highlight("a1", A_PASSAGE)],
+};
+
+const BOOK_B: BookDetail = {
+  id: "bookB",
+  fileName: "Durable Objects.pdf",
+  pageCount: 120,
+  hasThumbnail: true,
+  selections: [highlight("b1", B_PASSAGE)],
+};
+
+/**
+ * Answers the two requests the reader makes on its own: the PDF binary (which
+ * jsdom cannot render anyway) and the chat history of a highlight that is
+ * opened. Every request it saw is recorded, so a test can show that the book
+ * itself was never asked for.
+ */
+function readerFetchStub() {
+  const urls: string[] = [];
+  // Every caller here reaches the network through `fetcher`, which is only
+  // ever handed a url string.
+  const fetchFn = (url: string) => {
+    urls.push(url);
+    if (url.endsWith("/chats")) {
+      return Promise.resolve(new Response(JSON.stringify({ messages: [] }), { status: 200 }));
+    }
+    return Promise.resolve(new Response(null, { status: 404 }));
+  };
+  return { urls, fetchFn };
+}
+
+/** Lets a test leave the book it is on, the way the shelf link would. */
+function OpenOtherBook({ pdfId }: { pdfId: string }) {
+  const navigate = useNavigate();
+  return (
+    <button type="button" onClick={() => navigate(`/books/${pdfId}`)}>
+      別の本を開く
+    </button>
+  );
+}
+
+function renderReader(pdfId: string, seed: Record<string, unknown>) {
+  const { urls, fetchFn } = readerFetchStub();
+  vi.stubGlobal("fetch", fetchFn);
+
+  render(
+    <SwrTestCache seed={seed}>
+      <MemoryRouter initialEntries={[`/books/${pdfId}`]}>
+        <OpenOtherBook pdfId={BOOK_B.id} />
+        <Routes>
+          <Route path="/books/:pdfId" element={<AppPage />} />
+        </Routes>
+      </MemoryRouter>
+    </SwrTestCache>,
+  );
+  return { urls };
+}
+
+describe("AppPage", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("opens the book from the cache the upload filled instead of asking for it again", async () => {
+    const { urls } = renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A });
+
+    expect(await screen.findByText(BOOK_A.fileName)).toBeInTheDocument();
+    expect(urls).toStrictEqual([`/api/pdf/${BOOK_A.id}/file`]);
+  });
+
+  it("leaves the chat of the book being read behind when another book is opened", async () => {
+    renderReader(BOOK_A.id, {
+      [bookKey(BOOK_A.id)]: BOOK_A,
+      [bookKey(BOOK_B.id)]: BOOK_B,
+    });
+
+    // Opening a highlight puts its passage on screen, above the conversation
+    await userEvent.click(await screen.findByText(A_PASSAGE));
+    expect(screen.getByRole("button", { name: "一覧に戻る" })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "別の本を開く" }));
+
+    expect(await screen.findByText(BOOK_B.fileName)).toBeInTheDocument();
+    expect(screen.getByText(B_PASSAGE)).toBeInTheDocument();
+    expect(screen.queryByText(A_PASSAGE)).not.toBeInTheDocument();
+  });
+
+  it("says what went wrong when the book cannot be read", async () => {
+    renderReader(BOOK_A.id, {});
+
+    expect(
+      await screen.findByText(
+        `エラーが発生しました: request to /api/pdf/bookA failed with status 404`,
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/front/pages/AppPage.tsx
+++ b/src/front/pages/AppPage.tsx
@@ -1,8 +1,7 @@
-// oxlint-disable-next-line no-restricted-imports -- SWR が読んだ本を共有ストア (jotai) の atom へ反映するために必要
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { Provider, useAtom, useSetAtom } from "jotai";
 import { Link, useParams } from "react-router";
-import { pdfDocAtom, pdfStatusAtom, pdfErrorAtom, currentPageAtom } from "../atoms/pdfAtom";
+import { currentPageAtom } from "../atoms/pdfAtom";
 import {
   activeSelectionAtom,
   chatMessagesAtom,
@@ -50,9 +49,6 @@ export function AppPage() {
 
 function BookReader({ pdfId }: { pdfId: string | undefined }) {
   const { data: book, error } = useBook(pdfId);
-  const setPdfDoc = useSetAtom(pdfDocAtom);
-  const setPdfStatus = useSetAtom(pdfStatusAtom);
-  const setPdfError = useSetAtom(pdfErrorAtom);
   const [, setActiveSelection] = useAtom(activeSelectionAtom);
   const [, setChatMessages] = useAtom(chatMessagesAtom);
   const [, setCurrentPage] = useAtom(currentPageAtom);
@@ -65,36 +61,6 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
     [],
   );
   useReadingLocation(pdfId, locatePassage, linkedPassage);
-
-  // The viewer and its panels read the open book from the store, so what SWR
-  // holds has to be put there. Depending on the book's fields rather than the
-  // object keeps a highlight being added — which rewrites the cached book —
-  // from running this again.
-  useEffect(() => {
-    if (!pdfId) return;
-    if (book) {
-      setPdfDoc({ id: book.id, fileName: book.fileName, pageCount: book.pageCount });
-      setPdfStatus("ready");
-      setPdfError(null);
-      return;
-    }
-    if (error) {
-      setPdfError((error as Error).message);
-      setPdfStatus("error");
-      return;
-    }
-    setPdfStatus("loading");
-    setPdfError(null);
-  }, [
-    pdfId,
-    book?.id,
-    book?.fileName,
-    book?.pageCount,
-    error,
-    setPdfDoc,
-    setPdfStatus,
-    setPdfError,
-  ]);
 
   // Load chat history when selection changes
   const handleSelectionClick = useCallback(
@@ -142,7 +108,11 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
       <main className="flex-1 min-h-0 flex">
         {/* Left panel: PDF Viewer */}
         <div style={{ width: `${leftWidth}%` }} className="h-full min-w-0">
-          <PdfViewer onSelectionClick={handleSelectionClick} />
+          <PdfViewer
+            book={book}
+            bookError={error as Error | undefined}
+            onSelectionClick={handleSelectionClick}
+          />
         </div>
 
         {/* Resize handle */}
@@ -174,7 +144,7 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
 
         {/* Right panel: Chat Area */}
         <div style={{ width: `${100 - leftWidth}%` }} className="h-full min-w-0">
-          <ChatArea onSelectionClick={handleSelectionClick} />
+          <ChatArea book={book} onSelectionClick={handleSelectionClick} />
         </div>
       </main>
     </div>

--- a/src/front/pages/AppPage.tsx
+++ b/src/front/pages/AppPage.tsx
@@ -1,6 +1,6 @@
-// oxlint-disable-next-line no-restricted-imports -- URL の pdfId から本を復元するために必要
+// oxlint-disable-next-line no-restricted-imports -- SWR が読んだ本を共有ストア (jotai) の atom へ反映するために必要
 import { useState, useEffect, useCallback, useMemo } from "react";
-import { useAtom, useSetAtom } from "jotai";
+import { Provider, useAtom, useSetAtom } from "jotai";
 import { Link, useParams } from "react-router";
 import { pdfDocAtom, pdfStatusAtom, pdfErrorAtom, currentPageAtom } from "../atoms/pdfAtom";
 import {
@@ -12,10 +12,11 @@ import {
 import { PdfViewer } from "../components/PdfViewer/PdfViewer";
 import { ChatArea } from "../components/ChatArea/ChatArea";
 import { SettingsMenu } from "../components/SettingsMenu";
+import { useBook } from "../hooks/useBook";
 import { useReadingLocation } from "../hooks/useReadingLocation";
 import { passageFromNavigation } from "../lib/textFragment";
 import { fetcher } from "../lib/fetcher";
-import { bookDetailSchema, locatedPageSchema } from "../../shared/schemas/book";
+import { locatedPageSchema } from "../../shared/schemas/book";
 import { chatHistorySchema } from "../../shared/schemas/chat";
 
 /** Asks the server which page a passage from a `#:~:text=` link is on. */
@@ -27,11 +28,31 @@ async function locatePassage(pdfId: string, passage: string): Promise<number | n
   return pageNumber;
 }
 
+/**
+ * The reader, with a store of its own per book.
+ *
+ * Everything it holds — the open chat, the passage being asked about, the page
+ * being read — belongs to one book and means nothing under the next one. Giving
+ * the store the book's id as its key throws all of it away in a single step
+ * when another book is opened, instead of resetting each piece by hand and
+ * rendering once with whatever was missed. The book itself survives the swap:
+ * it lives in the SWR cache, which is outside the store.
+ */
 export function AppPage() {
   const { pdfId } = useParams();
-  const [pdfDoc, setPdfDoc] = useAtom(pdfDocAtom);
-  const [, setPdfStatus] = useAtom(pdfStatusAtom);
-  const [, setPdfError] = useAtom(pdfErrorAtom);
+
+  return (
+    <Provider key={pdfId}>
+      <BookReader pdfId={pdfId} />
+    </Provider>
+  );
+}
+
+function BookReader({ pdfId }: { pdfId: string | undefined }) {
+  const { data: book, error } = useBook(pdfId);
+  const setPdfDoc = useSetAtom(pdfDocAtom);
+  const setPdfStatus = useSetAtom(pdfStatusAtom);
+  const setPdfError = useSetAtom(pdfErrorAtom);
   const [, setActiveSelection] = useAtom(activeSelectionAtom);
   const [, setChatMessages] = useAtom(chatMessagesAtom);
   const [, setCurrentPage] = useAtom(currentPageAtom);
@@ -45,40 +66,34 @@ export function AppPage() {
   );
   useReadingLocation(pdfId, locatePassage, linkedPassage);
 
-  // Restore the book from the URL. Without this a reload or a direct link
-  // would land on an empty viewer, since the atom is only filled by an upload.
+  // The viewer and its panels read the open book from the store, so what SWR
+  // holds has to be put there. Depending on the book's fields rather than the
+  // object keeps a highlight being added — which rewrites the cached book —
+  // from running this again.
   useEffect(() => {
-    if (!pdfId || pdfDoc?.id === pdfId) return;
-
-    let cancelled = false;
-    setActiveSelection(null);
-    setChatMessages([]);
+    if (!pdfId) return;
+    if (book) {
+      setPdfDoc({ id: book.id, fileName: book.fileName, pageCount: book.pageCount });
+      setPdfStatus("ready");
+      setPdfError(null);
+      return;
+    }
+    if (error) {
+      setPdfError((error as Error).message);
+      setPdfStatus("error");
+      return;
+    }
     setPdfStatus("loading");
     setPdfError(null);
-
-    fetcher(`/api/pdf/${pdfId}`, bookDetailSchema)
-      .then((book) => {
-        if (cancelled) return;
-        setPdfDoc({ id: book.id, fileName: book.fileName, pageCount: book.pageCount });
-        setPdfStatus("ready");
-      })
-      .catch((err: Error) => {
-        if (cancelled) return;
-        setPdfError(err.message);
-        setPdfStatus("error");
-      });
-
-    return () => {
-      cancelled = true;
-    };
   }, [
     pdfId,
-    pdfDoc?.id,
+    book?.id,
+    book?.fileName,
+    book?.pageCount,
+    error,
     setPdfDoc,
     setPdfStatus,
     setPdfError,
-    setActiveSelection,
-    setChatMessages,
   ]);
 
   // Load chat history when selection changes
@@ -92,11 +107,11 @@ export function AppPage() {
       // Otherwise the conversation left behind shows under the new passage
       // until its own history arrives
       setChatMessages([]);
-      if (!pdfDoc) return;
+      if (!pdfId) return;
 
       try {
         const data = await fetcher(
-          `/api/pdf/${pdfDoc.id}/selections/${selection.id}/chats`,
+          `/api/pdf/${pdfId}/selections/${selection.id}/chats`,
           chatHistorySchema,
         );
 
@@ -105,7 +120,7 @@ export function AppPage() {
         setChatMessages([]);
       }
     },
-    [abortChatStream, pdfDoc, setActiveSelection, setChatMessages, setCurrentPage],
+    [abortChatStream, pdfId, setActiveSelection, setChatMessages, setCurrentPage],
   );
 
   return (
@@ -117,8 +132,8 @@ export function AppPage() {
         <Link to="/" className="ml-4 text-sm text-blue-600 hover:underline">
           ← 本棚
         </Link>
-        {pdfDoc && (
-          <span className="ml-3 text-sm text-gray-500 truncate max-w-xs">{pdfDoc.fileName}</span>
+        {book && (
+          <span className="ml-3 text-sm text-gray-500 truncate max-w-xs">{book.fileName}</span>
         )}
         <div className="ml-auto">
           <SettingsMenu />

--- a/src/front/pages/ShelfPage.test.tsx
+++ b/src/front/pages/ShelfPage.test.tsx
@@ -2,9 +2,10 @@ import { describe, it, expect } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useParams } from "react-router";
-import { ShelfPage, type Book } from "./ShelfPage";
+import { ShelfPage } from "./ShelfPage";
+import type { BookSummary } from "../../shared/schemas/book";
 
-function book(overrides: Partial<Book> = {}): Book {
+function book(overrides: Partial<BookSummary> = {}): BookSummary {
   return {
     id: "book-1",
     fileName: "Cloudflare Workers 入門.pdf",
@@ -16,7 +17,7 @@ function book(overrides: Partial<Book> = {}): Book {
 }
 
 function renderShelf(props: {
-  loadBooks?: () => Promise<Book[]>;
+  loadBooks?: () => Promise<BookSummary[]>;
   deleteBook?: (id: string) => Promise<unknown>;
 }) {
   render(

--- a/src/front/pages/ShelfPage.test.tsx
+++ b/src/front/pages/ShelfPage.test.tsx
@@ -90,7 +90,7 @@ describe("ShelfPage", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "削除する" }));
 
-    expect(deletedIds).toEqual(["book-1"]);
+    expect(deletedIds).toStrictEqual(["book-1"]);
     expect(
       screen.queryByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
     ).not.toBeInTheDocument();
@@ -122,7 +122,7 @@ describe("ShelfPage", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "キャンセル" }));
 
-    expect(deletedIds).toEqual([]);
+    expect(deletedIds).toStrictEqual([]);
     expect(
       screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
     ).toBeInTheDocument();
@@ -158,7 +158,7 @@ describe("ShelfPage", () => {
     );
     await userEvent.keyboard("{Escape}");
 
-    expect(deletedIds).toEqual([]);
+    expect(deletedIds).toStrictEqual([]);
     expect(
       screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
     ).toBeInTheDocument();
@@ -175,7 +175,7 @@ describe("ShelfPage", () => {
     // The backdrop is the dialog's own wrapper; it has no role of its own
     await userEvent.click(screen.getByRole("alertdialog").parentElement!);
 
-    expect(deletedIds).toEqual([]);
+    expect(deletedIds).toStrictEqual([]);
     expect(
       screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
     ).toBeInTheDocument();

--- a/src/front/pages/ShelfPage.test.tsx
+++ b/src/front/pages/ShelfPage.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useParams } from "react-router";
 import { ShelfPage } from "./ShelfPage";
 import type { BookSummary } from "../../shared/schemas/book";
+import { SwrTestCache } from "../../test/swrTestCache";
 
 function book(overrides: Partial<BookSummary> = {}): BookSummary {
   return {
@@ -21,12 +22,14 @@ function renderShelf(props: {
   deleteBook?: (id: string) => Promise<unknown>;
 }) {
   render(
-    <MemoryRouter>
-      <Routes>
-        <Route path="/" element={<ShelfPage {...props} />} />
-        <Route path="/books/:pdfId" element={<ReaderStub />} />
-      </Routes>
-    </MemoryRouter>,
+    <SwrTestCache>
+      <MemoryRouter>
+        <Routes>
+          <Route path="/" element={<ShelfPage {...props} />} />
+          <Route path="/books/:pdfId" element={<ReaderStub />} />
+        </Routes>
+      </MemoryRouter>
+    </SwrTestCache>,
   );
 }
 

--- a/src/front/pages/ShelfPage.tsx
+++ b/src/front/pages/ShelfPage.tsx
@@ -5,8 +5,6 @@ import { FileSelector } from "../components/PdfViewer/FileSelector";
 import { fetcher } from "../lib/fetcher";
 import { bookDeletedSchema, bookListSchema, type BookSummary } from "../../shared/schemas/book";
 
-export type Book = BookSummary;
-
 /** Module-level so the effect below keeps a stable dependency. */
 const fetchBooks = () => fetcher("/api/pdfs", bookListSchema).then((data) => data.books);
 
@@ -14,7 +12,7 @@ const requestBookDeletion = (id: string) =>
   fetcher(`/api/pdf/${id}`, bookDeletedSchema, { method: "DELETE" });
 
 interface ShelfPageProps {
-  loadBooks?: () => Promise<Book[]>;
+  loadBooks?: () => Promise<BookSummary[]>;
   deleteBook?: (id: string) => Promise<unknown>;
 }
 
@@ -27,9 +25,9 @@ function BookCard({
   onOpen,
   onDelete,
 }: {
-  book: Book;
+  book: BookSummary;
   onOpen: (id: string) => void;
-  onDelete: (book: Book) => void;
+  onDelete: (book: BookSummary) => void;
 }) {
   const [coverFailed, setCoverFailed] = useState(false);
   const showCover = book.hasThumbnail && !coverFailed;
@@ -81,7 +79,7 @@ function DeleteConfirmDialog({
   onConfirm,
   onCancel,
 }: {
-  book: Book;
+  book: BookSummary;
   onConfirm: () => void;
   onCancel: () => void;
 }) {
@@ -133,9 +131,9 @@ export function ShelfPage({
   deleteBook = requestBookDeletion,
 }: ShelfPageProps = {}) {
   const navigate = useNavigate();
-  const [books, setBooks] = useState<Book[] | null>(null);
+  const [books, setBooks] = useState<BookSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [bookPendingDeletion, setBookPendingDeletion] = useState<Book | null>(null);
+  const [bookPendingDeletion, setBookPendingDeletion] = useState<BookSummary | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -156,7 +154,7 @@ export function ShelfPage({
 
   const openBook = useCallback((id: string) => navigate(`/books/${id}`), [navigate]);
 
-  const removeBook = async (book: Book) => {
+  const removeBook = async (book: BookSummary) => {
     setError(null);
     setBookPendingDeletion(null);
     try {

--- a/src/front/pages/ShelfPage.tsx
+++ b/src/front/pages/ShelfPage.tsx
@@ -1,12 +1,14 @@
-// oxlint-disable-next-line no-restricted-imports -- マウント時に一度だけ本棚を取得する。再検証もキャッシュ共有も要らないため SWR は使わない
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 import { useNavigate } from "react-router";
+import useSWR from "swr";
 import { FileSelector } from "../components/PdfViewer/FileSelector";
 import { fetcher } from "../lib/fetcher";
 import { bookDeletedSchema, bookListSchema, type BookSummary } from "../../shared/schemas/book";
 
-/** Module-level so the effect below keeps a stable dependency. */
-const fetchBooks = () => fetcher("/api/pdfs", bookListSchema).then((data) => data.books);
+/** Cache key of the shelf, and the endpoint it is read from. */
+const SHELF_KEY = "/api/pdfs";
+
+const fetchBooks = () => fetcher(SHELF_KEY, bookListSchema).then((data) => data.books);
 
 const requestBookDeletion = (id: string) =>
   fetcher(`/api/pdf/${id}`, bookDeletedSchema, { method: "DELETE" });
@@ -131,37 +133,26 @@ export function ShelfPage({
   deleteBook = requestBookDeletion,
 }: ShelfPageProps = {}) {
   const navigate = useNavigate();
-  const [books, setBooks] = useState<BookSummary[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const { data: books, error: loadError, mutate } = useSWR(SHELF_KEY, loadBooks);
+  const [deletionError, setDeletionError] = useState<string | null>(null);
   const [bookPendingDeletion, setBookPendingDeletion] = useState<BookSummary | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
-    loadBooks()
-      .then((loaded) => {
-        if (!cancelled) setBooks(loaded);
-      })
-      .catch((err: Error) => {
-        if (!cancelled) {
-          setError(`本棚の読み込みに失敗しました: ${err.message}`);
-          setBooks([]);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [loadBooks]);
+  const error =
+    deletionError ??
+    (loadError ? `本棚の読み込みに失敗しました: ${(loadError as Error).message}` : null);
 
   const openBook = useCallback((id: string) => navigate(`/books/${id}`), [navigate]);
 
   const removeBook = async (book: BookSummary) => {
-    setError(null);
+    setDeletionError(null);
     setBookPendingDeletion(null);
     try {
       await deleteBook(book.id);
-      setBooks((current) => current?.filter((b) => b.id !== book.id) ?? current);
+      // The server has already dropped it, so re-reading the shelf would only
+      // confirm what this list can work out for itself.
+      await mutate((current) => current?.filter((b) => b.id !== book.id), { revalidate: false });
     } catch (err) {
-      setError(`削除に失敗しました: ${(err as Error).message}`);
+      setDeletionError(`削除に失敗しました: ${(err as Error).message}`);
     }
   };
 
@@ -175,7 +166,7 @@ export function ShelfPage({
       <main className="mx-auto max-w-6xl p-6">
         {error && <p className="mb-4 rounded-md bg-red-50 p-3 text-sm text-red-600">{error}</p>}
 
-        {books === null && <p className="text-sm text-gray-500">読み込み中...</p>}
+        {!books && !error && <p className="text-sm text-gray-500">読み込み中...</p>}
 
         {books?.length === 0 && !error && (
           <div className="py-24 text-center">

--- a/src/test/swrTestCache.tsx
+++ b/src/test/swrTestCache.tsx
@@ -1,0 +1,35 @@
+import { SWRConfig } from "swr";
+import type { ReactNode } from "react";
+
+/**
+ * A private SWR cache for one test, optionally pre-filled.
+ *
+ * The cache SWR uses by default is a module-level singleton, so without this
+ * wrapper a test would read whatever the test before it fetched, and the suite
+ * would only pass in the order it happened to be written in.
+ *
+ * Seeded entries stand in for the server: `revalidateIfStale` is off so they
+ * are not immediately re-fetched over the network. A key with no seed is still
+ * fetched, since SWR always revalidates when it has nothing to show.
+ */
+export function SwrTestCache({
+  seed,
+  children,
+}: {
+  seed?: Record<string, unknown>;
+  children: ReactNode;
+}) {
+  return (
+    <SWRConfig
+      value={{
+        provider: () => new Map(Object.entries(seed ?? {}).map(([key, data]) => [key, { data }])),
+        revalidateIfStale: false,
+        // A failing request is a fact the test asserts on, not something to
+        // wait out; retries would only leave timers running past the test.
+        shouldRetryOnError: false,
+      }}
+    >
+      {children}
+    </SWRConfig>
+  );
+}


### PR DESCRIPTION
Closes #5

## 概要

`useEffect` + `fetch` によるデータ取得 4 箇所を SWR へ移し、`backfillCover` の mutation を `useSWRMutation` にした。SWR キャッシュがサーバ由来データの唯一の置き場になり、`selectionsAtom` / `pdfDocAtom` / `pdfStatusAtom` / `pdfErrorAtom` の 4 つの atom が不要になって消えている。

| 対象 | 変更 |
| --- | --- |
| 本棚一覧 | `useSWR`。削除は `mutate` で楽観更新 |
| 本の復元 (`AppPage`) | `useBook` (`useSWR`)。`PdfViewer` / `ChatArea` へは props で渡す |
| ハイライト一覧 | `useHighlights` が本と同じキーを共有。読み取りが本を開くたび 2 回 → 1 回に |
| 引用箇所のページ解決 | `useSWRImmutable` (passage が無ければキー null) |
| 表紙の遅延生成 | `useSWRMutation` |

ルートに `SWRConfig { revalidateOnFocus: false }` を置いた。ローカル単一ユーザーでデータは自分の操作でしか変わらず、フォーカス往復による再取得はブラウザテストを不安定にするだけのため。

## 副次的に直ったもの

- **本を開くたびに発生していた `/api/pdf/:pdfId` の重複 GET が消えた**。SWR の結果を atom へ写す際に `hasThumbnail` が落ちていたため、表紙の遅延生成が同じエンドポイントを SWR の外でもう一度取りに行っていた
- 本のメタデータ表示にあった 1 レンダーの遅れが消えた (atom への写しを経由しなくなったため)
- `useEffect` の理由コメント付きファイルが 12 → 9 に減った

## 挙動の変更

- **本ごとに jotai のストアを作り直す** (`<Provider key={pdfId}>`)。選択範囲・チャット・現在ページは次の本では意味を持たないので、1 つずつ手でリセットして漏れたものと一緒に描画するより確実。素の `key` では atom はリセットされない (jotai の `useStore` はモジュールレベルのシングルトンにフォールバックするため)
- **Web 検索の ON/OFF が localStorage に永続化された**。ストアを作り直すと毎回既定 (ON) に戻ってしまい、本の切り替えと本棚 ↔ リーダーの往復のたびにリセットされるため。設定メニューで隣に並ぶキーバインド設定と永続性が揃った
- `FileSelector` のアップロード失敗時の atom 書き込みを削除した。ストア分離により root store への書き込みとなり誰にも読まれないため。**退行ではない** — 変更前も `pdfErrorAtom` の読み手は `PdfViewer` だけで、`FileSelector` は本棚にしかないので本棚でのアップロード失敗は元から無言だった (穴自体は残るので #8 へ申し送り)
- 到達不能だった「PDFファイルを選択してください」の分岐を削除 (リーダーのルートには必ず pdfId があるため)

## テスト

jsdom **140 → 158** (+18)、worker 39 据え置き、E2E 21 pass。テスト間のキャッシュ汚染を防ぐため `src/test/swrTestCache.tsx` を追加した (SWR の `initCache` が provider オブジェクトをキーに持つため、`--sequence.shuffle` の複数シードで順序非依存を確認済み)。

レビューで「壊しても検出できない」と指摘された箇所は、変異させて実際に落ちることを確認した:

| 変異 | 変異前 | 変異後 |
| --- | --- | --- |
| 表紙バックフィルを常にスキップ | 148 件全通過 | 2 件 fail |
| キャッシュ先充填のキーを別物に | 148 件全通過 | 2 件 fail |
| `<Provider key={pdfId}>` → `<Provider>` | — | 1 件 fail |

`AppPage` のテストが本番に無いテスト専用設定 (`revalidateIfStale: false`) に依存していた問題も修正した。本番で再検証を止めると、既にハイライトのある本をアップロード経路で開いたとき一覧が空のまま固定される (先充填は `selections: []` を推定値で置き、再検証でしか正しくならない) ため、テストのほうを本番と同じ設定に揃え「サーバの応答を待たずに本文が出る」ことを検証する形にした。

| ゲート | 結果 |
| --- | --- |
| `vp check` | pass |
| `pnpm test` (jsdom) | 158 passed |
| `pnpm run test:worker` | 39 passed |
| `pnpm run test:e2e` | 21 passed |
| `vp build` | pass |

## CLAUDE.md

「`useEffect` の扱い」節と「状態管理とルーティング」節を全文書き直した。局所的な追記を重ねた結果、撤回したはずの概念への参照が残る状態になっていたため (fresh context の監査で検出)。

- `useEffect` の例外根拠に実在しない `destroy` 呼び出しを挙げていたのをやめ、実在する 9 ファイルを 4 分類した表に置き換え
- **チャット履歴だけは SWR に載っていない**ことを理由付きで明記 (SSE が同じ状態をトークンごとに書き換えるため、キャッシュに載せると再検証が回答を上書きしうる)。「データ取得はすべて SWR」という含意を与えないよう「移した」対象も限定した
- SWR の fetcher は必ず `lib/fetcher.ts` の `fetcher` を通すこと (生 `fetch` を渡すとスキーマ検証を素通りする) を zod 節と相互参照

## 申し送り

- `PDFDocumentProxy` を `destroy()` していない (本を切り替えるたび pdf.js の worker リソースが残るリークになりうる)
- チャット履歴が SWR を経由していない (issue の移行対象 4 箇所に含まれないため未着手)
- アップロード失敗・ハイライト保存失敗が `console.error` のみ → #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)