### PR TITLE
✨ feat: エラーハンドリングを neverthrow の Result 型に移行する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,9 +117,9 @@ front と server が交わす形は `src/shared/schemas/` に zod スキーマ�
 - **クライアントの受け口**は `src/front/lib/fetcher.ts` の `fetcher(url, schema, init?, fetchFn?)`。
   `schema.safeParse` を通った値だけを返す。**レスポンスが返ったあとの失敗 2 系統**——サーバが
   拒否した（`error.code` を載せる。取れないときは `"UNKNOWN"`）と、レスポンスがスキーマに
-  合わない（`"INVALID_RESPONSE"`）——を `ApiError`（`message` / `code` / `status`）に揃えて
-  throw する。`fetch` 自体が reject するネットワーク断・abort はここでは包まず、
-  `TypeError` / `AbortError` がそのまま呼び出し側へ伝わる
+  合わない（`"INVALID_RESPONSE"`）——を `ApiError`（`message` / `code` / `status` / `kind`）に
+  揃えて throw する。`fetch` 自体が reject するネットワーク断・abort はここでは包まず、
+  `TypeError` / `AbortError` がそのまま呼び出し側へ伝わる（包む版は下記 `resultFetcher`）
 - **`src/server/services/chatService.ts` の `LlmMessage`** は LLM 送信用で `system` role を
   含み、保存される `ChatMessage`（`src/shared/schemas/chat.ts`）とは別物。shared に混ぜないこと
 
@@ -129,6 +129,52 @@ front と server が交わす形は `src/shared/schemas/` に zod スキーマ�
 意味がない。ワイヤ上の `code` は前方互換のため `z.string()` で受け（読み手は知らない code を
 渡す以外にできることがない）、サーバ側の構築だけ `shared/schemas/error.ts` の `ErrorCode`
 union + `satisfies` で固定する。
+
+### 失敗の運び方（neverthrow）
+
+**失敗はユーザーに見える形にするか、握りつぶす理由をコメントに書くかのどちらかにする。**
+`console.error` だけで済ませない（それは前者でも後者でもない）。
+
+- **サーバの service は `ResultAsync`**。エラー型は `src/server/services/serviceError.ts` の
+  `ServiceError = { type: "NOT_FOUND" } | { type: "STORAGE"; cause }` の 2 つだけ。route が
+  `.match()` で封筒に落とす（`src/server/routes/pdf.ts` の `serviceFailureResponse` /
+  `storageFailureResponse`）。「無い」は各エンドポイントの言葉で 404、「ストアが応答しない」は
+  一律 `INTERNAL_ERROR` の 500 で、`cause` はサーバのログにだけ出す
+- **想定外の throw と未定義パスは `src/server/index.ts` の `app.onError` / `notFound` が拾う**。
+  Hono の既定は `text/plain` の "Internal Server Error" を返し、これは封筒ではないので
+  `fetcher` からは `UNKNOWN` にしか見えない。`/api/*` だけが Worker に来る
+  （`wrangler.jsonc` の `run_worker_first`）ので、`notFound` が SPA の直リンクを奪うことはない
+- **フロントの読み取り（SWR）は throw ベースの `fetcher` のまま**。SWR の `error` state が
+  その境界の Result そのもので、`Err` に変換して戻すのは往復の無駄
+- **mutation とイベントハンドラ起点の 1 回きりの取得は `resultFetcher`**
+  （`ResultAsync<T, ApiError>`）。受け皿になる SWR が無いので、失敗は値で返さないと消える。
+  `fetch` 自体の reject もここで包むため、`ApiError.kind` で `http` / `network` / `parse` を
+  区別できる（`network` の `code` は `NETWORK_ERROR` / `ABORTED`、`status` は 0）
+- **レンダー中の throw は Result では拾えない**ので、`src/front/routes.tsx` が両ルートに
+  `errorElement`（`src/front/components/RouteErrorBoundary.tsx`）を張る
+
+失敗の受け皿と表示場所は次のとおり。新しい失敗を足すときはこの表のどれかに合流させる:
+
+| 失敗                              | 受け皿                                                | 出る場所                                   |
+| --------------------------------- | ----------------------------------------------------- | ------------------------------------------ |
+| 本棚の読み込み・削除・追加        | `ShelfPage` の `actionError` と SWR の `error`        | 本棚上部の赤い枠                           |
+| 本の読み込み                      | `useBook` の `error` → `bookError` prop               | ビューア中央とチャットパネル               |
+| PDF バイナリの取得・pdf.js の構築 | `usePdfDocument` の `error`                           | ビューア中央                               |
+| ページの描画                      | `PdfPage` の `onError` → `PdfViewer` の `renderError` | ビューア上部（ページを移ると消える）       |
+| 目次の取得                        | `usePdfOutline` の `error`                            | 目次パネル                                 |
+| ハイライトの保存                  | `useAskAboutSelection` の `saveError`                 | ビューア上部（ポップオーバーは開いたまま） |
+| チャットの送信・履歴の取得        | `chatErrorAtom`                                       | チャットパネル                             |
+| リンク先の passage が見つからない | `useReadingLocation` の `passageNotFound`             | ヘッダ直下の帯                             |
+
+`chatErrorAtom` だけ二重の口がある。**atom が表示の正、`sendMessage` の戻り値
+（`ResultAsync<MessageId, ApiError>`）は呼び出し元のフロー制御用**という分担で、戻り値を
+捨てた呼び出し元があっても画面が無言にならないようにしてある。新しい送信の開始と、
+別のハイライトを開いたときにクリアする。
+
+意図的に握りつぶしているのは 3 か所だけで、いずれも理由をコメントに書いてある:
+表紙の生成（`pdfLoader.ts`。本棚がタイトルで代替する）、SSE 断片のパース
+（`sseParser.ts` / `deepseekService.ts`）、クライアント切断後の送信
+（`routes/pdf.ts`。回答の保存を守るため）。
 
 #### `positionData` の正準形
 
@@ -183,8 +229,15 @@ union + `satisfies` で固定する。
   `src/front/hooks/useChatStream.ts` が `src/shared/schemas/sse.ts` の
   `chatSseEventSchema`（4 イベントの discriminated union）で `safeParse` し、通ったものだけ
   扱う。**キャストで済ませないこと**——未知の種別の出典が `CitationBadge` の描画に届く
-- 送信は **必ず `useChatStream` の `sendMessage` を通す**。ポップオーバーからの初回質問も同様。
-  ここを生 `fetch` にすると質問文の即時表示と「考え中…」が出なくなる
+- 送信は **必ず `useChatStream` の `sendMessage` を通す**。ポップオーバーからの初回質問も
+  `useAskAboutSelection` 経由でここに来る。生 `fetch` にすると質問文の即時表示と
+  「考え中…」が出なくなる
+- **回答を保存できなかったときは `done` ではなく `event: error`（`CHAT_SAVE_FAILED`）を送る**。
+  保存前に `done` を送ると、画面には回答が出そろっているのにリロードで消える。
+  ここを `.catch(console.error)` に戻さないこと
+- ポップオーバーからの初回質問は**保存された回答を待たない**。`sendMessage` の完了を待つと
+  ポップオーバーが 10 秒前後ページを覆う。閉じる合図はハイライトの保存が成功したこと
+  （`useAskAboutSelection`）で、ストリーム自体の失敗は `chatErrorAtom` が受ける
 
 ### DeepSeek の呼び分け
 
@@ -206,28 +259,30 @@ PDF 引用は `fullText` 内の位置からページ番号を割り出してジ�
 ### 状態管理とルーティング
 
 **画面に出しっぱなしにするサーバのデータは SWR、クライアントだけの状態は Jotai の atom**
-（`src/front/atoms/`）。両方に同じものを載せないこと。`neverthrow` はテンプレート由来の
-未使用依存で、現在どこからも import していない。
+（`src/front/atoms/`）。両方に同じものを載せないこと。
 
 - `/` … 本棚（`ShelfPage`）。一覧は `useSWR("/api/pdfs")`
 - `/books/:pdfId` … リーダー（`AppPage`）。本は `useBook(pdfId)` で読むので
   リロード・直リンクでも開ける。読んだ本は `PdfViewer` / `ChatArea` へ **props で**
   渡す（atom に写さない。読み手はこの 2 つだけなので prop drilling にならない）
+- どちらのルートにも `errorElement` が付く（上記「失敗の運び方（neverthrow）」）
 
 **チャットだけは SWR に載っていない**。`chatMessagesAtom` が持ち、履歴の読み込みは
-`AppPage` の `handleSelectionClick` が生の `fetcher` を呼ぶ。理由は、同じ状態を SSE の
+`AppPage` の `handleSelectionClick` が `resultFetcher` を直接呼ぶ。理由は、同じ状態を SSE の
 ストリームがトークンごとに書き換えるため（`useChatStream`）——キャッシュに載せると
 再検証が流れてきた回答を上書きしうる。**「データ取得はすべて SWR」ではない**。
-イベントハンドラ起点の 1 回きりの取得（履歴・選択の作成・アップロード）は生の `fetcher`
-で書く。
+イベントハンドラ起点の 1 回きりの取得（履歴・選択の作成・アップロード）は SWR を通さず
+`resultFetcher` で書く（受け皿になる SWR が無いので、失敗は値で返さないと消える）。
 
 SWR の使い方で押さえるところ:
 
 - **fetcher は必ず `src/front/lib/fetcher.ts` の `fetcher` を通す**（上記
   「外部入力のバリデーション（zod）」）。`useSWR(key, () => fetch(...).then(r => r.json()))`
   のように生 `fetch` を渡すとスキーマ検証を素通りし、`ApiError` / `INVALID_RESPONSE`
-  の防護が消える。現在の SWR 呼び出しは全て `fetcher` 経由（PDF バイナリの取得だけは
-  JSON ではないので `usePdfDocument` が生の fetch を使うが、これは SWR ではない）
+  の防護が消える。SWR の `error` state が受け止めるので、ここは throw する `fetcher` の
+  ままでよく、`resultFetcher` に替えない。現在の SWR 呼び出しは全て `fetcher` 経由
+  （PDF バイナリの取得だけは JSON ではないので `usePdfDocument` が生の fetch を使い、
+  拒否の読み取りだけ `readRefusal` を通す。これは SWR ではない）
 - **ルートの `SWRConfig`**（`src/front/main.tsx`）で `revalidateOnFocus` を切っている。
   ローカル単一ユーザーのアプリでデータは自分の操作でしか変わらず、focus 復帰の再検証は
   Playwright のフォーカス往復で E2E を非決定にするだけ
@@ -254,7 +309,8 @@ SWR の使い方で押さえるところ:
   `keybindingModeAtom` / `useWebSearchAtom` がその形）
 - **テストの差し替え口は 2 つある**。取得そのものを差し替えるなら DI 引数——
   `useBook(pdfId, loadBook)` / `useHighlights(pdfId, loadBook)` /
-  `ShelfPage({ loadBooks, deleteBook })` / `FileSelector({ extract })` がその口。
+  `useAskAboutSelection(addHighlight, saveSelection)` /
+  `ShelfPage({ loadBooks, deleteBook, extract })` / `FileSelector({ extract })` がその口。
   キャッシュの中身を用意したいなら `src/test/swrTestCache.tsx` の `SwrTestCache` で包む
   （SWR の既定キャッシュはモジュールレベルの singleton なので、包まないとテストが互いの
   キャッシュを見て実行順に依存する。`seed` を渡すとそのキーをサーバの代わりに使う）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,23 +135,44 @@ union + `satisfies` で固定する。
 **失敗はユーザーに見える形にするか、握りつぶす理由をコメントに書くかのどちらかにする。**
 `console.error` だけで済ませない（それは前者でも後者でもない）。
 
-- **サーバの service は `ResultAsync`**。エラー型は `src/server/services/serviceError.ts` の
-  `ServiceError = { type: "NOT_FOUND" } | { type: "STORAGE"; cause }` の 2 つだけ。route が
-  `.match()` で封筒に落とす（`src/server/routes/pdf.ts` の `serviceFailureResponse` /
-  `storageFailureResponse`）。「無い」は各エンドポイントの言葉で 404、「ストアが応答しない」は
-  一律 `INTERNAL_ERROR` の 500 で、`cause` はサーバのログにだけ出す
-- **想定外の throw と未定義パスは `src/server/index.ts` の `app.onError` / `notFound` が拾う**。
+- **D1 / R2 に触る service は `ResultAsync`**（現状 `pdfService.ts` の 4 関数）。エラー型は
+  `src/server/services/serviceError.ts` の
+  `ServiceError = { type: "NOT_FOUND" } | { type: "STORAGE"; cause }` の 2 つだけで、
+  `notFound()` / `storageFailure(cause)` が作る。route が `.match()` で封筒に落とす
+  （`src/server/routes/pdf.ts` の `serviceFailureResponse` が 404、`storageFailureResponse`
+  が 500 を組み立てる。**名前が似ているが、`storageFailure` は service が返す値、
+  `storageFailureResponse` は route が返すレスポンス**）。「無い」は各エンドポイントの言葉で
+  404、「ストアが応答しない」は一律 `INTERNAL_ERROR` の 500 で、`cause` はサーバのログにだけ
+  出す。バインディングに触らない service（`chatService.ts` は純粋関数、`deepseekService.ts`
+  は throw + callbacks でストリームを運ぶ）はこの対象外
+- **想定外の throw と未定義パスは `src/server/index.ts` の `app.onError` / `notFound` が拾う**
+  （それぞれ `INTERNAL_ERROR` / `ROUTE_NOT_FOUND`。どちらも `shared/schemas/error.ts` の
+  `ERROR_CODES` に載っており、`index.ts` が `satisfies ErrorCode` で固定して唯一発行する）。
   Hono の既定は `text/plain` の "Internal Server Error" を返し、これは封筒ではないので
   `fetcher` からは `UNKNOWN` にしか見えない。`/api/*` だけが Worker に来る
   （`wrangler.jsonc` の `run_worker_first`）ので、`notFound` が SPA の直リンクを奪うことはない
 - **フロントの読み取り（SWR）は throw ベースの `fetcher` のまま**。SWR の `error` state が
   その境界の Result そのもので、`Err` に変換して戻すのは往復の無駄
-- **mutation とイベントハンドラ起点の 1 回きりの取得は `resultFetcher`**
+- **失敗を画面に出す mutation とイベントハンドラ起点の 1 回きりの取得は `resultFetcher`**
   （`ResultAsync<T, ApiError>`）。受け皿になる SWR が無いので、失敗は値で返さないと消える。
-  `fetch` 自体の reject もここで包むため、`ApiError.kind` で `http` / `network` / `parse` を
-  区別できる（`network` の `code` は `NETWORK_ERROR` / `ABORTED`、`status` は 0）
+  現在の該当箇所は本の削除（`ShelfPage`）・アップロード（`FileSelector`）・ハイライトの作成
+  （`useAskAboutSelection`）・チャット履歴の取得（`AppPage`）の 4 つ。
+  **例外は `usePdfDocument.ts` の `storeCoverIfMissing`** で、これは失敗を出さないと決めた
+  書き込み（下記「意図的に握りつぶす」）なので `fetcher` + try/catch のままでよい
+- **`ApiError` の `kind`** は `http`（サーバが拒否した）/ `parse`（返ってきた形が違う）/
+  `network`（応答が無い）。`parse` は `fetcher` も立てるので throw 経路にも現れる。
+  `network` だけは `resultFetcher` でしか作られない（`fetcher` は fetch の reject を包まない）。
+  クライアント固有の `code` は `fetcher.ts` の `CLIENT_ERROR_CODES` に集約してあり
+  （`UNKNOWN` / `INVALID_RESPONSE` / `NETWORK_ERROR` / `ABORTED`）、**リテラルで書かないこと**——
+  `ApiError.code` は `string` なので typo しても型で落ちない
 - **レンダー中の throw は Result では拾えない**ので、`src/front/routes.tsx` が両ルートに
   `errorElement`（`src/front/components/RouteErrorBoundary.tsx`）を張る
+
+**表示する文言は、それを描くコンポーネントが組み立てる。**フックは理由（サーバや例外の
+`message`）だけを返す——`usePdfDocument` / `usePdfOutline` / `useAskAboutSelection` /
+`PdfPage` の `onError` はすべてこの形で、前置きは `PdfViewer` と `PdfOutline` が付ける。
+**例外は `chatErrorAtom` ただ 1 つ**で、書き手が複数（送信の失敗と履歴の取得失敗）・読み手が
+1 つ（`ChatArea`）なので、完成した文を atom が持つ。
 
 失敗の受け皿と表示場所は次のとおり。新しい失敗を足すときはこの表のどれかに合流させる:
 
@@ -167,14 +188,28 @@ union + `satisfies` で固定する。
 | リンク先の passage が見つからない | `useReadingLocation` の `passageNotFound`             | ヘッダ直下の帯                             |
 
 `chatErrorAtom` だけ二重の口がある。**atom が表示の正、`sendMessage` の戻り値
-（`ResultAsync<MessageId, ApiError>`）は呼び出し元のフロー制御用**という分担で、戻り値を
-捨てた呼び出し元があっても画面が無言にならないようにしてある。新しい送信の開始と、
-別のハイライトを開いたときにクリアする。
+（`ResultAsync<string, ApiError>`。成功時の値は保存された回答の id）は呼び出し元の
+フロー制御用**という分担で、戻り値を捨てた呼び出し元があっても画面が無言にならないように
+してある。新しい送信の開始と、別のハイライトを開いたときにクリアする。
 
-意図的に握りつぶしているのは 3 種類だけで、いずれも理由をコメントに書いてある:
-表紙（`pdfLoader.ts` の生成と `usePdfDocument.ts` の後追い保存。本棚がタイトルで代替する）、
-SSE 断片のパース（`sseParser.ts` / `deepseekService.ts`）、クライアント切断後の送信
-（`routes/pdf.ts`。回答の保存を守るため）。
+#### 意図的に握りつぶす
+
+次の 7 箇所は失敗を画面に出さない。いずれも理由をコメントに書いてあり、**理由を書かずに
+握りつぶしを増やさないこと**:
+
+| 箇所                                                         | 握りつぶす理由                                                       |
+| ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| `pdfLoader.ts` の表紙生成 / `usePdfDocument.ts` の後追い保存 | 表紙は装飾。本棚がタイトルで代替する                                 |
+| `sseParser.ts` / `deepseekService.ts` の断片パース           | ストリームの 1 ブロックが壊れても残りは使える                        |
+| `routes/pdf.ts` のクライアント切断後の送信                   | throw を通すと回答の保存に届かない                                   |
+| `pdfService.ts` の `readPositionData`                        | 壊れた 1 行で本ごと開けなくしない（下記「`positionData` の正準形」） |
+| `chatService.ts` の `readCitations`                          | 出典が読めなくても回答そのものは見せる                               |
+| `textFragment.ts` のリンク解析                               | 解析できない = passage へのリンクではない、という正常系              |
+| `usePdfOutline.ts` の `resolvePageNumber`                    | dest が解けない 1 項目はページ無しで並べ、残りは使える               |
+
+`SelectionPopover` の `onSubmit` を囲む catch も握りつぶしだが、これは**報告しないため
+ではなく報告する主体が別だから**（質問の失敗は `useAskAboutSelection` が受け持つ。
+ここで再 throw するとイベントハンドラの外へ抜け、`errorElement` にも届かない）。
 
 #### `positionData` の正準形
 
@@ -235,9 +270,17 @@ SSE 断片のパース（`sseParser.ts` / `deepseekService.ts`）、クライア
 - **回答を保存できなかったときは `done` ではなく `event: error`（`CHAT_SAVE_FAILED`）を送る**。
   保存前に `done` を送ると、画面には回答が出そろっているのにリロードで消える。
   ここを `.catch(console.error)` に戻さないこと
+- **`CHAT_SAVE_FAILED` だけは回答を画面に残す**。他の `event: error` は生成が途中で切れた
+  ことを意味するので断片を捨てるが、これは回答が完成したうえで書き込みだけが落ちた場合で、
+  消すと読むこともコピーすることもできなくなる（生成コストは既に払っている）。
+  `useChatStream` がこのコードで分岐し、`chatFailureMessage` も「取得に失敗」ではなく
+  「保存できませんでした」と言い換える
 - ポップオーバーからの初回質問は**保存された回答を待たない**。`sendMessage` の完了を待つと
   ポップオーバーが 10 秒前後ページを覆う。閉じる合図はハイライトの保存が成功したこと
   （`useAskAboutSelection`）で、ストリーム自体の失敗は `chatErrorAtom` が受ける
+- **ポップオーバーは保存が終わるまで開いたままなので、送信中フラグが要る**
+  （`SelectionPopover` の `asking`）。無いと 2 回目の送信がハイライトを二重に作り、
+  2 本目の回答が 1 本目を `abortChatStream` で殺す。`onSubmit` を await する型なのはこのため
 
 ### DeepSeek の呼び分け
 
@@ -280,9 +323,10 @@ SWR の使い方で押さえるところ:
   「外部入力のバリデーション（zod）」）。`useSWR(key, () => fetch(...).then(r => r.json()))`
   のように生 `fetch` を渡すとスキーマ検証を素通りし、`ApiError` / `INVALID_RESPONSE`
   の防護が消える。SWR の `error` state が受け止めるので、ここは throw する `fetcher` の
-  ままでよく、`resultFetcher` に替えない。現在の SWR 呼び出しは全て `fetcher` 経由
-  （PDF バイナリの取得だけは JSON ではないので `usePdfDocument` が生の fetch を使い、
-  拒否の読み取りだけ `readRefusal` を通す。これは SWR ではない）
+  ままでよく、`resultFetcher` に替えない。現在の SWR 呼び出しは全て `fetcher` 経由。
+  **JSON ではない 2 つ——PDF バイナリ（`usePdfDocument`）とチャットの SSE
+  （`useChatStream`）——だけが生の `fetch` を直接使う**。どちらも SWR ではなく、拒否の
+  読み取りは `fetcher.ts` の `readRefusal` を通して同じ文言に揃える
 - **ルートの `SWRConfig`**（`src/front/main.tsx`）で `revalidateOnFocus` を切っている。
   ローカル単一ユーザーのアプリでデータは自分の操作でしか変わらず、focus 復帰の再検証は
   Playwright のフォーカス往復で E2E を非決定にするだけ
@@ -309,8 +353,12 @@ SWR の使い方で押さえるところ:
   `keybindingModeAtom` / `useWebSearchAtom` がその形）
 - **テストの差し替え口は 2 つある**。取得そのものを差し替えるなら DI 引数——
   `useBook(pdfId, loadBook)` / `useHighlights(pdfId, loadBook)` /
+  `usePdfDocument(book, fetchFn)` / `useChatStream(fetchFn, now)` /
   `useAskAboutSelection(addHighlight, saveSelection)` /
-  `ShelfPage({ loadBooks, deleteBook, extract })` / `FileSelector({ extract })` がその口。
+  `ShelfPage({ loadBooks, deleteBook, extract })` / `FileSelector({ extract })` /
+  `PdfViewer({ measureSelection, saveSelection })` がその口。`measureSelection` は
+  ポップオーバーを開く唯一の入口で、**実 DOM 選択と pdf.js が描いたページを両方要求する
+  経路（質問・保存失敗の表示・二重送信の防止）を jsdom で動かすための seam**。
   キャッシュの中身を用意したいなら `src/test/swrTestCache.tsx` の `SwrTestCache` で包む
   （SWR の既定キャッシュはモジュールレベルの singleton なので、包まないとテストが互いの
   キャッシュを見て実行順に依存する。`seed` を渡すとそのキーをサーバの代わりに使う）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,9 +171,9 @@ union + `satisfies` で固定する。
 捨てた呼び出し元があっても画面が無言にならないようにしてある。新しい送信の開始と、
 別のハイライトを開いたときにクリアする。
 
-意図的に握りつぶしているのは 3 か所だけで、いずれも理由をコメントに書いてある:
-表紙の生成（`pdfLoader.ts`。本棚がタイトルで代替する）、SSE 断片のパース
-（`sseParser.ts` / `deepseekService.ts`）、クライアント切断後の送信
+意図的に握りつぶしているのは 3 種類だけで、いずれも理由をコメントに書いてある:
+表紙（`pdfLoader.ts` の生成と `usePdfDocument.ts` の後追い保存。本棚がタイトルで代替する）、
+SSE 断片のパース（`sseParser.ts` / `deepseekService.ts`）、クライアント切断後の送信
 （`routes/pdf.ts`。回答の保存を守るため）。
 
 #### `positionData` の正準形

--- a/src/front/atoms/chatAtom.ts
+++ b/src/front/atoms/chatAtom.ts
@@ -13,6 +13,18 @@ export const chatMessagesAtom = atom<ChatMessage[]>([]);
 export const streamingContentAtom = atom<string>("");
 export const isStreamingAtom = atom<boolean>(false);
 
+/**
+ * What went wrong with this conversation, worded for the reader, or null when
+ * nothing has.
+ *
+ * The panel reads this and nothing else: `sendMessage` also hands its failure
+ * back so a caller can decide what to do next, but a caller that ignores the
+ * return value still cannot leave the reader staring at an unanswered
+ * question. Whoever writes here words the message, since "the answer never
+ * came" and "the history could not be read" are not the same sentence.
+ */
+export const chatErrorAtom = atom<string | null>(null);
+
 /** Shared, so leaving a chat can stop an answer any of the panels started. */
 export const chatAbortControllerAtom = atom<AbortController | null>(null);
 

--- a/src/front/components/ChatArea/ChatArea.test.tsx
+++ b/src/front/components/ChatArea/ChatArea.test.tsx
@@ -66,8 +66,9 @@ function renderChat(
   const opened: ActiveSelection[] = [];
   render(
     // The highlights the panel lists come from the book's cache entry, the same
-    // one the viewer draws from.
-    <SwrTestCache seed={{ [bookKey(BOOK.id)]: BOOK }}>
+    // one the viewer draws from. A book that failed to load has no such entry,
+    // so seeding one would contradict the state under test.
+    <SwrTestCache seed={book ? { [bookKey(BOOK.id)]: BOOK } : {}}>
       <Provider store={store}>
         <ChatArea
           book={book}

--- a/src/front/components/ChatArea/ChatArea.test.tsx
+++ b/src/front/components/ChatArea/ChatArea.test.tsx
@@ -3,7 +3,12 @@ import { render, screen, act, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider, createStore } from "jotai";
 import { ChatArea } from "./ChatArea";
-import { doneEvent, streamingFetchStub, tokenEvent } from "../../../test/streamingFetchStub";
+import {
+  doneEvent,
+  errorEvent,
+  streamingFetchStub,
+  tokenEvent,
+} from "../../../test/streamingFetchStub";
 import {
   activeSelectionAtom,
   chatAbortControllerAtom,
@@ -45,8 +50,16 @@ const BOOK: BookDetail = {
   selections: HIGHLIGHTS,
 };
 
-function renderChat(options: { activeSelection?: ActiveSelection | null } = {}) {
-  const { activeSelection = { id: "s1", selectedText: SELECTED_TEXT, pageNumber: 42 } } = options;
+function renderChat(
+  options: {
+    activeSelection?: ActiveSelection | null;
+    /** Set to render the panel as it looks when the book itself failed to load. */
+    bookError?: Error;
+  } = {},
+) {
+  const { activeSelection = { id: "s1", selectedText: SELECTED_TEXT, pageNumber: 42 }, bookError } =
+    options;
+  const book = bookError ? undefined : BOOK;
   const store = createStore();
   store.set(activeSelectionAtom, activeSelection);
 
@@ -56,7 +69,11 @@ function renderChat(options: { activeSelection?: ActiveSelection | null } = {}) 
     // one the viewer draws from.
     <SwrTestCache seed={{ [bookKey(BOOK.id)]: BOOK }}>
       <Provider store={store}>
-        <ChatArea book={BOOK} onSelectionClick={(selection) => opened.push(selection)} />
+        <ChatArea
+          book={book}
+          bookError={bookError}
+          onSelectionClick={(selection) => opened.push(selection)}
+        />
       </Provider>
     </SwrTestCache>,
   );
@@ -104,10 +121,43 @@ describe("ChatArea", () => {
     ]);
   });
 
+  it("says why the answer never came instead of leaving the question unanswered", async () => {
+    const { fetchFn, calls } = streamingFetchStub();
+    vi.stubGlobal("fetch", fetchFn);
+    renderChat();
+
+    await userEvent.type(screen.getByPlaceholderText("質問を入力..."), "この段落を一言で要約して");
+    await userEvent.keyboard("{Enter}");
+    await act(async () => {
+      calls[0].emit(errorEvent("AI_API_ERROR", "upstream is down"));
+      calls[0].end();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /^回答の取得に失敗しました: upstream is down$/,
+      ),
+    );
+    // The question stays on screen, and the wait that would suggest an answer
+    // is still coming is over
+    expect(screen.getByText("この段落を一言で要約して")).toBeVisible();
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
   it("shows the selected passage the question is about", () => {
     renderChat();
 
     expect(screen.getByText(SELECTED_TEXT)).toBeInTheDocument();
+  });
+
+  it("says the book could not be read rather than showing it as one without highlights", () => {
+    // The highlights come from the book itself, so a book that failed to load
+    // is indistinguishable from one nobody has marked up yet.
+    renderChat({ activeSelection: null, bookError: new Error("PDF not found") });
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /^ハイライトを読み込めませんでした: PDF not found$/,
+    );
   });
 
   it("lists the book's highlights while no passage is selected", () => {

--- a/src/front/components/ChatArea/ChatArea.tsx
+++ b/src/front/components/ChatArea/ChatArea.tsx
@@ -4,6 +4,7 @@ import {
   streamingContentAtom,
   isStreamingAtom,
   activeSelectionAtom,
+  chatErrorAtom,
   abortChatStreamAtom,
   type ActiveSelection,
 } from "../../atoms/chatAtom";
@@ -18,15 +19,27 @@ import { useHighlights } from "../../hooks/useHighlights";
 interface ChatAreaProps {
   /** The book being read, or nothing while it is still being read in. */
   book: BookDetail | undefined;
+  /** Why the book could not be read, if it could not. */
+  bookError?: Error;
   onSelectionClick: (selection: ActiveSelection) => void;
 }
 
-export function ChatArea({ book, onSelectionClick }: ChatAreaProps) {
+/** A failure worded for the reader, in the one place the panel shows them. */
+function ChatErrorNotice({ message }: { message: string }) {
+  return (
+    <p role="alert" className="m-2 rounded-md bg-red-50 p-3 text-sm text-red-600">
+      {message}
+    </p>
+  );
+}
+
+export function ChatArea({ book, bookError, onSelectionClick }: ChatAreaProps) {
   const [activeSelection, setActiveSelection] = useAtom(activeSelectionAtom);
   const { highlights } = useHighlights(book?.id);
   const messages = useAtomValue(chatMessagesAtom);
   const streamingContent = useAtomValue(streamingContentAtom);
   const isStreaming = useAtomValue(isStreamingAtom);
+  const chatError = useAtomValue(chatErrorAtom);
   const useWebSearch = useAtomValue(useWebSearchAtom);
   const abortChatStream = useSetAtom(abortChatStreamAtom);
 
@@ -36,6 +49,18 @@ export function ChatArea({ book, onSelectionClick }: ChatAreaProps) {
     if (!book || !activeSelection) return;
     await sendMessage(book.id, activeSelection.id, content, useWebSearch);
   };
+
+  if (bookError && !book) {
+    // The highlights are read out of the book, so a book that did not load has
+    // no list to show — and an empty list here reads as "nothing marked yet".
+    // A book already in hand still wins: a failed re-read of it changes nothing
+    // about the highlights on screen.
+    return (
+      <div className="flex h-full flex-col justify-center bg-white">
+        <ChatErrorNotice message={`ハイライトを読み込めませんでした: ${bookError.message}`} />
+      </div>
+    );
+  }
 
   if (!book) {
     return (
@@ -68,6 +93,7 @@ export function ChatArea({ book, onSelectionClick }: ChatAreaProps) {
         streamingContent={streamingContent}
         isStreaming={isStreaming}
       />
+      {chatError !== null && <ChatErrorNotice message={chatError} />}
       <ChatInput
         onSend={handleSend}
         disabled={isStreaming}

--- a/src/front/components/PdfViewer/FileSelector.test.tsx
+++ b/src/front/components/PdfViewer/FileSelector.test.tsx
@@ -27,10 +27,20 @@ function extraction(thumbnail: Blob | null): ExtractedPdfData {
 }
 
 /** Answers the upload the way the API does, and records what it was sent. */
-function uploadStub() {
+function uploadStub({ refuse = false } = {}) {
   const uploads: { url: string; method: string }[] = [];
   const fetchFn = (url: string, init?: RequestInit) => {
     uploads.push({ url, method: init?.method ?? "GET" });
+    if (refuse) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: { code: "PDF_EXTRACT_FAILED", message: "Failed to process PDF" },
+          }),
+          { status: 500, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    }
     const body = {
       id: PDF_ID,
       fileName: FILE_NAME,
@@ -42,19 +52,21 @@ function uploadStub() {
   return { uploads, fetchFn };
 }
 
-async function chooseAPdf(thumbnail: Blob | null) {
-  const { uploads, fetchFn } = uploadStub();
+async function chooseAPdf(thumbnail: Blob | null, { refuse = false } = {}) {
+  const { uploads, fetchFn } = uploadStub({ refuse });
   vi.stubGlobal("fetch", fetchFn);
 
   // The cache is built here rather than inside the provider so the test can
   // read what the upload filed in it.
   const cache: Cache = new Map();
   const opened: string[] = [];
+  const failures: string[] = [];
 
   const { container } = render(
     <SWRConfig value={{ provider: () => cache }}>
       <FileSelector
         onOpened={(id) => opened.push(id)}
+        onError={(message) => failures.push(message)}
         extract={async () => extraction(thumbnail)}
       />
     </SWRConfig>,
@@ -68,7 +80,7 @@ async function chooseAPdf(thumbnail: Blob | null) {
     new File(["%PDF-1.7"], FILE_NAME, { type: "application/pdf" }),
   );
 
-  return { cache, opened, uploads };
+  return { cache, opened, uploads, failures };
 }
 
 describe("FileSelector", () => {
@@ -100,6 +112,18 @@ describe("FileSelector", () => {
       hasThumbnail: false,
       selections: [],
     } satisfies BookDetail);
+  });
+
+  it("hands up the reason an upload was refused rather than swallowing it", async () => {
+    // The failure used to reach console.error only, so choosing a file the
+    // server rejected looked exactly like choosing no file at all.
+    const { cache, opened, failures } = await chooseAPdf(COVER, { refuse: true });
+
+    await waitFor(() =>
+      expect(failures).toStrictEqual(["PDFを開けませんでした: Failed to process PDF"]),
+    );
+    expect(opened).toStrictEqual([]);
+    expect(cache.get(bookKey(PDF_ID))).toBeUndefined();
   });
 
   it("sends the chosen file to the endpoint that stores books", async () => {

--- a/src/front/components/PdfViewer/FileSelector.tsx
+++ b/src/front/components/PdfViewer/FileSelector.tsx
@@ -21,6 +21,9 @@ interface FileSelectorProps {
   extract?: (file: File) => Promise<ExtractedPdfData>;
 }
 
+/** Whatever was thrown, as something with a `message` the reader can be shown. */
+const asError = (cause: unknown) => (cause instanceof Error ? cause : new Error(String(cause)));
+
 export function FileSelector({
   onOpened,
   onError,
@@ -37,30 +40,28 @@ export function FileSelector({
 
     // Reading the file is pdf.js' job and can fail on its own (a file that is
     // not really a PDF), so it is part of the same result as the upload.
-    const stored = ResultAsync.fromPromise(extract(file), (cause) =>
-      cause instanceof Error ? cause : new Error(String(cause)),
-    ).andThen((extracted) => {
-      // Send as multipart/form-data (avoids base64 overhead)
-      const formData = new FormData();
-      formData.append("file", file);
-      formData.append("fullText", extracted.fullText);
-      formData.append("pageCount", String(extracted.pageCount));
-      if (extracted.thumbnail) {
-        formData.append("thumbnail", extracted.thumbnail, "cover.webp");
-      }
+    // Everything from reading the file to filling the cache is one outcome, so
+    // that a rejection anywhere in it reaches the reader. An event handler is
+    // the end of the line: a promise that rejects here is caught by nothing —
+    // not even the route's errorElement — and the reader would be left with a
+    // file picker that appeared to do nothing.
+    const opened = ResultAsync.fromPromise(extract(file), asError)
+      .andThen((extracted) => {
+        // Send as multipart/form-data (avoids base64 overhead)
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append("fullText", extracted.fullText);
+        formData.append("pageCount", String(extracted.pageCount));
+        if (extracted.thumbnail) {
+          formData.append("thumbnail", extracted.thumbnail, "cover.webp");
+        }
 
-      return resultFetcher("/api/pdf/open", pdfMetadataSchema, {
-        method: "POST",
-        body: formData,
-      }).map((result) => ({ result, hasThumbnail: extracted.thumbnail !== null }));
-    });
-
-    const outcome = await stored;
-    // Allow selecting the same file again
-    e.target.value = "";
-
-    await outcome.match(
-      async ({ result, hasThumbnail }) => {
+        return resultFetcher("/api/pdf/open", pdfMetadataSchema, {
+          method: "POST",
+          body: formData,
+        }).map((result) => ({ result, hasThumbnail: extracted.thumbnail !== null }));
+      })
+      .andThen(({ result, hasThumbnail }) => {
         // The upload already answered with everything the reader needs to open
         // the book, so hand it to the cache the reader reads from. Without this
         // the reader would show an empty viewer while it asked for the very
@@ -70,20 +71,26 @@ export function FileSelector({
         // one. Opening a book that was annotated before therefore shows its
         // highlights a moment late, when the reader's own read of the book
         // lands on top of this entry.
-        const opened: BookDetail = {
+        const book: BookDetail = {
           id: result.id,
           fileName: result.fileName,
           pageCount: result.pageCount,
           hasThumbnail,
           selections: [],
         };
-        await mutate(bookKey(result.id), opened, { revalidate: false });
+        return ResultAsync.fromPromise(
+          mutate(bookKey(result.id), book, { revalidate: false }),
+          asError,
+        ).map(() => result.id);
+      });
 
-        onOpened?.(result.id);
-      },
-      async (failure) => {
-        onError?.(`PDFを開けませんでした: ${failure.message}`);
-      },
+    const outcome = await opened;
+    // Allow selecting the same file again
+    e.target.value = "";
+
+    outcome.match(
+      (pdfId) => onOpened?.(pdfId),
+      (failure) => onError?.(`PDFを開けませんでした: ${failure.message}`),
     );
   };
 

--- a/src/front/components/PdfViewer/FileSelector.tsx
+++ b/src/front/components/PdfViewer/FileSelector.tsx
@@ -1,13 +1,20 @@
 import { useRef } from "react";
 import { useSWRConfig } from "swr";
+import { ResultAsync } from "neverthrow";
 import { extractPdfData, type ExtractedPdfData } from "../../lib/pdfLoader";
-import { fetcher } from "../../lib/fetcher";
+import { resultFetcher } from "../../lib/fetcher";
 import { bookKey } from "../../hooks/useBook";
 import { pdfMetadataSchema, type BookDetail } from "../../../shared/schemas/book";
 
 interface FileSelectorProps {
   /** Called with the book id once the upload finished, so the caller can navigate. */
   onOpened?: (pdfId: string) => void;
+  /**
+   * Called with the reason a chosen file did not become a book. This component
+   * has nowhere of its own to show it — it lives in a header next to a button —
+   * so the page it sits on decides where the reader reads it.
+   */
+  onError?: (message: string) => void;
   label?: string;
   className?: string;
   /** Reads the text and cover out of the chosen file; injectable for tests. */
@@ -16,6 +23,7 @@ interface FileSelectorProps {
 
 export function FileSelector({
   onOpened,
+  onError,
   label = "PDFを開く",
   className,
   extract = extractPdfData,
@@ -27,10 +35,11 @@ export function FileSelector({
     const file = e.target.files?.[0];
     if (!file) return;
 
-    try {
-      // Extract text and render the cover client-side (pdf.js)
-      const extracted = await extract(file);
-
+    // Reading the file is pdf.js' job and can fail on its own (a file that is
+    // not really a PDF), so it is part of the same result as the upload.
+    const stored = ResultAsync.fromPromise(extract(file), (cause) =>
+      cause instanceof Error ? cause : new Error(String(cause)),
+    ).andThen((extracted) => {
       // Send as multipart/form-data (avoids base64 overhead)
       const formData = new FormData();
       formData.append("file", file);
@@ -40,36 +49,42 @@ export function FileSelector({
         formData.append("thumbnail", extracted.thumbnail, "cover.webp");
       }
 
-      const result = await fetcher("/api/pdf/open", pdfMetadataSchema, {
+      return resultFetcher("/api/pdf/open", pdfMetadataSchema, {
         method: "POST",
         body: formData,
-      });
+      }).map((result) => ({ result, hasThumbnail: extracted.thumbnail !== null }));
+    });
 
-      // The upload already answered with everything the reader needs to open
-      // the book, so hand it to the cache the reader reads from. Without this
-      // the reader would show an empty viewer while it asked for the very
-      // thing that was just sent.
-      //
-      // The highlight list starts empty because the upload does not report
-      // one. Opening a book that was annotated before therefore shows its
-      // highlights a moment late, when the reader's own read of the book
-      // lands on top of this entry.
-      const opened: BookDetail = {
-        id: result.id,
-        fileName: result.fileName,
-        pageCount: result.pageCount,
-        hasThumbnail: extracted.thumbnail !== null,
-        selections: [],
-      };
-      await mutate(bookKey(result.id), opened, { revalidate: false });
+    const outcome = await stored;
+    // Allow selecting the same file again
+    e.target.value = "";
 
-      onOpened?.(result.id);
-    } catch (err) {
-      console.error("Failed to open the PDF:", err);
-    } finally {
-      // Allow selecting the same file again
-      e.target.value = "";
-    }
+    await outcome.match(
+      async ({ result, hasThumbnail }) => {
+        // The upload already answered with everything the reader needs to open
+        // the book, so hand it to the cache the reader reads from. Without this
+        // the reader would show an empty viewer while it asked for the very
+        // thing that was just sent.
+        //
+        // The highlight list starts empty because the upload does not report
+        // one. Opening a book that was annotated before therefore shows its
+        // highlights a moment late, when the reader's own read of the book
+        // lands on top of this entry.
+        const opened: BookDetail = {
+          id: result.id,
+          fileName: result.fileName,
+          pageCount: result.pageCount,
+          hasThumbnail,
+          selections: [],
+        };
+        await mutate(bookKey(result.id), opened, { revalidate: false });
+
+        onOpened?.(result.id);
+      },
+      async (failure) => {
+        onError?.(`PDFを開けませんでした: ${failure.message}`);
+      },
+    );
   };
 
   return (

--- a/src/front/components/PdfViewer/PdfOutline.test.tsx
+++ b/src/front/components/PdfViewer/PdfOutline.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vite-plus/test";
+import { render, screen } from "@testing-library/react";
+import { PdfOutline } from "./PdfOutline";
+
+describe("PdfOutline", () => {
+  it("says the table of contents could not be read rather than showing the book as having none", () => {
+    render(
+      <PdfOutline
+        outline={null}
+        error="Invalid outline destination"
+        currentPage={1}
+        onJump={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /^目次を読み込めませんでした: Invalid outline destination$/,
+    );
+  });
+
+  it("says a book without a table of contents has none", () => {
+    render(<PdfOutline outline={[]} error={null} currentPage={1} onJump={() => {}} />);
+
+    expect(screen.getByText("この本には目次がありません")).toBeInTheDocument();
+  });
+});

--- a/src/front/components/PdfViewer/PdfOutline.tsx
+++ b/src/front/components/PdfViewer/PdfOutline.tsx
@@ -2,6 +2,8 @@ import type { OutlineEntry } from "../../hooks/usePdfOutline";
 
 interface PdfOutlineProps {
   outline: OutlineEntry[] | null;
+  /** Why the bookmarks could not be read, if they could not. */
+  error: string | null;
   currentPage: number;
   onJump: (pageNumber: number) => void;
 }
@@ -72,7 +74,7 @@ function OutlineItem({
   );
 }
 
-export function PdfOutline({ outline, currentPage, onJump }: PdfOutlineProps) {
+export function PdfOutline({ outline, error, currentPage, onJump }: PdfOutlineProps) {
   const activeTitle = outline ? findActiveTitle(outline, currentPage) : null;
 
   return (
@@ -84,7 +86,15 @@ export function PdfOutline({ outline, currentPage, onJump }: PdfOutlineProps) {
         目次
       </h2>
 
-      {outline === null && <p className="p-3 text-xs text-gray-400">読み込み中...</p>}
+      {error !== null && (
+        <p role="alert" className="p-3 text-xs text-red-600">
+          目次を読み込めませんでした: {error}
+        </p>
+      )}
+
+      {outline === null && error === null && (
+        <p className="p-3 text-xs text-gray-400">読み込み中...</p>
+      )}
 
       {outline?.length === 0 && (
         <p className="p-3 text-xs text-gray-400">この本には目次がありません</p>

--- a/src/front/components/PdfViewer/PdfPage.test.tsx
+++ b/src/front/components/PdfViewer/PdfPage.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vite-plus/test";
+import { render, waitFor } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import type { PDFDocumentProxy } from "pdfjs-dist";
+import { PdfPage } from "./PdfPage";
+
+/** A document that refuses the page asked of it, as a damaged file would. */
+const DAMAGED_DOC = {
+  getPage: () => Promise.reject(new Error("Invalid page request")),
+} as unknown as PDFDocumentProxy;
+
+describe("PdfPage", () => {
+  it("hands up the reason a page could not be drawn instead of leaving it blank", async () => {
+    // The failure used to reach console.error only, so the reader was left
+    // looking at an empty page frame with the page counter still on it.
+    const reported: string[] = [];
+
+    render(
+      <Provider store={createStore()}>
+        <PdfPage
+          pdfDoc={DAMAGED_DOC}
+          pageNumber={3}
+          containerWidth={600}
+          onError={(message) => reported.push(message)}
+        />
+      </Provider>,
+    );
+
+    await waitFor(() => expect(reported).toStrictEqual(["Invalid page request"]));
+  });
+});

--- a/src/front/components/PdfViewer/PdfPage.test.tsx
+++ b/src/front/components/PdfViewer/PdfPage.test.tsx
@@ -10,7 +10,7 @@ const DAMAGED_DOC = {
 } as unknown as PDFDocumentProxy;
 
 describe("PdfPage", () => {
-  it("hands up the reason a page could not be drawn instead of leaving it blank", async () => {
+  it("hands the failure up to its caller when the page cannot be drawn", async () => {
     // The failure used to reach console.error only, so the reader was left
     // looking at an empty page frame with the page counter still on it.
     const reported: string[] = [];

--- a/src/front/components/PdfViewer/PdfPage.tsx
+++ b/src/front/components/PdfViewer/PdfPage.tsx
@@ -11,9 +11,14 @@ interface PdfPageProps {
   pageNumber: number;
   /** Width to fit the page into, so the viewer can be resized freely. */
   containerWidth: number;
+  /**
+   * Called with the reason this page could not be drawn. A cancelled render is
+   * not one: it is the normal path when the page or the width changes.
+   */
+  onError?: (message: string) => void;
 }
 
-export function PdfPage({ pdfDoc, pageNumber, containerWidth }: PdfPageProps) {
+export function PdfPage({ pdfDoc, pageNumber, containerWidth, onError }: PdfPageProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const textLayerRef = useRef<HTMLDivElement>(null);
   const renderTaskRef = useRef<RenderTask | null>(null);
@@ -107,8 +112,11 @@ export function PdfPage({ pdfDoc, pageNumber, containerWidth }: PdfPageProps) {
       setViewport({ width: viewport.width, height: viewport.height, baseWidth });
     }
 
-    renderPage().catch((err) => {
+    renderPage().catch((err: unknown) => {
       console.error("Failed to render page:", err);
+      // A cancelled render never gets here — renderPage returns on it — so
+      // anything that does is a page the reader will not see drawn.
+      if (!cancelled) onError?.(err instanceof Error ? err.message : String(err));
     });
 
     return () => {
@@ -117,7 +125,7 @@ export function PdfPage({ pdfDoc, pageNumber, containerWidth }: PdfPageProps) {
       releaseSelectionGuard.current?.();
       releaseSelectionGuard.current = null;
     };
-  }, [pdfDoc, pageNumber, containerWidth, setViewport]);
+  }, [pdfDoc, pageNumber, containerWidth, setViewport, onError]);
 
   return (
     <div className="relative mb-4 shadow-lg mx-auto" style={{ width: "fit-content" }}>

--- a/src/front/components/PdfViewer/PdfViewer.test.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, afterEach, vi } from "vite-plus/test";
+import { render, screen } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import { PdfViewer } from "./PdfViewer";
+import { SwrTestCache } from "../../../test/swrTestCache";
+import { bookKey } from "../../hooks/useBook";
+import type { BookDetail } from "../../../shared/schemas/book";
+
+const BOOK: BookDetail = {
+  id: "p1",
+  fileName: "Cloudflare Workers.pdf",
+  pageCount: 209,
+  hasThumbnail: true,
+  selections: [],
+};
+
+/** Answers the request for the book's binary with the given refusal. */
+function bucketWithout(body: unknown, status: number): typeof fetch {
+  return () =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+}
+
+function renderViewer() {
+  render(
+    <SwrTestCache seed={{ [bookKey(BOOK.id)]: BOOK }}>
+      <Provider store={createStore()}>
+        <PdfViewer book={BOOK} bookError={undefined} onSelectionClick={() => {}} />
+      </Provider>
+    </SwrTestCache>,
+  );
+}
+
+describe("PdfViewer", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("says why the book cannot be shown instead of opening to a blank page", async () => {
+    // The book itself loaded, so none of the other messages apply: without this
+    // one the reader is left looking at an empty panel under a page counter.
+    vi.stubGlobal(
+      "fetch",
+      bucketWithout(
+        { error: { code: "PDF_FILE_MISSING", message: "PDF binary not found in storage" } },
+        404,
+      ),
+    );
+
+    renderViewer();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /^PDFを表示できません: PDF binary not found in storage$/,
+    );
+  });
+});

--- a/src/front/components/PdfViewer/PdfViewer.test.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.test.tsx
@@ -1,10 +1,15 @@
 import { describe, it, expect, afterEach, vi } from "vite-plus/test";
-import { render, screen } from "@testing-library/react";
+import { render, screen, act, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider, createStore } from "jotai";
-import { PdfViewer } from "./PdfViewer";
+import { errAsync, ok, okAsync, ResultAsync, type Result } from "neverthrow";
+import { PdfViewer, type MeasureSelection } from "./PdfViewer";
 import { SwrTestCache } from "../../../test/swrTestCache";
 import { bookKey } from "../../hooks/useBook";
+import { ApiError } from "../../lib/fetcher";
+import type { SaveSelection } from "../../hooks/useAskAboutSelection";
 import type { BookDetail } from "../../../shared/schemas/book";
+import type { CreatedSelection } from "../../../shared/schemas/selection";
 
 const BOOK: BookDetail = {
   id: "p1",
@@ -25,14 +30,56 @@ function bucketWithout(body: unknown, status: number): typeof fetch {
     );
 }
 
-function renderViewer() {
-  render(
+const PASSAGE = "エッジはサーバーレス実行基盤です。";
+
+/** A passage the reader has dragged over, as the real measurement reports it. */
+const MEASURED: ReturnType<MeasureSelection> = {
+  position: { x: 40, y: 120, width: 160 },
+  selectedText: PASSAGE,
+  selectionPosition: {
+    startIndex: 0,
+    endIndex: 12,
+    pageNumber: 1,
+    rects: [{ x: 40, y: 120, width: 160, height: 18 }],
+    pageWidth: 600,
+  },
+};
+
+const STORED: CreatedSelection = {
+  id: "s1",
+  selectedText: PASSAGE,
+  pageNumber: 1,
+  positionData: MEASURED.selectionPosition,
+  createdAt: "2026-08-01T10:00:00.000Z",
+};
+
+function renderViewer(
+  options: { measureSelection?: MeasureSelection; saveSelection?: SaveSelection } = {},
+) {
+  return render(
     <SwrTestCache seed={{ [bookKey(BOOK.id)]: BOOK }}>
       <Provider store={createStore()}>
-        <PdfViewer book={BOOK} bookError={undefined} onSelectionClick={() => {}} />
+        <PdfViewer
+          book={BOOK}
+          bookError={undefined}
+          onSelectionClick={() => {}}
+          measureSelection={options.measureSelection}
+          saveSelection={options.saveSelection}
+        />
       </Provider>
     </SwrTestCache>,
   );
+}
+
+/**
+ * Drag over a passage, the way a reader does.
+ *
+ * The viewer reads the selection on a timer after mouseup (the browser has not
+ * settled the selection yet at that point), so the wait is part of the gesture.
+ */
+async function selectPassage(container: HTMLElement) {
+  fireEvent.mouseUp(container.firstElementChild!);
+  return screen.findByPlaceholderText("選択した文章について質問する...");
 }
 
 describe("PdfViewer", () => {
@@ -56,5 +103,75 @@ describe("PdfViewer", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent(
       /^PDFを表示できません: PDF binary not found in storage$/,
     );
+  });
+
+  it("says the highlight could not be saved and keeps the question in reach", async () => {
+    // The issue's symptom was the opposite: the popover closed on submit, so a
+    // failed save took the typed question with it and said nothing.
+    vi.stubGlobal("fetch", bucketWithout({ ok: true }, 200));
+    const { container } = renderViewer({
+      measureSelection: () => MEASURED,
+      saveSelection: () => errAsync(new ApiError("PDF not found", "PDF_NOT_FOUND", 404)),
+    });
+
+    const input = await selectPassage(container);
+    await userEvent.type(input, "この段落を一言で要約して");
+    await userEvent.click(screen.getByRole("button", { name: "質問する" }));
+
+    expect(
+      await screen.findByText("ハイライトを保存できませんでした: PDF not found"),
+    ).toBeVisible();
+    // The question is still there to send again
+    expect(screen.getByPlaceholderText("選択した文章について質問する...")).toHaveValue(
+      "この段落を一言で要約して",
+    );
+  });
+
+  it("closes the popover once the highlight is stored", async () => {
+    vi.stubGlobal("fetch", bucketWithout({ ok: true }, 200));
+    const { container } = renderViewer({
+      measureSelection: () => MEASURED,
+      saveSelection: () => okAsync(STORED),
+    });
+
+    const input = await selectPassage(container);
+    await userEvent.type(input, "この段落を一言で要約して");
+    await userEvent.click(screen.getByRole("button", { name: "質問する" }));
+
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText("選択した文章について質問する...")).toBeNull(),
+    );
+    expect(screen.queryByText(/^ハイライトを保存できませんでした/)).toBeNull();
+  });
+
+  it("stores one highlight however many times the reader submits while the save is in flight", async () => {
+    // The popover now outlives the submit, so only its own gate stops a second
+    // ask storing a second highlight and starting an answer that aborts the
+    // first one.
+    vi.stubGlobal("fetch", bucketWithout({ ok: true }, 200));
+    const saves: string[] = [];
+    let storeIt!: (stored: Result<CreatedSelection, ApiError>) => void;
+    const inFlight = new Promise<Result<CreatedSelection, ApiError>>((resolve) => {
+      storeIt = resolve;
+    });
+    const saveSelection: SaveSelection = (pdfId) => {
+      saves.push(pdfId);
+      return new ResultAsync(inFlight);
+    };
+    const { container } = renderViewer({ measureSelection: () => MEASURED, saveSelection });
+
+    const input = await selectPassage(container);
+    await userEvent.type(input, "この段落を一言で要約して");
+    await userEvent.click(screen.getByRole("button", { name: "質問する" }));
+
+    // While it is saving, neither route in starts a second one
+    await userEvent.click(await screen.findByRole("button", { name: "送信中..." }));
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(saves).toStrictEqual([BOOK.id]);
+
+    await act(async () => {
+      storeIt(ok(STORED));
+    });
   });
 });

--- a/src/front/components/PdfViewer/PdfViewer.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.tsx
@@ -15,7 +15,7 @@ import { usePdfDocument } from "../../hooks/usePdfDocument";
 import { usePdfOutline } from "../../hooks/usePdfOutline";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
 import { useWebSearchAtom } from "../../atoms/settingsAtom";
-import { useAskAboutSelection } from "../../hooks/useAskAboutSelection";
+import { useAskAboutSelection, type SaveSelection } from "../../hooks/useAskAboutSelection";
 import { useHighlights } from "../../hooks/useHighlights";
 import type { ViewerAction } from "../../lib/keybindings";
 
@@ -25,29 +25,90 @@ interface PdfViewerProps {
   /** Why the book could not be read, if it could not. */
   bookError: Error | undefined;
   onSelectionClick: (selection: ActiveSelection) => void;
+  /**
+   * Measures the passage the reader has just dragged over, against the page it
+   * is on, into everything the popover needs.
+   *
+   * Injectable because everything the popover then does — asking, reporting a
+   * save that failed, refusing to ask twice — hangs off a real DOM selection
+   * inside a page pdf.js has drawn, and jsdom can produce neither. This is the
+   * seam those paths are tested through.
+   */
+  measureSelection?: MeasureSelection;
+  /** Stores the highlight; injectable so a failed save can be tested. */
+  saveSelection?: SaveSelection;
 }
+
+/** The popover the viewer opens over a passage, with everything it needs. */
+export interface SelectionPopoverState {
+  position: { x: number; y: number; width: number };
+  selectedText: string;
+  selectionPosition: {
+    startIndex: number;
+    endIndex: number;
+    pageNumber: number;
+    rects: SelectionRect[];
+    pageWidth: number;
+  };
+}
+
+export type MeasureSelection = (pageEl: HTMLDivElement | null) => SelectionPopoverState | null;
+
+/**
+ * Read the current selection and place it on the page.
+ *
+ * Rects are measured against the page element rather than the scroll container
+ * (which drifts as the reader scrolls), and one rect per line, so a passage
+ * spanning several lines is marked as it was drawn.
+ */
+const measureSelectionOnPage: MeasureSelection = (pageEl) => {
+  const passage = getSelectionFromTextLayer();
+  // Not a passage — a click on a highlight, say. The popover stays as it is.
+  if (!passage) return null;
+
+  const selection = window.getSelection();
+  if (!selection || !selection.rangeCount || !pageEl) return null;
+
+  const range = selection.getRangeAt(0);
+  const rect = range.getBoundingClientRect();
+  const pageRect = pageEl.getBoundingClientRect();
+
+  return {
+    position: {
+      x: rect.left - pageRect.left,
+      y: rect.top - pageRect.top,
+      width: rect.width,
+    },
+    selectedText: passage.text,
+    selectionPosition: {
+      startIndex: passage.startIndex,
+      endIndex: passage.endIndex,
+      pageNumber: passage.pageNumber,
+      rects: selectionOnPage(range, pageEl).rects,
+      // Rects are page pixels; without the width they were measured at, the
+      // highlight would drift once the page is rendered at another size
+      pageWidth: pageRect.width,
+    },
+  };
+};
 
 /** How far j/k move the page, in pixels. A few lines, like vim's line scroll. */
 const SCROLL_STEP = 80;
 
-export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps) {
+export function PdfViewer({
+  book,
+  bookError,
+  onSelectionClick,
+  measureSelection = measureSelectionOnPage,
+  saveSelection,
+}: PdfViewerProps) {
   const [currentPage, setCurrentPage] = useAtom(currentPageAtom);
   const useWebSearch = useAtomValue(useWebSearchAtom);
   const viewport = useAtomValue(pageViewportAtom);
   const containerRef = useRef<HTMLDivElement>(null);
   const pageRef = useRef<HTMLDivElement>(null);
 
-  const [popoverState, setPopoverState] = useState<{
-    position: { x: number; y: number; width: number };
-    selectedText: string;
-    selectionPosition: {
-      startIndex: number;
-      endIndex: number;
-      pageNumber: number;
-      rects: SelectionRect[];
-      pageWidth: number;
-    };
-  } | null>(null);
+  const [popoverState, setPopoverState] = useState<SelectionPopoverState | null>(null);
 
   const [contentWidth, setContentWidth] = useState(0);
   const [liveSelection, setLiveSelection] = useState<PageSelection | null>(null);
@@ -57,7 +118,7 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
   const { highlights, addHighlight } = useHighlights(book?.id);
   const { pdfDocument, error: documentError } = usePdfDocument(book);
   const { outline, error: outlineError } = usePdfOutline(pdfDocument);
-  const { askAboutSelection, saveError } = useAskAboutSelection(addHighlight);
+  const { askAboutSelection, saveError } = useAskAboutSelection(addHighlight, saveSelection);
   // Kept with the page it happened on, so turning away from a page that could
   // not be drawn takes its message with it.
   const [renderError, setRenderError] = useState<{ page: number; message: string } | null>(null);
@@ -152,49 +213,12 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
   }, []);
 
   const handleMouseUp = useCallback(() => {
+    // The browser has not settled the selection at mouseup time yet
     setTimeout(() => {
-      const result = getSelectionFromTextLayer();
-      if (!result) {
-        // Don't clear popover if clicking a highlight
-        return;
-      }
-
-      const selection = window.getSelection();
-      if (!selection || !selection.rangeCount) return;
-
-      const range = selection.getRangeAt(0);
-      const rect = range.getBoundingClientRect();
-      // Highlights are placed inside the page element, so measure against it
-      // rather than the scroll container (which drifts as the user scrolls).
-      const pageEl = pageRef.current;
-      if (!pageEl) return;
-      const pageRect = pageEl.getBoundingClientRect();
-
-      const position = {
-        x: rect.left - pageRect.left,
-        y: rect.top - pageRect.top,
-        width: rect.width,
-      };
-
-      // One rect per line, so a selection spanning several lines is marked as
-      // the reader drew it rather than as one box over the whole paragraph
-      const { rects } = selectionOnPage(range, pageEl);
-
-      setPopoverState({
-        position,
-        selectedText: result.text,
-        selectionPosition: {
-          startIndex: result.startIndex,
-          endIndex: result.endIndex,
-          pageNumber: result.pageNumber,
-          rects,
-          // Rects are page pixels; without the width they were measured at,
-          // the highlight would drift once the page is rendered at another size
-          pageWidth: pageRect.width,
-        },
-      });
+      const measured = measureSelection(pageRef.current);
+      if (measured) setPopoverState(measured);
     }, 10);
-  }, []);
+  }, [measureSelection]);
 
   const handlePopoverSubmit = useCallback(
     async (question: string) => {
@@ -255,7 +279,7 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
       {documentError !== null ? (
         <div className="flex items-center justify-center flex-1">
           <p role="alert" className="text-red-500 text-lg">
-            {documentError}
+            PDFを表示できません: {documentError}
           </p>
         </div>
       ) : null}
@@ -268,7 +292,7 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
 
       {saveError !== null ? (
         <p role="alert" className="m-2 rounded-md bg-red-50 p-3 text-sm text-red-600">
-          {saveError}
+          ハイライトを保存できませんでした: {saveError}
         </p>
       ) : null}
 
@@ -278,9 +302,16 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
         </p>
       ) : null}
 
-      {pdfDocument && (
+      {/* The page and everything anchored to it. `popoverState` is in the
+          condition because the popover is positioned against the page element
+          and so has to live inside it: in a browser only a drawn page can
+          produce a popover, but a test driving `measureSelection` has no pdf.js
+          to draw one with. */}
+      {(pdfDocument || popoverState) && (
         <div className="flex min-h-0 flex-1">
           {outlineOpen && (
+            // Only reachable once pdf.js has handed over a document, so this
+            // wiring of `error` is held by the type checker, not by a test.
             <PdfOutline
               outline={outline}
               error={outlineError}
@@ -291,7 +322,9 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
 
           <div ref={containerRef} className="flex-1 overflow-auto p-4">
             <div ref={pageRef} className="relative mx-auto" style={{ width: "fit-content" }}>
-              {contentWidth > 0 && (
+              {/* Same again: only a drawn page reports a render failure, so
+                  `onError` is wired under the type checker's eye alone. */}
+              {pdfDocument && contentWidth > 0 && (
                 <PdfPage
                   pdfDoc={pdfDocument}
                   pageNumber={currentPage}

--- a/src/front/components/PdfViewer/PdfViewer.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.tsx
@@ -2,7 +2,7 @@
 import { useRef, useState, useCallback, useEffect } from "react";
 import { useAtomValue, useAtom } from "jotai";
 import { currentPageAtom, pageViewportAtom, outlineOpenAtom } from "../../atoms/pdfAtom";
-import { activeSelectionAtom, chatMessagesAtom, type ActiveSelection } from "../../atoms/chatAtom";
+import type { ActiveSelection } from "../../atoms/chatAtom";
 import type { SelectionRect } from "../../../shared/schemas/selection";
 import type { BookDetail } from "../../../shared/schemas/book";
 import { PdfPage } from "./PdfPage";
@@ -15,11 +15,9 @@ import { usePdfDocument } from "../../hooks/usePdfDocument";
 import { usePdfOutline } from "../../hooks/usePdfOutline";
 import { useKeyboardShortcuts } from "../../hooks/useKeyboardShortcuts";
 import { useWebSearchAtom } from "../../atoms/settingsAtom";
-import { useChatStream } from "../../hooks/useChatStream";
+import { useAskAboutSelection } from "../../hooks/useAskAboutSelection";
 import { useHighlights } from "../../hooks/useHighlights";
 import type { ViewerAction } from "../../lib/keybindings";
-import { fetcher } from "../../lib/fetcher";
-import { createdSelectionSchema } from "../../../shared/schemas/selection";
 
 interface PdfViewerProps {
   /** The book being read, or nothing while it is still being read in. */
@@ -34,8 +32,6 @@ const SCROLL_STEP = 80;
 
 export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps) {
   const [currentPage, setCurrentPage] = useAtom(currentPageAtom);
-  const [, setActiveSelection] = useAtom(activeSelectionAtom);
-  const [, setChatMessages] = useAtom(chatMessagesAtom);
   const useWebSearch = useAtomValue(useWebSearchAtom);
   const viewport = useAtomValue(pageViewportAtom);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -61,7 +57,7 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
   const { highlights, addHighlight } = useHighlights(book?.id);
   const { pdfDocument } = usePdfDocument(book);
   const { outline } = usePdfOutline(pdfDocument);
-  const { sendMessage } = useChatStream();
+  const { askAboutSelection, saveError } = useAskAboutSelection(addHighlight);
 
   const pageCount = book?.pageCount ?? 1;
   const handleShortcut = useCallback(
@@ -196,46 +192,27 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
   const handlePopoverSubmit = useCallback(
     async (question: string) => {
       if (!popoverState || !book) return;
-      setPopoverState(null);
 
-      try {
-        const selection = await fetcher(`/api/pdf/${book.id}/selections`, createdSelectionSchema, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            selectedText: popoverState.selectedText,
-            pageNumber: popoverState.selectionPosition.pageNumber,
-            // The rest of the measurement (the text offsets the passage was
-            // found at) is stripped by the endpoint.
-            positionData: popoverState.selectionPosition,
-          }),
-        });
+      const asked = await askAboutSelection(
+        book.id,
+        {
+          selectedText: popoverState.selectedText,
+          pageNumber: popoverState.selectionPosition.pageNumber,
+          // The rest of the measurement (the text offsets the passage was
+          // found at) is stripped by the endpoint.
+          positionData: popoverState.selectionPosition,
+        },
+        question,
+        useWebSearch,
+      );
 
-        addHighlight(selection);
-
-        // Open the chat for this selection, then stream the answer into it.
-        // Going through sendMessage is what shows the question immediately and
-        // renders the answer as it arrives.
-        setActiveSelection({
-          id: selection.id,
-          selectedText: selection.selectedText,
-          pageNumber: selection.pageNumber,
-        });
-        setChatMessages([]);
-        await sendMessage(book.id, selection.id, question, useWebSearch);
-      } catch (err) {
-        console.error("Failed to create selection:", err);
-      }
+      // Closing on the stored highlight rather than on the answer: the answer
+      // takes seconds, and a popover held open for it would sit over the page
+      // the whole time. A highlight that was not stored keeps the popover, and
+      // the question in it, so the reader can send it again.
+      if (asked.isOk()) setPopoverState(null);
     },
-    [
-      popoverState,
-      book,
-      addHighlight,
-      useWebSearch,
-      setActiveSelection,
-      setChatMessages,
-      sendMessage,
-    ],
+    [popoverState, book, askAboutSelection, useWebSearch],
   );
 
   const handlePopoverDismiss = useCallback(() => {
@@ -272,6 +249,12 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
         <div className="flex items-center justify-center flex-1">
           <div className="text-gray-500 text-lg">PDFを読み込み中...</div>
         </div>
+      ) : null}
+
+      {saveError !== null ? (
+        <p role="alert" className="m-2 rounded-md bg-red-50 p-3 text-sm text-red-600">
+          {saveError}
+        </p>
       ) : null}
 
       {pdfDocument && (

--- a/src/front/components/PdfViewer/PdfViewer.tsx
+++ b/src/front/components/PdfViewer/PdfViewer.tsx
@@ -55,9 +55,16 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
   const [outlineOpen, setOutlineOpen] = useAtom(outlineOpenAtom);
 
   const { highlights, addHighlight } = useHighlights(book?.id);
-  const { pdfDocument } = usePdfDocument(book);
-  const { outline } = usePdfOutline(pdfDocument);
+  const { pdfDocument, error: documentError } = usePdfDocument(book);
+  const { outline, error: outlineError } = usePdfOutline(pdfDocument);
   const { askAboutSelection, saveError } = useAskAboutSelection(addHighlight);
+  // Kept with the page it happened on, so turning away from a page that could
+  // not be drawn takes its message with it.
+  const [renderError, setRenderError] = useState<{ page: number; message: string } | null>(null);
+  const reportRenderError = useCallback(
+    (message: string) => setRenderError({ page: currentPage, message }),
+    [currentPage],
+  );
 
   const pageCount = book?.pageCount ?? 1;
   const handleShortcut = useCallback(
@@ -245,6 +252,14 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
         </div>
       ) : null}
 
+      {documentError !== null ? (
+        <div className="flex items-center justify-center flex-1">
+          <p role="alert" className="text-red-500 text-lg">
+            {documentError}
+          </p>
+        </div>
+      ) : null}
+
       {!book && !bookError ? (
         <div className="flex items-center justify-center flex-1">
           <div className="text-gray-500 text-lg">PDFを読み込み中...</div>
@@ -257,10 +272,21 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
         </p>
       ) : null}
 
+      {renderError?.page === currentPage ? (
+        <p role="alert" className="m-2 rounded-md bg-red-50 p-3 text-sm text-red-600">
+          このページを表示できません: {renderError.message}
+        </p>
+      ) : null}
+
       {pdfDocument && (
         <div className="flex min-h-0 flex-1">
           {outlineOpen && (
-            <PdfOutline outline={outline} currentPage={currentPage} onJump={setCurrentPage} />
+            <PdfOutline
+              outline={outline}
+              error={outlineError}
+              currentPage={currentPage}
+              onJump={setCurrentPage}
+            />
           )}
 
           <div ref={containerRef} className="flex-1 overflow-auto p-4">
@@ -270,6 +296,7 @@ export function PdfViewer({ book, bookError, onSelectionClick }: PdfViewerProps)
                   pdfDoc={pdfDocument}
                   pageNumber={currentPage}
                   containerWidth={contentWidth}
+                  onError={reportRenderError}
                 />
               )}
               <HighlightOverlay

--- a/src/front/components/PdfViewer/SelectionPopover.test.tsx
+++ b/src/front/components/PdfViewer/SelectionPopover.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vite-plus/test";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SelectionPopover } from "./SelectionPopover";
 
@@ -31,6 +31,64 @@ describe("SelectionPopover", () => {
     await userEvent.click(screen.getByRole("button", { name: "質問する" }));
 
     expect(onSubmit.mock.calls).toEqual([["この段落を一言で要約して"]]);
+  });
+
+  it("asks once while the first ask is still in flight", async () => {
+    // The popover now stays open until the highlight is stored, so a second
+    // submit during that window used to create a second highlight and a second
+    // answer that killed the first one's stream.
+    let finishAsking!: () => void;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishAsking = resolve;
+        }),
+    );
+    render(<SelectionPopover onSubmit={onSubmit} onDismiss={vi.fn()} />);
+    const input = screen.getByPlaceholderText("選択した文章について質問する...");
+    await userEvent.type(input, "この段落を一言で要約して");
+
+    await userEvent.click(screen.getByRole("button", { name: "質問する" }));
+
+    // The reader can see the ask is under way, and neither the button nor
+    // Enter starts a second one
+    const asking = screen.getByRole("button", { name: "送信中..." });
+    expect(asking).toBeDisabled();
+    await userEvent.click(asking);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSubmit.mock.calls).toEqual([["この段落を一言で要約して"]]);
+
+    await act(async () => {
+      finishAsking();
+    });
+  });
+
+  it("lets the reader ask again once a failed ask has finished", async () => {
+    // The popover is kept open on failure precisely so the question can be
+    // sent again; it must not stay stuck in its sending state.
+    let failAsking!: () => void;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((_, reject) => {
+          failAsking = () => reject(new Error("Server exploded"));
+        }),
+    );
+    render(<SelectionPopover onSubmit={onSubmit} onDismiss={vi.fn()} />);
+    const input = screen.getByPlaceholderText("選択した文章について質問する...");
+    await userEvent.type(input, "この段落を一言で要約して");
+
+    await userEvent.click(screen.getByRole("button", { name: "質問する" }));
+    await act(async () => {
+      failAsking();
+    });
+
+    await userEvent.click(await screen.findByRole("button", { name: "質問する" }));
+
+    expect(onSubmit.mock.calls).toEqual([
+      ["この段落を一言で要約して"],
+      ["この段落を一言で要約して"],
+    ]);
   });
 
   it("keeps the question unsent when Enter only confirms an IME conversion", async () => {

--- a/src/front/components/PdfViewer/SelectionPopover.tsx
+++ b/src/front/components/PdfViewer/SelectionPopover.tsx
@@ -3,7 +3,12 @@ import { useState, useRef, useEffect } from "react";
 import { isSubmitKey } from "../../lib/isSubmitKey";
 
 interface SelectionPopoverProps {
-  onSubmit: (question: string) => void;
+  /**
+   * Asks the question. Awaited, so the popover can hold the reader off until
+   * the ask has been dealt with: it stays open when the highlight could not be
+   * stored, and a popover that stays open is one that can be submitted twice.
+   */
+  onSubmit: (question: string) => void | Promise<void>;
   onDismiss: () => void;
 }
 
@@ -13,6 +18,7 @@ interface SelectionPopoverProps {
  */
 export function SelectionPopover({ onSubmit, onDismiss }: SelectionPopoverProps) {
   const [question, setQuestion] = useState("");
+  const [asking, setAsking] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
 
@@ -44,17 +50,30 @@ export function SelectionPopover({ onSubmit, onDismiss }: SelectionPopoverProps)
     return () => document.removeEventListener("mousedown", handleClick);
   }, [onDismiss]);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const q = question.trim();
-    if (q) {
-      onSubmit(q);
+    // One ask at a time. Both routes in (the button and Enter) come through
+    // here, so this is the only gate needed.
+    if (!q || asking) return;
+
+    setAsking(true);
+    try {
+      await onSubmit(q);
+    } catch {
+      // Reporting is the asker's job — it owns the message and where it shows.
+      // Swallowing here only stops a rejection escaping an event handler,
+      // where nothing (not even the route's errorElement) would catch it.
+    } finally {
+      // A successful ask unmounts this popover, so this only ever puts a
+      // failed one back within reach of the reader.
+      setAsking(false);
     }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (isSubmitKey(e.nativeEvent as unknown as KeyboardEvent)) {
       e.preventDefault();
-      handleSubmit();
+      void handleSubmit();
     }
   };
 
@@ -73,7 +92,8 @@ export function SelectionPopover({ onSubmit, onDismiss }: SelectionPopoverProps)
         onChange={(e) => setQuestion(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder="選択した文章について質問する..."
-        className="w-full min-w-[280px] p-2 text-sm border border-gray-300 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+        readOnly={asking}
+        className="w-full min-w-[280px] p-2 text-sm border border-gray-300 rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent read-only:bg-gray-50"
         rows={2}
       />
       <div className="flex justify-end gap-2 mt-2">
@@ -86,11 +106,11 @@ export function SelectionPopover({ onSubmit, onDismiss }: SelectionPopoverProps)
         </button>
         <button
           type="button"
-          onClick={handleSubmit}
-          disabled={!question.trim()}
+          onClick={() => void handleSubmit()}
+          disabled={!question.trim() || asking}
           className="px-3 py-1 text-xs bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
         >
-          質問する
+          {asking ? "送信中..." : "質問する"}
         </button>
       </div>
     </div>

--- a/src/front/components/RouteErrorBoundary.test.tsx
+++ b/src/front/components/RouteErrorBoundary.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach, vi } from "vite-plus/test";
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router";
+import { RouteErrorBoundary } from "./RouteErrorBoundary";
+
+function Exploding(): never {
+  throw new Error("Cannot read properties of undefined");
+}
+
+describe("RouteErrorBoundary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("says the page broke instead of leaving a blank screen", async () => {
+    // A throw while rendering is the one failure a Result cannot carry: React
+    // unmounts the whole tree, and without a boundary the reader is left
+    // looking at an empty document.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const router = createMemoryRouter(
+      [{ path: "/", element: <Exploding />, errorElement: <RouteErrorBoundary /> }],
+      { initialEntries: ["/"] },
+    );
+
+    render(<RouterProvider router={router} />);
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /^表示中に問題が発生しました: Cannot read properties of undefined$/,
+    );
+    expect(screen.getByRole("link", { name: "本棚に戻る" })).toBeInTheDocument();
+  });
+});

--- a/src/front/components/RouteErrorBoundary.tsx
+++ b/src/front/components/RouteErrorBoundary.tsx
@@ -1,0 +1,25 @@
+import { Link, useRouteError } from "react-router";
+
+/**
+ * What a route shows when rendering it threw.
+ *
+ * Everything else in this app reports a failure as a value, but a throw during
+ * render is not on that path: React tears the tree down and the reader is left
+ * with a blank page and no way back. In a data router the `errorElement` is the
+ * boundary, so this component is both.
+ */
+export function RouteErrorBoundary() {
+  const error = useRouteError();
+  const reason = error instanceof Error ? error.message : String(error);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 p-6">
+      <p role="alert" className="rounded-md bg-red-50 p-4 text-sm text-red-600">
+        表示中に問題が発生しました: {reason}
+      </p>
+      <Link to="/" className="text-sm text-blue-600 hover:underline">
+        本棚に戻る
+      </Link>
+    </div>
+  );
+}

--- a/src/front/hooks/useAskAboutSelection.test.tsx
+++ b/src/front/hooks/useAskAboutSelection.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, afterEach, vi } from "vite-plus/test";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import { errAsync, okAsync } from "neverthrow";
+import type { ReactNode } from "react";
+import { useAskAboutSelection, type SaveSelection } from "./useAskAboutSelection";
+import { activeSelectionAtom, chatMessagesAtom } from "../atoms/chatAtom";
+import { ApiError } from "../lib/fetcher";
+import { streamingFetchStub } from "../../test/streamingFetchStub";
+import type { CreatedSelection } from "../../shared/schemas/selection";
+
+const PDF_ID = "p1";
+const QUESTION = "この段落を一言で要約して";
+const PASSAGE = "エッジはサーバーレス実行基盤です。";
+
+const DRAFT = {
+  selectedText: PASSAGE,
+  pageNumber: 42,
+  positionData: { rects: [{ x: 10, y: 20, width: 100, height: 16 }], pageWidth: 600 },
+};
+
+const STORED: CreatedSelection = {
+  id: "s1",
+  selectedText: PASSAGE,
+  pageNumber: 42,
+  positionData: { rects: [{ x: 10, y: 20, width: 100, height: 16 }], pageWidth: 600 },
+  createdAt: "2026-08-01T10:00:00.000Z",
+};
+
+function renderAsk(saveSelection: SaveSelection) {
+  const store = createStore();
+  const added: CreatedSelection[] = [];
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+
+  return {
+    store,
+    added,
+    view: renderHook(
+      () => useAskAboutSelection((selection) => added.push(selection), saveSelection),
+      { wrapper },
+    ),
+  };
+}
+
+describe("useAskAboutSelection", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the highlight, opens its chat and asks the question once it is stored", async () => {
+    const { fetchFn, calls } = streamingFetchStub();
+    vi.stubGlobal("fetch", fetchFn);
+    const { store, added, view } = renderAsk(() => okAsync(STORED));
+
+    await act(async () => {
+      await view.result.current.askAboutSelection(PDF_ID, DRAFT, QUESTION, false);
+    });
+
+    expect(added).toStrictEqual([STORED]);
+    expect(store.get(activeSelectionAtom)).toStrictEqual({
+      id: "s1",
+      selectedText: PASSAGE,
+      pageNumber: 42,
+    });
+    await waitFor(() =>
+      expect(calls.map((call) => [call.url, call.body])).toStrictEqual([
+        ["/api/pdf/p1/selections/s1/chats", { content: QUESTION, useWebSearch: false }],
+      ]),
+    );
+    expect(view.result.current.saveError).toBeNull();
+  });
+
+  it("says the highlight could not be saved and asks nothing about it", async () => {
+    // Asking about a passage that was never stored would stream an answer into
+    // a conversation with nothing to attach it to.
+    const { fetchFn, calls } = streamingFetchStub();
+    vi.stubGlobal("fetch", fetchFn);
+    const { store, added, view } = renderAsk(() =>
+      errAsync(new ApiError("PDF not found", "PDF_NOT_FOUND", 404)),
+    );
+
+    let asked!: Awaited<ReturnType<typeof view.result.current.askAboutSelection>>;
+    await act(async () => {
+      asked = await view.result.current.askAboutSelection(PDF_ID, DRAFT, QUESTION, false);
+    });
+
+    expect(asked._unsafeUnwrapErr().code).toBe("PDF_NOT_FOUND");
+    expect(view.result.current.saveError).toBe("ハイライトを保存できませんでした: PDF not found");
+    expect(added).toStrictEqual([]);
+    expect(calls).toStrictEqual([]);
+    expect(store.get(activeSelectionAtom)).toBeNull();
+    expect(store.get(chatMessagesAtom)).toStrictEqual([]);
+  });
+});

--- a/src/front/hooks/useAskAboutSelection.test.tsx
+++ b/src/front/hooks/useAskAboutSelection.test.tsx
@@ -86,7 +86,13 @@ describe("useAskAboutSelection", () => {
       asked = await view.result.current.askAboutSelection(PDF_ID, DRAFT, QUESTION, false);
     });
 
-    expect(asked._unsafeUnwrapErr().code).toBe("PDF_NOT_FOUND");
+    const failure = asked._unsafeUnwrapErr();
+    expect([failure.message, failure.code, failure.status, failure.kind]).toStrictEqual([
+      "PDF not found",
+      "PDF_NOT_FOUND",
+      404,
+      "http",
+    ]);
     expect(view.result.current.saveError).toBe("ハイライトを保存できませんでした: PDF not found");
     expect(added).toStrictEqual([]);
     expect(calls).toStrictEqual([]);

--- a/src/front/hooks/useAskAboutSelection.test.tsx
+++ b/src/front/hooks/useAskAboutSelection.test.tsx
@@ -93,7 +93,7 @@ describe("useAskAboutSelection", () => {
       404,
       "http",
     ]);
-    expect(view.result.current.saveError).toBe("ハイライトを保存できませんでした: PDF not found");
+    expect(view.result.current.saveError).toBe("PDF not found");
     expect(added).toStrictEqual([]);
     expect(calls).toStrictEqual([]);
     expect(store.get(activeSelectionAtom)).toBeNull();

--- a/src/front/hooks/useAskAboutSelection.ts
+++ b/src/front/hooks/useAskAboutSelection.ts
@@ -1,0 +1,78 @@
+import { useCallback, useState } from "react";
+import { useSetAtom } from "jotai";
+import type { ResultAsync } from "neverthrow";
+import { activeSelectionAtom, chatMessagesAtom } from "../atoms/chatAtom";
+import { resultFetcher, type ApiError } from "../lib/fetcher";
+import {
+  createdSelectionSchema,
+  type CreatedSelection,
+  type PositionData,
+} from "../../shared/schemas/selection";
+import { useChatStream } from "./useChatStream";
+
+/** A highlight the reader has just drawn, before the server has an id for it. */
+export interface SelectionDraft {
+  selectedText: string;
+  pageNumber: number;
+  /** Sent whole; the endpoint keeps only `rects` and `pageWidth`. */
+  positionData: PositionData;
+}
+
+export type SaveSelection = (
+  pdfId: string,
+  draft: SelectionDraft,
+) => ResultAsync<CreatedSelection, ApiError>;
+
+const storeSelection: SaveSelection = (pdfId, draft) =>
+  resultFetcher(`/api/pdf/${pdfId}/selections`, createdSelectionSchema, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(draft),
+  });
+
+/**
+ * Turn a passage the reader has just marked into a highlight and a question
+ * about it.
+ *
+ * The two steps are in that order for a reason: the answer is stored against
+ * the highlight, so asking before the highlight exists would stream a reply
+ * with nothing to hang it on. A failure to store therefore stops the ask, and
+ * the caller is told so — the viewer keeps its popover open, with the question
+ * still in it, rather than losing what the reader typed.
+ */
+export function useAskAboutSelection(
+  addHighlight: (selection: CreatedSelection) => void,
+  saveSelection: SaveSelection = storeSelection,
+) {
+  const setActiveSelection = useSetAtom(activeSelectionAtom);
+  const setChatMessages = useSetAtom(chatMessagesAtom);
+  const { sendMessage } = useChatStream();
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const askAboutSelection = useCallback(
+    (pdfId: string, draft: SelectionDraft, question: string, useWebSearch: boolean) => {
+      setSaveError(null);
+
+      return saveSelection(pdfId, draft)
+        .andTee((selection) => {
+          addHighlight(selection);
+          setActiveSelection({
+            id: selection.id,
+            selectedText: selection.selectedText,
+            pageNumber: selection.pageNumber,
+          });
+          setChatMessages([]);
+          // The answer is not waited for. It takes seconds to arrive, and what
+          // the caller is waiting on is whether the highlight was kept. The
+          // stream reports its own failures through chatErrorAtom.
+          void sendMessage(pdfId, selection.id, question, useWebSearch);
+        })
+        .orTee((failure) => {
+          setSaveError(`ハイライトを保存できませんでした: ${failure.message}`);
+        });
+    },
+    [addHighlight, saveSelection, sendMessage, setActiveSelection, setChatMessages],
+  );
+
+  return { askAboutSelection, saveError };
+}

--- a/src/front/hooks/useAskAboutSelection.ts
+++ b/src/front/hooks/useAskAboutSelection.ts
@@ -68,7 +68,9 @@ export function useAskAboutSelection(
           void sendMessage(pdfId, selection.id, question, useWebSearch);
         })
         .orTee((failure) => {
-          setSaveError(`ハイライトを保存できませんでした: ${failure.message}`);
+          // Why it failed, in the server's words. The viewer writes the
+          // sentence around it, as every other display of a failure does.
+          setSaveError(failure.message);
         });
     },
     [addHighlight, saveSelection, sendMessage, setActiveSelection, setChatMessages],

--- a/src/front/hooks/useChatStream.test.tsx
+++ b/src/front/hooks/useChatStream.test.tsx
@@ -2,10 +2,12 @@ import { describe, it, expect } from "vite-plus/test";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { Provider, createStore } from "jotai";
 import type { ReactNode } from "react";
+import type { ResultAsync } from "neverthrow";
 import { useChatStream } from "./useChatStream";
 import {
   abortChatStreamAtom,
   chatAbortControllerAtom,
+  chatErrorAtom,
   chatMessagesAtom,
   isStreamingAtom,
   streamingContentAtom,
@@ -35,7 +37,7 @@ describe("useChatStream", () => {
     const { fetchFn, calls } = streamingFetchStub();
     const { store, view } = renderChatStream(fetchFn);
 
-    let sent!: Promise<void>;
+    let sent!: ResultAsync<string, ApiError>;
     await act(async () => {
       sent = view.result.current.sendMessage("p1", "s1", QUESTION, false);
     });
@@ -62,13 +64,10 @@ describe("useChatStream", () => {
   it("keeps a half-written answer out of the conversation when the chat is left", async () => {
     const { fetchFn, calls } = streamingFetchStub();
     const { store, view } = renderChatStream(fetchFn);
-    const errors: Error[] = [];
 
-    let sent!: Promise<void>;
+    let sent!: ResultAsync<string, ApiError>;
     await act(async () => {
-      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false, {
-        onError: (err) => errors.push(err),
-      });
+      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false);
     });
     await act(async () => {
       calls[0].emit(tokenEvent("単一の"));
@@ -85,14 +84,17 @@ describe("useChatStream", () => {
     ]);
     expect(store.get(streamingContentAtom)).toBe("");
     expect(store.get(isStreamingAtom)).toBe(false);
-    expect(errors).toEqual([]);
+    // Nothing was delivered, so the send failed — but the reader asked for that
+    // and must not be shown an error for it.
+    expect((await sent)._unsafeUnwrapErr().code).toBe("ABORTED");
+    expect(store.get(chatErrorAtom)).toBeNull();
   });
 
   it("drops the answer still streaming when the next question is asked", async () => {
     const { fetchFn, calls } = streamingFetchStub();
     const { store, view } = renderChatStream(fetchFn);
 
-    let firstSent!: Promise<void>;
+    let firstSent!: ResultAsync<string, ApiError>;
     await act(async () => {
       firstSent = view.result.current.sendMessage("p1", "s1", "最初の質問", false);
     });
@@ -101,7 +103,7 @@ describe("useChatStream", () => {
     });
     await waitFor(() => expect(store.get(streamingContentAtom)).toBe("途中まで"));
 
-    let secondSent!: Promise<void>;
+    let secondSent!: ResultAsync<string, ApiError>;
     await act(async () => {
       secondSent = view.result.current.sendMessage("p1", "s1", "次の質問", false);
     });
@@ -129,7 +131,7 @@ describe("useChatStream", () => {
     const { store, view } = renderChatStream(fetchFn);
     const received: Citation[] = [];
 
-    let sent!: Promise<void>;
+    let sent!: ResultAsync<string, ApiError>;
     await act(async () => {
       sent = view.result.current.sendMessage("p1", "s1", QUESTION, false, {
         onCitation: (citation) => received.push(citation),
@@ -153,14 +155,11 @@ describe("useChatStream", () => {
 
   it("reports the code as well as the message when the stream carries an error event", async () => {
     const { fetchFn, calls } = streamingFetchStub();
-    const { view } = renderChatStream(fetchFn);
-    const errors: Error[] = [];
+    const { store, view } = renderChatStream(fetchFn);
 
-    let sent!: Promise<void>;
+    let sent!: ResultAsync<string, ApiError>;
     await act(async () => {
-      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false, {
-        onError: (err) => errors.push(err),
-      });
+      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false);
     });
     await act(async () => {
       calls[0].emit(errorEvent("AI_API_ERROR", "upstream is down"));
@@ -168,10 +167,92 @@ describe("useChatStream", () => {
       await sent;
     });
 
-    expect(errors.map((err) => [err.message, (err as ApiError).code])).toStrictEqual([
-      ["upstream is down", "AI_API_ERROR"],
+    const failure = (await sent)._unsafeUnwrapErr();
+    expect([failure.message, failure.code, failure.kind]).toStrictEqual([
+      "upstream is down",
+      "AI_API_ERROR",
+      "http",
     ]);
-    expect(errors[0]).toBeInstanceOf(ApiError);
+    expect(store.get(chatErrorAtom)).toBe("回答の取得に失敗しました: upstream is down");
+  });
+
+  it("keeps the server's own words when the request is refused before the stream starts", async () => {
+    // The refusal used to become "HTTP 400", which threw away the one thing
+    // that says what to change about the question.
+    const refusing: typeof fetch = () =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: { code: "VALIDATION_ERROR", message: "Invalid request body: content" },
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    const { store, view } = renderChatStream(refusing);
+
+    let sent!: ResultAsync<string, ApiError>;
+    await act(async () => {
+      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false);
+      await sent;
+    });
+
+    const failure = (await sent)._unsafeUnwrapErr();
+    expect([failure.message, failure.code, failure.status, failure.kind]).toStrictEqual([
+      "Invalid request body: content",
+      "VALIDATION_ERROR",
+      400,
+      "http",
+    ]);
+    expect(store.get(chatErrorAtom)).toBe(
+      "回答の取得に失敗しました: Invalid request body: content",
+    );
+  });
+
+  it("reports a request that never reached the server instead of leaving the panel silent", async () => {
+    const offline: typeof fetch = () => Promise.reject(new TypeError("Failed to fetch"));
+    const { store, view } = renderChatStream(offline);
+
+    let sent!: ResultAsync<string, ApiError>;
+    await act(async () => {
+      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false);
+      await sent;
+    });
+
+    expect((await sent)._unsafeUnwrapErr().code).toBe("NETWORK_ERROR");
+    expect(store.get(chatErrorAtom)).toBe(
+      "回答の取得に失敗しました: request to /api/pdf/p1/selections/s1/chats could not be sent",
+    );
+    expect(store.get(isStreamingAtom)).toBe(false);
+  });
+
+  it("drops the previous failure when the next question is asked", async () => {
+    const { fetchFn, calls } = streamingFetchStub();
+    const { store, view } = renderChatStream(fetchFn);
+
+    let failed!: ResultAsync<string, ApiError>;
+    await act(async () => {
+      failed = view.result.current.sendMessage("p1", "s1", QUESTION, false);
+    });
+    await act(async () => {
+      calls[0].emit(errorEvent("AI_API_ERROR", "upstream is down"));
+      calls[0].end();
+      await failed;
+    });
+    expect(store.get(chatErrorAtom)).toBe("回答の取得に失敗しました: upstream is down");
+
+    let retried!: ResultAsync<string, ApiError>;
+    await act(async () => {
+      retried = view.result.current.sendMessage("p1", "s1", "もう一度", false);
+    });
+    await act(async () => {
+      calls[1].emit(tokenEvent("単一のインスタンスです"));
+      calls[1].emit(doneEvent("m2"));
+      calls[1].end();
+      await retried;
+    });
+
+    expect((await retried)._unsafeUnwrap()).toBe("m2");
+    expect(store.get(chatErrorAtom)).toBeNull();
   });
 
   it("stamps both messages with the injected clock instead of the wall clock", async () => {
@@ -179,7 +260,7 @@ describe("useChatStream", () => {
     const { fetchFn, calls } = streamingFetchStub();
     const { store, view } = renderChatStream(fetchFn, () => fixedNow);
 
-    let sent!: Promise<void>;
+    let sent!: ResultAsync<string, ApiError>;
     await act(async () => {
       sent = view.result.current.sendMessage("p1", "s1", QUESTION, false);
     });

--- a/src/front/hooks/useChatStream.test.tsx
+++ b/src/front/hooks/useChatStream.test.tsx
@@ -24,6 +24,11 @@ import type { Citation } from "../../shared/schemas/citation";
 
 const QUESTION = "Durable Objects とは?";
 
+/** The four facts a caller reads off a failure, in one comparable value. */
+function failureOf(error: ApiError): [string, string, number, string] {
+  return [error.message, error.code, error.status, error.kind];
+}
+
 function renderChatStream(fetchFn: typeof fetch, now?: () => Date) {
   const store = createStore();
   const wrapper = ({ children }: { children: ReactNode }) => (
@@ -86,7 +91,12 @@ describe("useChatStream", () => {
     expect(store.get(isStreamingAtom)).toBe(false);
     // Nothing was delivered, so the send failed — but the reader asked for that
     // and must not be shown an error for it.
-    expect((await sent)._unsafeUnwrapErr().code).toBe("ABORTED");
+    expect(failureOf((await sent)._unsafeUnwrapErr())).toStrictEqual([
+      "The operation was aborted.",
+      "ABORTED",
+      0,
+      "network",
+    ]);
     expect(store.get(chatErrorAtom)).toBeNull();
   });
 
@@ -167,10 +177,10 @@ describe("useChatStream", () => {
       await sent;
     });
 
-    const failure = (await sent)._unsafeUnwrapErr();
-    expect([failure.message, failure.code, failure.kind]).toStrictEqual([
+    expect(failureOf((await sent)._unsafeUnwrapErr())).toStrictEqual([
       "upstream is down",
       "AI_API_ERROR",
+      200,
       "http",
     ]);
     expect(store.get(chatErrorAtom)).toBe("回答の取得に失敗しました: upstream is down");
@@ -196,8 +206,7 @@ describe("useChatStream", () => {
       await sent;
     });
 
-    const failure = (await sent)._unsafeUnwrapErr();
-    expect([failure.message, failure.code, failure.status, failure.kind]).toStrictEqual([
+    expect(failureOf((await sent)._unsafeUnwrapErr())).toStrictEqual([
       "Invalid request body: content",
       "VALIDATION_ERROR",
       400,
@@ -218,7 +227,12 @@ describe("useChatStream", () => {
       await sent;
     });
 
-    expect((await sent)._unsafeUnwrapErr().code).toBe("NETWORK_ERROR");
+    expect(failureOf((await sent)._unsafeUnwrapErr())).toStrictEqual([
+      "request to /api/pdf/p1/selections/s1/chats could not be sent",
+      "NETWORK_ERROR",
+      0,
+      "network",
+    ]);
     expect(store.get(chatErrorAtom)).toBe(
       "回答の取得に失敗しました: request to /api/pdf/p1/selections/s1/chats could not be sent",
     );

--- a/src/front/hooks/useChatStream.test.tsx
+++ b/src/front/hooks/useChatStream.test.tsx
@@ -186,6 +186,58 @@ describe("useChatStream", () => {
     expect(store.get(chatErrorAtom)).toBe("回答の取得に失敗しました: upstream is down");
   });
 
+  it("keeps an answer the server could not store on screen and says it will not last", async () => {
+    // The model finished and the tokens are already paid for; only the write
+    // failed. Discarding it would take a readable answer away from the reader
+    // for a reason that has nothing to do with the answer.
+    const { fetchFn, calls } = streamingFetchStub();
+    const { store, view } = renderChatStream(fetchFn);
+
+    let sent!: ResultAsync<string, ApiError>;
+    await act(async () => {
+      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false);
+    });
+    await act(async () => {
+      calls[0].emit(tokenEvent("単一のインスタンスです"));
+      calls[0].emit(errorEvent("CHAT_SAVE_FAILED", "The answer could not be saved"));
+      calls[0].end();
+      await sent;
+    });
+
+    expect(store.get(chatMessagesAtom).map((m) => [m.role, m.content])).toStrictEqual([
+      ["user", QUESTION],
+      ["assistant", "単一のインスタンスです"],
+    ]);
+    expect(store.get(chatErrorAtom)).toBe(
+      "この回答は保存できませんでした。チャットを開き直すと消えます",
+    );
+    expect((await sent)._unsafeUnwrapErr().code).toBe("CHAT_SAVE_FAILED");
+  });
+
+  it("drops a half-written answer the model never finished", async () => {
+    // The other side of the split: a stream that broke mid-generation has no
+    // answer to keep, so leaving the fragment would read as a finished reply.
+    const { fetchFn, calls } = streamingFetchStub();
+    const { store, view } = renderChatStream(fetchFn);
+
+    let sent!: ResultAsync<string, ApiError>;
+    await act(async () => {
+      sent = view.result.current.sendMessage("p1", "s1", QUESTION, false);
+    });
+    await act(async () => {
+      calls[0].emit(tokenEvent("単一の"));
+      calls[0].emit(errorEvent("AI_STREAM_ERROR", "upstream closed the stream"));
+      calls[0].end();
+      await sent;
+    });
+
+    expect(store.get(chatMessagesAtom).map((m) => [m.role, m.content])).toStrictEqual([
+      ["user", QUESTION],
+    ]);
+    expect(store.get(streamingContentAtom)).toBe("");
+    expect(store.get(chatErrorAtom)).toBe("回答の取得に失敗しました: upstream closed the stream");
+  });
+
   it("keeps the server's own words when the request is refused before the stream starts", async () => {
     // The refusal used to become "HTTP 400", which threw away the one thing
     // that says what to change about the question.

--- a/src/front/hooks/useChatStream.ts
+++ b/src/front/hooks/useChatStream.ts
@@ -10,10 +10,9 @@ import {
   abortChatStreamAtom,
 } from "../atoms/chatAtom";
 import { createSseParser } from "../lib/sseParser";
-import { ApiError, networkFailure } from "../lib/fetcher";
+import { ApiError, networkFailure, readRefusal } from "../lib/fetcher";
 import type { ChatMessage } from "../../shared/schemas/chat";
 import type { Citation } from "../../shared/schemas/citation";
-import { errorEnvelopeSchema } from "../../shared/schemas/error";
 import { chatSseEventSchema } from "../../shared/schemas/sse";
 
 interface ChatStreamOptions {
@@ -30,19 +29,6 @@ export const chatFailureMessage = (failure: ApiError) =>
  * renders and `sendMessage` is not rebuilt on every render.
  */
 const systemNow = () => new Date();
-
-/** The refusal the server described, or the status when it described nothing. */
-async function refusal(url: string, response: Response): Promise<ApiError> {
-  const body: unknown = await response.json().catch(() => null);
-  const envelope = errorEnvelopeSchema.safeParse(body);
-  return envelope.success
-    ? new ApiError(envelope.data.error.message, envelope.data.error.code, response.status)
-    : new ApiError(
-        `request to ${url} failed with status ${response.status}`,
-        "UNKNOWN",
-        response.status,
-      );
-}
 
 /**
  * Send a question and render the answer as it streams in.
@@ -101,7 +87,7 @@ export function useChatStream(fetchFn: typeof fetch = fetch, now: () => Date = s
             signal: controller.signal,
           });
 
-          if (!response.ok) throw await refusal(url, response);
+          if (!response.ok) throw await readRefusal(url, response);
 
           const reader = response.body?.getReader();
           if (!reader) {

--- a/src/front/hooks/useChatStream.ts
+++ b/src/front/hooks/useChatStream.ts
@@ -1,28 +1,29 @@
 import { useCallback } from "react";
 import { useAtom, useSetAtom } from "jotai";
+import { ResultAsync, err, ok, type Result } from "neverthrow";
 import {
   chatMessagesAtom,
   streamingContentAtom,
   isStreamingAtom,
   chatAbortControllerAtom,
+  chatErrorAtom,
   abortChatStreamAtom,
 } from "../atoms/chatAtom";
 import { createSseParser } from "../lib/sseParser";
-import { ApiError } from "../lib/fetcher";
+import { ApiError, networkFailure } from "../lib/fetcher";
 import type { ChatMessage } from "../../shared/schemas/chat";
 import type { Citation } from "../../shared/schemas/citation";
+import { errorEnvelopeSchema } from "../../shared/schemas/error";
 import { chatSseEventSchema } from "../../shared/schemas/sse";
-
-/** fetch reports an abort with a DOMException, which does not extend Error. */
-function isAbortError(err: unknown): boolean {
-  return (err instanceof DOMException || err instanceof Error) && err.name === "AbortError";
-}
 
 interface ChatStreamOptions {
   onCitation?: (citation: Citation) => void;
   onDone?: (messageId: string) => void;
-  onError?: (error: Error) => void;
 }
+
+/** How a failure of this conversation is worded for the reader. */
+export const chatFailureMessage = (failure: ApiError) =>
+  `回答の取得に失敗しました: ${failure.message}`;
 
 /**
  * Default clock. Kept at module level so its identity is stable across
@@ -30,133 +31,172 @@ interface ChatStreamOptions {
  */
 const systemNow = () => new Date();
 
+/** The refusal the server described, or the status when it described nothing. */
+async function refusal(url: string, response: Response): Promise<ApiError> {
+  const body: unknown = await response.json().catch(() => null);
+  const envelope = errorEnvelopeSchema.safeParse(body);
+  return envelope.success
+    ? new ApiError(envelope.data.error.message, envelope.data.error.code, response.status)
+    : new ApiError(
+        `request to ${url} failed with status ${response.status}`,
+        "UNKNOWN",
+        response.status,
+      );
+}
+
 /**
  * Send a question and render the answer as it streams in.
+ *
+ * `sendMessage` hands back the id of the stored answer, or the reason there is
+ * none. The same reason is put in `chatErrorAtom`, which is what the panel
+ * shows: the return value is for a caller that has its own decision to make
+ * (the viewer keeps its popover open when the ask never got anywhere), not for
+ * getting the failure on screen.
  */
 export function useChatStream(fetchFn: typeof fetch = fetch, now: () => Date = systemNow) {
   const [, setMessages] = useAtom(chatMessagesAtom);
   const [, setStreamingContent] = useAtom(streamingContentAtom);
   const [, setIsStreaming] = useAtom(isStreamingAtom);
   const [, setAbortController] = useAtom(chatAbortControllerAtom);
+  const [, setChatError] = useAtom(chatErrorAtom);
   const abortChatStream = useSetAtom(abortChatStreamAtom);
 
   const sendMessage = useCallback(
-    async (
+    (
       pdfId: string,
       selectionId: string,
       content: string,
       useWebSearch: boolean,
       options: ChatStreamOptions = {},
-    ) => {
-      // Only one answer streams at a time, so asking again never leaves an
-      // older one writing into this conversation
-      abortChatStream();
+    ): ResultAsync<string, ApiError> => {
+      const url = `/api/pdf/${pdfId}/selections/${selectionId}/chats`;
 
-      // Show the question straight away, before the model has answered
-      const userMsg: ChatMessage = {
-        id: `temp-${now().getTime()}`,
-        role: "user",
-        content,
-        createdAt: now().toISOString(),
-      };
-      setMessages((prev) => [...prev, userMsg]);
-      setStreamingContent("");
-      setIsStreaming(true);
+      const run = async (): Promise<Result<string, ApiError>> => {
+        // Only one answer streams at a time, so asking again never leaves an
+        // older one writing into this conversation
+        abortChatStream();
 
-      const controller = new AbortController();
-      setAbortController(controller);
-      let aborted = false;
+        // Show the question straight away, before the model has answered
+        const userMsg: ChatMessage = {
+          id: `temp-${now().getTime()}`,
+          role: "user",
+          content,
+          createdAt: now().toISOString(),
+        };
+        setMessages((prev) => [...prev, userMsg]);
+        setStreamingContent("");
+        setIsStreaming(true);
+        // Whatever went wrong last time is about the question before this one
+        setChatError(null);
 
-      try {
-        const response = await fetchFn(`/api/pdf/${pdfId}/selections/${selectionId}/chats`, {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ content, useWebSearch }),
-          signal: controller.signal,
-        });
+        const controller = new AbortController();
+        setAbortController(controller);
+        let aborted = false;
 
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
+        try {
+          const response = await fetchFn(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ content, useWebSearch }),
+            signal: controller.signal,
+          });
 
-        const reader = response.body?.getReader();
-        if (!reader) throw new Error("No response body");
+          if (!response.ok) throw await refusal(url, response);
 
-        const decoder = new TextDecoder();
-        const parse = createSseParser();
-        let fullContent = "";
-        const citations: Citation[] = [];
-        let messageId = "";
-        let streamError: Error | null = null;
+          const reader = response.body?.getReader();
+          if (!reader) {
+            throw new ApiError(
+              `response to ${url} carried no body to read`,
+              "INVALID_RESPONSE",
+              response.status,
+              "parse",
+            );
+          }
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
+          const decoder = new TextDecoder();
+          const parse = createSseParser();
+          let fullContent = "";
+          const citations: Citation[] = [];
+          let messageId = "";
+          let streamError: ApiError | null = null;
 
-          for (const block of parse(decoder.decode(value, { stream: true }))) {
-            // An event the schema does not recognise is skipped rather than
-            // passed on: a citation of an unknown kind would reach the badge
-            // that renders by `type`, and a malformed token would be appended
-            // to the answer as it is.
-            const parsed = chatSseEventSchema.safeParse(block);
-            if (!parsed.success) continue;
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
 
-            const event = parsed.data;
-            switch (event.event) {
-              case "token": {
-                fullContent += event.data.content;
-                setStreamingContent(fullContent);
-                break;
-              }
-              case "citation": {
-                citations.push(event.data);
-                options.onCitation?.(event.data);
-                break;
-              }
-              case "done": {
-                messageId = event.data.messageId;
-                break;
-              }
-              case "error": {
-                // The stream carries its failures at HTTP 200, so the status
-                // an error of this kind reports is the stream's own.
-                streamError = new ApiError(event.data.message, event.data.code, response.status);
-                break;
+            for (const block of parse(decoder.decode(value, { stream: true }))) {
+              // An event the schema does not recognise is skipped rather than
+              // passed on: a citation of an unknown kind would reach the badge
+              // that renders by `type`, and a malformed token would be appended
+              // to the answer as it is.
+              const parsed = chatSseEventSchema.safeParse(block);
+              if (!parsed.success) continue;
+
+              const event = parsed.data;
+              switch (event.event) {
+                case "token": {
+                  fullContent += event.data.content;
+                  setStreamingContent(fullContent);
+                  break;
+                }
+                case "citation": {
+                  citations.push(event.data);
+                  options.onCitation?.(event.data);
+                  break;
+                }
+                case "done": {
+                  messageId = event.data.messageId;
+                  break;
+                }
+                case "error": {
+                  // The stream carries its failures at HTTP 200, so the status
+                  // an error of this kind reports is the stream's own.
+                  streamError = new ApiError(event.data.message, event.data.code, response.status);
+                  break;
+                }
               }
             }
           }
-        }
 
-        if (streamError) throw streamError;
+          if (streamError) throw streamError;
 
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: messageId || `temp-${now().getTime()}`,
-            role: "assistant",
-            content: fullContent,
-            citations,
-            createdAt: now().toISOString(),
-          },
-        ]);
-        setStreamingContent("");
-        options.onDone?.(messageId);
-      } catch (err) {
-        // Leaving the chat is not a failure to report, and the atom that
-        // aborted has already put the panel back at rest
-        if (isAbortError(err)) {
-          aborted = true;
-          return;
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: messageId || `temp-${now().getTime()}`,
+              role: "assistant",
+              content: fullContent,
+              citations,
+              createdAt: now().toISOString(),
+            },
+          ]);
+          setStreamingContent("");
+          options.onDone?.(messageId);
+          return ok(messageId);
+        } catch (cause) {
+          const failure = cause instanceof ApiError ? cause : networkFailure(url, cause);
+
+          // Leaving the chat delivered no answer either, but the reader asked
+          // for that: the atom the panel reads stays clear, and only a caller
+          // that inspects the result can tell it apart.
+          if (failure.code === "ABORTED") {
+            aborted = true;
+            return err(failure);
+          }
+
+          setStreamingContent("");
+          setChatError(chatFailureMessage(failure));
+          return err(failure);
+        } finally {
+          if (!aborted) {
+            setIsStreaming(false);
+            // Only clear the stream this call owns; a newer one may have taken over
+            setAbortController((current) => (current === controller ? null : current));
+          }
         }
-        setStreamingContent("");
-        options.onError?.(err instanceof Error ? err : new Error(String(err)));
-      } finally {
-        if (!aborted) {
-          setIsStreaming(false);
-          // Only clear the stream this call owns; a newer one may have taken over
-          setAbortController((current) => (current === controller ? null : current));
-        }
-      }
+      };
+
+      return new ResultAsync(run());
     },
     [
       abortChatStream,
@@ -166,6 +206,7 @@ export function useChatStream(fetchFn: typeof fetch = fetch, now: () => Date = s
       setStreamingContent,
       setIsStreaming,
       setAbortController,
+      setChatError,
     ],
   );
 

--- a/src/front/hooks/useChatStream.ts
+++ b/src/front/hooks/useChatStream.ts
@@ -10,9 +10,10 @@ import {
   abortChatStreamAtom,
 } from "../atoms/chatAtom";
 import { createSseParser } from "../lib/sseParser";
-import { ApiError, networkFailure, readRefusal } from "../lib/fetcher";
+import { ApiError, CLIENT_ERROR_CODES, networkFailure, readRefusal } from "../lib/fetcher";
 import type { ChatMessage } from "../../shared/schemas/chat";
 import type { Citation } from "../../shared/schemas/citation";
+import type { ErrorCode } from "../../shared/schemas/error";
 import { chatSseEventSchema } from "../../shared/schemas/sse";
 
 interface ChatStreamOptions {
@@ -20,9 +21,20 @@ interface ChatStreamOptions {
   onDone?: (messageId: string) => void;
 }
 
+/**
+ * The answer arrived in full and only the write of it failed.
+ *
+ * Everything else that ends a stream early leaves no answer to speak of, so
+ * this one code is the difference between "there is nothing to show you" and
+ * "here it is, but it will not be here next time".
+ */
+const ANSWER_NOT_SAVED = "CHAT_SAVE_FAILED" satisfies ErrorCode;
+
 /** How a failure of this conversation is worded for the reader. */
 export const chatFailureMessage = (failure: ApiError) =>
-  `回答の取得に失敗しました: ${failure.message}`;
+  failure.code === ANSWER_NOT_SAVED
+    ? "この回答は保存できませんでした。チャットを開き直すと消えます"
+    : `回答の取得に失敗しました: ${failure.message}`;
 
 /**
  * Default clock. Kept at module level so its identity is stable across
@@ -93,7 +105,7 @@ export function useChatStream(fetchFn: typeof fetch = fetch, now: () => Date = s
           if (!reader) {
             throw new ApiError(
               `response to ${url} carried no body to read`,
-              "INVALID_RESPONSE",
+              CLIENT_ERROR_CODES.invalidResponse,
               response.status,
               "parse",
             );
@@ -144,18 +156,27 @@ export function useChatStream(fetchFn: typeof fetch = fetch, now: () => Date = s
             }
           }
 
-          if (streamError) throw streamError;
+          const finishedAnswer: ChatMessage = {
+            id: messageId || `temp-${now().getTime()}`,
+            role: "assistant",
+            content: fullContent,
+            citations,
+            createdAt: now().toISOString(),
+          };
 
-          setMessages((prev) => [
-            ...prev,
-            {
-              id: messageId || `temp-${now().getTime()}`,
-              role: "assistant",
-              content: fullContent,
-              citations,
-              createdAt: now().toISOString(),
-            },
-          ]);
+          if (streamError) {
+            // Two very different endings arrive by the same door. A stream that
+            // broke mid-generation has no answer to keep. One the server could
+            // not store does: the model finished, the tokens are paid for, and
+            // the reader can still read and copy it — they are only told it
+            // will not be there when they come back.
+            if (streamError.code === ANSWER_NOT_SAVED) {
+              setMessages((prev) => [...prev, finishedAnswer]);
+            }
+            throw streamError;
+          }
+
+          setMessages((prev) => [...prev, finishedAnswer]);
           setStreamingContent("");
           options.onDone?.(messageId);
           return ok(messageId);
@@ -165,7 +186,7 @@ export function useChatStream(fetchFn: typeof fetch = fetch, now: () => Date = s
           // Leaving the chat delivered no answer either, but the reader asked
           // for that: the atom the panel reads stays clear, and only a caller
           // that inspects the result can tell it apart.
-          if (failure.code === "ABORTED") {
+          if (failure.code === CLIENT_ERROR_CODES.aborted) {
             aborted = true;
             return err(failure);
           }

--- a/src/front/hooks/usePdfDocument.test.ts
+++ b/src/front/hooks/usePdfDocument.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vite-plus/test";
+import { renderHook, waitFor } from "@testing-library/react";
 import type * as pdfjsTypes from "pdfjs-dist";
-import { storeCoverIfMissing } from "./usePdfDocument";
+import { storeCoverIfMissing, usePdfDocument } from "./usePdfDocument";
+import type { BookDetail } from "../../shared/schemas/book";
 
 const PDF_ID = "01JBOOK";
 
@@ -59,5 +61,44 @@ describe("storeCoverIfMissing", () => {
     await storeCoverIfMissing(PDF_ID, UNRENDERED_DOC, HAS_NO_COVER, fetchFn, async () => null);
 
     expect(calls).toStrictEqual([]);
+  });
+});
+
+const BOOK: BookDetail = {
+  id: PDF_ID,
+  fileName: "Cloudflare Workers.pdf",
+  pageCount: 209,
+  hasThumbnail: true,
+  selections: [],
+};
+
+describe("usePdfDocument", () => {
+  it("reports the server's reason when the book's file cannot be fetched", async () => {
+    // The viewer used to be left with no document and no reason for it, which
+    // reads on screen as a book that opened to a blank page.
+    const missing: typeof fetch = () =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            error: { code: "PDF_FILE_MISSING", message: "PDF binary not found in storage" },
+          }),
+          { status: 404, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+
+    const { result } = renderHook(() => usePdfDocument(BOOK, missing));
+
+    await waitFor(() =>
+      expect(result.current.error).toBe("PDFを表示できません: PDF binary not found in storage"),
+    );
+    expect(result.current.pdfDocument).toBeNull();
+  });
+
+  it("reports a request for the book's file that never reached the server", async () => {
+    const offline: typeof fetch = () => Promise.reject(new TypeError("Failed to fetch"));
+
+    const { result } = renderHook(() => usePdfDocument(BOOK, offline));
+
+    await waitFor(() => expect(result.current.error).toBe("PDFを表示できません: Failed to fetch"));
   });
 });

--- a/src/front/hooks/usePdfDocument.test.tsx
+++ b/src/front/hooks/usePdfDocument.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vite-plus/test";
 import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
 import type * as pdfjsTypes from "pdfjs-dist";
 import { storeCoverIfMissing, usePdfDocument } from "./usePdfDocument";
+import { SwrTestCache } from "../../test/swrTestCache";
 import type { BookDetail } from "../../shared/schemas/book";
 
 const PDF_ID = "01JBOOK";
@@ -72,6 +74,18 @@ const BOOK: BookDetail = {
   selections: [],
 };
 
+/**
+ * The hook files a cover backfill under the book's thumbnail key, so it is
+ * wrapped like every other SWR user: the default cache is a module-level
+ * singleton and would carry that entry between tests.
+ */
+function loadWith(fetchFn: typeof fetch) {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SwrTestCache>{children}</SwrTestCache>
+  );
+  return renderHook(() => usePdfDocument(BOOK, fetchFn), { wrapper });
+}
+
 describe("usePdfDocument", () => {
   it("reports the server's reason when the book's file cannot be fetched", async () => {
     // The viewer used to be left with no document and no reason for it, which
@@ -86,7 +100,7 @@ describe("usePdfDocument", () => {
         ),
       );
 
-    const { result } = renderHook(() => usePdfDocument(BOOK, missing));
+    const { result } = loadWith(missing);
 
     await waitFor(() =>
       expect(result.current.error).toBe("PDFを表示できません: PDF binary not found in storage"),
@@ -94,10 +108,25 @@ describe("usePdfDocument", () => {
     expect(result.current.pdfDocument).toBeNull();
   });
 
+  it("falls back to the status when a refusal is not this API's error envelope", async () => {
+    // An edge returning its own 502 page: there is no `error.message` to quote,
+    // and the reader still has to be told the book will not open.
+    const edgeFailure: typeof fetch = () =>
+      Promise.resolve(new Response("<html>502</html>", { status: 502 }));
+
+    const { result } = loadWith(edgeFailure);
+
+    await waitFor(() =>
+      expect(result.current.error).toBe(
+        `PDFを表示できません: request to /api/pdf/${PDF_ID}/file failed with status 502`,
+      ),
+    );
+  });
+
   it("reports a request for the book's file that never reached the server", async () => {
     const offline: typeof fetch = () => Promise.reject(new TypeError("Failed to fetch"));
 
-    const { result } = renderHook(() => usePdfDocument(BOOK, offline));
+    const { result } = loadWith(offline);
 
     await waitFor(() => expect(result.current.error).toBe("PDFを表示できません: Failed to fetch"));
   });

--- a/src/front/hooks/usePdfDocument.test.tsx
+++ b/src/front/hooks/usePdfDocument.test.tsx
@@ -102,9 +102,7 @@ describe("usePdfDocument", () => {
 
     const { result } = loadWith(missing);
 
-    await waitFor(() =>
-      expect(result.current.error).toBe("PDFを表示できません: PDF binary not found in storage"),
-    );
+    await waitFor(() => expect(result.current.error).toBe("PDF binary not found in storage"));
     expect(result.current.pdfDocument).toBeNull();
   });
 
@@ -118,7 +116,7 @@ describe("usePdfDocument", () => {
 
     await waitFor(() =>
       expect(result.current.error).toBe(
-        `PDFを表示できません: request to /api/pdf/${PDF_ID}/file failed with status 502`,
+        `request to /api/pdf/${PDF_ID}/file failed with status 502`,
       ),
     );
   });
@@ -128,6 +126,6 @@ describe("usePdfDocument", () => {
 
     const { result } = loadWith(offline);
 
-    await waitFor(() => expect(result.current.error).toBe("PDFを表示できません: Failed to fetch"));
+    await waitFor(() => expect(result.current.error).toBe("Failed to fetch"));
   });
 });

--- a/src/front/hooks/usePdfDocument.ts
+++ b/src/front/hooks/usePdfDocument.ts
@@ -43,6 +43,9 @@ export async function storeCoverIfMissing(
       fetchFn,
     );
   } catch (err) {
+    // The same deliberate silence as rendering the cover itself: this runs
+    // behind a book the reader has already opened, and a shelf falling back to
+    // the title is not something to interrupt them about.
     console.warn("Failed to backfill the book cover (non-critical):", err);
   }
 }

--- a/src/front/hooks/usePdfDocument.ts
+++ b/src/front/hooks/usePdfDocument.ts
@@ -56,7 +56,8 @@ export async function storeCoverIfMissing(
  *
  * A book whose binary is gone, or whose bytes pdf.js will not open, used to
  * leave the viewer with no document and nothing said about it — the reader saw
- * a book that opened to a blank page. `error` is that reason, worded for them.
+ * a book that opened to a blank page. `error` is why, in the words of whoever
+ * refused; the viewer is what turns it into a sentence.
  */
 export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fetch = fetch) {
   const [pdfDocument, setPdfDocument] = useState<pdfjsTypes.PDFDocumentProxy | null>(null);
@@ -100,7 +101,7 @@ export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fet
         const response = await fetchFn(url);
         if (!response.ok) {
           const refusal = await readRefusal(url, response);
-          if (!cancelled) setError(`PDFを表示できません: ${refusal.message}`);
+          if (!cancelled) setError(refusal.message);
           return;
         }
         const arrayBuffer = await response.arrayBuffer();
@@ -118,11 +119,7 @@ export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fet
         // Everything from here on is pdf.js refusing the bytes or the request
         // never arriving; both leave the reader with nothing to look at.
         console.error("Failed to load PDF for rendering:", cause);
-        if (!cancelled) {
-          setError(
-            `PDFを表示できません: ${cause instanceof Error ? cause.message : String(cause)}`,
-          );
-        }
+        if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause));
       }
     }
 

--- a/src/front/hooks/usePdfDocument.ts
+++ b/src/front/hooks/usePdfDocument.ts
@@ -4,7 +4,7 @@ import useSWRMutation from "swr/mutation";
 import type * as pdfjsTypes from "pdfjs-dist";
 import { pdfjsLib, PDFJS_ASSET_OPTIONS } from "../lib/pdfjsConfig";
 import { renderCoverThumbnail } from "../lib/pdfLoader";
-import { fetcher } from "../lib/fetcher";
+import { fetcher, readRefusal } from "../lib/fetcher";
 import { thumbnailStoredSchema, type BookDetail } from "../../shared/schemas/book";
 
 /** Where a book's cover is written, and the key the write is tracked under. */
@@ -50,9 +50,14 @@ export async function storeCoverIfMissing(
 /**
  * Load the pdfjs-dist PDFDocumentProxy for the given book by fetching the
  * stored PDF binary from the API.
+ *
+ * A book whose binary is gone, or whose bytes pdf.js will not open, used to
+ * leave the viewer with no document and nothing said about it — the reader saw
+ * a book that opened to a blank page. `error` is that reason, worded for them.
  */
 export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fetch = fetch) {
   const [pdfDocument, setPdfDocument] = useState<pdfjsTypes.PDFDocumentProxy | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const loadingRef = useRef<string | null>(null);
 
   // Storing a cover is a write, so it goes through a mutation rather than an
@@ -83,13 +88,16 @@ export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fet
 
     const pdfId = book.id;
     const hasThumbnail = book.hasThumbnail;
+    const url = `/api/pdf/${pdfId}/file`;
     let cancelled = false;
+    setError(null);
 
     async function loadPdf() {
       try {
-        const response = await fetchFn(`/api/pdf/${pdfId}/file`);
+        const response = await fetchFn(url);
         if (!response.ok) {
-          console.warn("PDF file not found on server, rendering unavailable");
+          const refusal = await readRefusal(url, response);
+          if (!cancelled) setError(`PDFを表示できません: ${refusal.message}`);
           return;
         }
         const arrayBuffer = await response.arrayBuffer();
@@ -103,8 +111,15 @@ export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fet
 
         setPdfDocument(doc);
         void backfillCover({ pdfId, doc, hasThumbnail });
-      } catch (err) {
-        console.error("Failed to load PDF for rendering:", err);
+      } catch (cause) {
+        // Everything from here on is pdf.js refusing the bytes or the request
+        // never arriving; both leave the reader with nothing to look at.
+        console.error("Failed to load PDF for rendering:", cause);
+        if (!cancelled) {
+          setError(
+            `PDFを表示できません: ${cause instanceof Error ? cause.message : String(cause)}`,
+          );
+        }
       }
     }
 
@@ -116,5 +131,5 @@ export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fet
     };
   }, [book?.id]);
 
-  return { pdfDocument };
+  return { pdfDocument, error };
 }

--- a/src/front/hooks/usePdfOutline.test.ts
+++ b/src/front/hooks/usePdfOutline.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vite-plus/test";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PDFDocumentProxy } from "pdfjs-dist";
+import { usePdfOutline } from "./usePdfOutline";
+
+/** A document whose bookmarks cannot be read, as a damaged file's cannot. */
+const UNREADABLE_OUTLINE = {
+  getOutline: () => Promise.reject(new Error("Invalid outline destination")),
+} as unknown as PDFDocumentProxy;
+
+/** A document that simply ships without a table of contents. */
+const NO_OUTLINE = {
+  getOutline: () => Promise.resolve(null),
+} as unknown as PDFDocumentProxy;
+
+describe("usePdfOutline", () => {
+  it("reports bookmarks that could not be read rather than passing them off as absent", async () => {
+    // Both used to end as an empty list, so a book whose outline failed to load
+    // looked exactly like a book that never had one.
+    const { result } = renderHook(() => usePdfOutline(UNREADABLE_OUTLINE));
+
+    await waitFor(() => expect(result.current.error).toBe("Invalid outline destination"));
+    expect(result.current.outline).toBeNull();
+  });
+
+  it("reports a book that ships without bookmarks as having none", async () => {
+    const { result } = renderHook(() => usePdfOutline(NO_OUTLINE));
+
+    await waitFor(() => expect(result.current.outline).toStrictEqual([]));
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/front/hooks/usePdfOutline.ts
+++ b/src/front/hooks/usePdfOutline.ts
@@ -44,25 +44,32 @@ async function toEntries(doc: PDFDocumentProxy, items: RawOutlineItem[]): Promis
 /**
  * Read the PDF's bookmarks (table of contents) and resolve each entry to a page.
  * Returns an empty array for PDFs that ship without an outline.
+ *
+ * A read that failed is kept apart from a book that has no bookmarks: both used
+ * to end as an empty list, so a reader could not tell "this book has no table
+ * of contents" from "the one it has could not be read".
  */
 export function usePdfOutline(doc: PDFDocumentProxy | null) {
   const [outline, setOutline] = useState<OutlineEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!doc) {
       setOutline(null);
+      setError(null);
       return;
     }
 
     let cancelled = false;
+    setError(null);
     doc
       .getOutline()
       .then(async (items) => {
         const entries = items ? await toEntries(doc, items) : [];
         if (!cancelled) setOutline(entries);
       })
-      .catch(() => {
-        if (!cancelled) setOutline([]);
+      .catch((cause: unknown) => {
+        if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause));
       });
 
     return () => {
@@ -70,5 +77,5 @@ export function usePdfOutline(doc: PDFDocumentProxy | null) {
     };
   }, [doc]);
 
-  return { outline };
+  return { outline, error };
 }

--- a/src/front/hooks/usePdfOutline.ts
+++ b/src/front/hooks/usePdfOutline.ts
@@ -27,6 +27,9 @@ async function resolvePageNumber(
       (await doc.getPageIndex(explicit[0] as Parameters<PDFDocumentProxy["getPageIndex"]>[0])) + 1
     );
   } catch {
+    // One bookmark pointing at nothing is not a broken table of contents: the
+    // entry is listed without a page and cannot be jumped to, while the rest
+    // of the outline stays usable.
     return null;
   }
 }

--- a/src/front/hooks/useReadingLocation.test.tsx
+++ b/src/front/hooks/useReadingLocation.test.tsx
@@ -11,12 +11,12 @@ const PDF_ID = "01JBOOK";
 
 /** Exposes the URL the hook drives and a way to turn pages like the viewer does. */
 function useHarness(locatePassage: LocatePassage, linkedPassage: string | null, visited: string[]) {
-  useReadingLocation(PDF_ID, locatePassage, linkedPassage);
+  const { passageNotFound } = useReadingLocation(PDF_ID, locatePassage, linkedPassage);
 
   const { search } = useLocation();
   if (visited[visited.length - 1] !== search) visited.push(search);
 
-  return { search, setCurrentPage: useSetAtom(currentPageAtom) };
+  return { search, passageNotFound, setCurrentPage: useSetAtom(currentPageAtom) };
 }
 
 function renderAt(
@@ -94,7 +94,37 @@ describe("useReadingLocation", () => {
       locatePassage: async () => null,
     });
 
-    await waitFor(() => expect(view.result.current.search).toBe("?page=1"));
+    await waitFor(() => expect(view.result.current.passageNotFound).toBe(true));
+    expect(view.result.current.search).toBe("?page=1");
     expect(store.get(currentPageAtom)).toBe(1);
+  });
+
+  it("reports a lookup that failed the same way as one that found nothing", async () => {
+    // Both leave the reader on page 1 with no idea why the link did not take
+    // them to the passage it named.
+    const { view } = renderAt(`/books/${PDF_ID}`, {
+      linkedPassage: "エッジは速い",
+      locatePassage: async () => {
+        throw new Error("PDF not found");
+      },
+    });
+
+    await waitFor(() => expect(view.result.current.passageNotFound).toBe(true));
+  });
+
+  it("keeps quiet while the lookup is still running", async () => {
+    const { view } = renderAt(`/books/${PDF_ID}`, {
+      linkedPassage: "エッジは速い",
+      locatePassage: () => new Promise(() => {}),
+    });
+
+    expect(view.result.current.passageNotFound).toBe(false);
+  });
+
+  it("keeps quiet for a page opened without a linked passage at all", async () => {
+    const { view } = renderAt(`/books/${PDF_ID}?page=42`);
+
+    await waitFor(() => expect(view.result.current.search).toBe("?page=42"));
+    expect(view.result.current.passageNotFound).toBe(false);
   });
 });

--- a/src/front/hooks/useReadingLocation.ts
+++ b/src/front/hooks/useReadingLocation.ts
@@ -25,12 +25,17 @@ function parsePage(value: string | null): number | null {
  *
  * A `#:~:text=` fragment — what Chrome's "Copy link to highlight" writes — wins
  * over `?page=`, since it names the passage the reader actually wants.
+ *
+ * `passageNotFound` is how a link that named a passage but did not deliver it
+ * says so. A book that simply does not contain it and a lookup that failed are
+ * the same thing from the reader's chair — the book opens on page 1 with no
+ * explanation — so they are reported together.
  */
 export function useReadingLocation(
   pdfId: string | undefined,
   locatePassage: LocatePassage,
   linkedPassage: string | null,
-): void {
+): { passageNotFound: boolean } {
   const [searchParams, setSearchParams] = useSearchParams();
   const [currentPage, setCurrentPage] = useAtom(currentPageAtom);
 
@@ -79,7 +84,7 @@ export function useReadingLocation(
 
   // Where a passage sits in a book cannot change while the book is open, so
   // this is asked once per link and never revalidated.
-  const { data: linkedPage } = useSWRImmutable(
+  const { data: linkedPage, error: locateError } = useSWRImmutable(
     pdfId && linkedPassage ? [pdfId, "locate", linkedPassage] : null,
     () => locatePassage(pdfId!, linkedPassage!),
   );
@@ -87,4 +92,11 @@ export function useReadingLocation(
   useEffect(() => {
     if (linkedPage) setCurrentPage(linkedPage);
   }, [linkedPage, setCurrentPage]);
+
+  // `undefined` is "still asking" and must not raise this; `null` is the
+  // server's answer that the passage is nowhere in the book.
+  const passageNotFound =
+    linkedPassage !== null && (linkedPage === null || locateError !== undefined);
+
+  return { passageNotFound };
 }

--- a/src/front/lib/fetcher.test.ts
+++ b/src/front/lib/fetcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vite-plus/test";
 import { z } from "zod";
-import { ApiError, fetcher } from "./fetcher";
+import { ApiError, fetcher, resultFetcher } from "./fetcher";
 
 const bookSchema = z.object({ id: z.string(), pageCount: z.number().int().positive() });
 
@@ -94,6 +94,87 @@ describe("fetcher", () => {
       "unexpected response from /api/pdf/b1",
       "INVALID_RESPONSE",
       200,
+    ]);
+  });
+});
+
+/** The four facts a caller reads off a failure, in one comparable value. */
+function failureOf(error: ApiError): [string, string, number, string] {
+  return [error.message, error.code, error.status, error.kind];
+}
+
+describe("resultFetcher", () => {
+  it("hands back the checked body as an Ok when the request succeeds", async () => {
+    const result = await resultFetcher(
+      "/api/pdf/b1",
+      bookSchema,
+      undefined,
+      respondingWith({ id: "b1", pageCount: 209 }),
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toStrictEqual({ id: "b1", pageCount: 209 });
+  });
+
+  it("reports a refusal as an Err carrying the server's own code", async () => {
+    const result = await resultFetcher(
+      "/api/pdf/b1",
+      bookSchema,
+      undefined,
+      respondingWith({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }, 404),
+    );
+
+    expect(failureOf(result._unsafeUnwrapErr())).toStrictEqual([
+      "PDF not found",
+      "PDF_NOT_FOUND",
+      404,
+      "http",
+    ]);
+  });
+
+  it("reports a body that does not match the schema as a parse failure", async () => {
+    const result = await resultFetcher(
+      "/api/pdf/b1",
+      bookSchema,
+      undefined,
+      respondingWith({ id: "b1", pageCount: "209" }),
+    );
+
+    expect(failureOf(result._unsafeUnwrapErr())).toStrictEqual([
+      "unexpected response from /api/pdf/b1",
+      "INVALID_RESPONSE",
+      200,
+      "parse",
+    ]);
+  });
+
+  it("reports a request that never reached the server as a network failure", async () => {
+    // This is where resultFetcher parts company with fetcher: a mutation has
+    // nobody above it to catch a raw TypeError, so the offline case has to
+    // arrive as the same ApiError every other failure does.
+    const offline: typeof fetch = () => Promise.reject(new TypeError("Failed to fetch"));
+
+    const result = await resultFetcher("/api/pdf/b1", bookSchema, undefined, offline);
+
+    expect(failureOf(result._unsafeUnwrapErr())).toStrictEqual([
+      "request to /api/pdf/b1 could not be sent",
+      "NETWORK_ERROR",
+      0,
+      "network",
+    ]);
+  });
+
+  it("reports an aborted request under a code the caller can single out", async () => {
+    const aborted: typeof fetch = () =>
+      Promise.reject(new DOMException("The operation was aborted.", "AbortError"));
+
+    const result = await resultFetcher("/api/pdf/b1", bookSchema, undefined, aborted);
+
+    expect(failureOf(result._unsafeUnwrapErr())).toStrictEqual([
+      "The operation was aborted.",
+      "ABORTED",
+      0,
+      "network",
     ]);
   });
 });

--- a/src/front/lib/fetcher.ts
+++ b/src/front/lib/fetcher.ts
@@ -87,8 +87,14 @@ const NETWORK_ERROR_CODE = "NETWORK_ERROR";
 /** Code reported when the caller's own signal cut the request short. */
 const ABORTED_CODE = "ABORTED";
 
-/** A rejection from `fetch` itself, given the shape every other failure has. */
-function networkFailure(url: string, cause: unknown): ApiError {
+/**
+ * A rejection from `fetch` itself, given the shape every other failure has.
+ *
+ * Exported for the one caller that does not go through `fetcher` at all: the
+ * chat stream reads the response body itself, and its failures have to be the
+ * same `ApiError` the rest of the app reports.
+ */
+export function networkFailure(url: string, cause: unknown): ApiError {
   if ((cause instanceof DOMException || cause instanceof Error) && cause.name === "AbortError") {
     return new ApiError(cause.message, ABORTED_CODE, 0, "network");
   }

--- a/src/front/lib/fetcher.ts
+++ b/src/front/lib/fetcher.ts
@@ -1,5 +1,13 @@
+import { ResultAsync } from "neverthrow";
 import type { z } from "zod";
 import { errorEnvelopeSchema } from "../../shared/schemas/error";
+
+/**
+ * Where a request came apart, for callers that treat the three differently:
+ * the server refused it (`http`), it never got a reply (`network`), or the
+ * reply was not something this client can read (`parse`).
+ */
+export type ApiErrorKind = "http" | "network" | "parse";
 
 /**
  * A request the API refused, or answered with something this client cannot
@@ -8,14 +16,17 @@ import { errorEnvelopeSchema } from "../../shared/schemas/error";
 export class ApiError extends Error {
   /** The server's `error.code`, or `"UNKNOWN"` when it did not send one. */
   readonly code: string;
-  /** Status of the response the error was read from. */
+  /** Status of the response the error was read from, or 0 when there was none. */
   readonly status: number;
+  /** Which of the three ways the request failed. */
+  readonly kind: ApiErrorKind;
 
-  constructor(message: string, code: string, status: number) {
+  constructor(message: string, code: string, status: number, kind: ApiErrorKind = "http") {
     super(message);
     this.name = "ApiError";
     this.code = code;
     this.status = status;
+    this.kind = kind;
   }
 }
 
@@ -59,8 +70,48 @@ export async function fetcher<S extends z.ZodType>(
 
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
-    throw new ApiError(`unexpected response from ${url}`, INVALID_RESPONSE_CODE, res.status);
+    throw new ApiError(
+      `unexpected response from ${url}`,
+      INVALID_RESPONSE_CODE,
+      res.status,
+      "parse",
+    );
   }
 
   return parsed.data;
+}
+
+/** Code reported when the request never produced a response at all. */
+const NETWORK_ERROR_CODE = "NETWORK_ERROR";
+
+/** Code reported when the caller's own signal cut the request short. */
+const ABORTED_CODE = "ABORTED";
+
+/** A rejection from `fetch` itself, given the shape every other failure has. */
+function networkFailure(url: string, cause: unknown): ApiError {
+  if ((cause instanceof DOMException || cause instanceof Error) && cause.name === "AbortError") {
+    return new ApiError(cause.message, ABORTED_CODE, 0, "network");
+  }
+  return new ApiError(`request to ${url} could not be sent`, NETWORK_ERROR_CODE, 0, "network");
+}
+
+/**
+ * `fetcher` for the calls that are not reads: writes, and the one-off requests
+ * an event handler makes.
+ *
+ * Those have no SWR above them holding an `error` state, so the failure has to
+ * come back in the value or it is lost — which is how a highlight could fail to
+ * save with nothing on screen to say so. Unlike `fetcher` this also covers the
+ * request that never reached the server: a caller reading a `Result` has no
+ * catch block for a stray `TypeError` to land in.
+ */
+export function resultFetcher<S extends z.ZodType>(
+  url: string,
+  schema: S,
+  init?: RequestInit,
+  fetchFn: typeof fetch = fetch,
+): ResultAsync<z.output<S>, ApiError> {
+  return ResultAsync.fromPromise(fetcher(url, schema, init, fetchFn), (cause) =>
+    cause instanceof ApiError ? cause : networkFailure(url, cause),
+  );
 }

--- a/src/front/lib/fetcher.ts
+++ b/src/front/lib/fetcher.ts
@@ -88,6 +88,25 @@ const NETWORK_ERROR_CODE = "NETWORK_ERROR";
 const ABORTED_CODE = "ABORTED";
 
 /**
+ * The refusal the server described, or the status when it described nothing.
+ *
+ * For the callers that read a response themselves rather than through
+ * `fetcher` — the chat stream and the PDF binary, neither of which is JSON —
+ * so that a refusal reaches them in the same words it reaches everyone else.
+ */
+export async function readRefusal(url: string, response: Response): Promise<ApiError> {
+  const body: unknown = await response.json().catch(() => null);
+  const envelope = errorEnvelopeSchema.safeParse(body);
+  return envelope.success
+    ? new ApiError(envelope.data.error.message, envelope.data.error.code, response.status)
+    : new ApiError(
+        `request to ${url} failed with status ${response.status}`,
+        UNKNOWN_ERROR_CODE,
+        response.status,
+      );
+}
+
+/**
  * A rejection from `fetch` itself, given the shape every other failure has.
  *
  * Exported for the one caller that does not go through `fetcher` at all: the

--- a/src/front/lib/fetcher.ts
+++ b/src/front/lib/fetcher.ts
@@ -30,11 +30,24 @@ export class ApiError extends Error {
   }
 }
 
-/** Code reported when the response body is not this API's error envelope. */
-const UNKNOWN_ERROR_CODE = "UNKNOWN";
-
-/** Code reported when a successful response does not match the caller's schema. */
-const INVALID_RESPONSE_CODE = "INVALID_RESPONSE";
+/**
+ * The codes this client invents, as opposed to the ones the server sends.
+ *
+ * Exported because `ApiError.code` is a plain `string` — the wire has to stay
+ * open to codes a newer server knows about — which means a caller comparing
+ * against a typed-out literal gets no help when it drifts. The server pins its
+ * own codes with `ERROR_CODES` + `satisfies`; this is the client's half.
+ */
+export const CLIENT_ERROR_CODES = {
+  /** The response body is not this API's error envelope. */
+  unknown: "UNKNOWN",
+  /** A successful response does not match the caller's schema. */
+  invalidResponse: "INVALID_RESPONSE",
+  /** The request never produced a response at all. */
+  network: "NETWORK_ERROR",
+  /** The caller's own signal cut the request short. */
+  aborted: "ABORTED",
+} as const;
 
 /**
  * Call the API and hand back a body that has been checked against `schema`.
@@ -54,25 +67,18 @@ export async function fetcher<S extends z.ZodType>(
   fetchFn: typeof fetch = fetch,
 ): Promise<z.output<S>> {
   const res = await fetchFn(url, init);
-  const body = await res.json().catch(() => null);
 
-  if (!res.ok) {
-    const failure = errorEnvelopeSchema.safeParse(body);
-    if (failure.success) {
-      throw new ApiError(failure.data.error.message, failure.data.error.code, res.status);
-    }
-    throw new ApiError(
-      `request to ${url} failed with status ${res.status}`,
-      UNKNOWN_ERROR_CODE,
-      res.status,
-    );
-  }
+  // Read before the body: a refusal is worded in exactly one place, so the two
+  // ways into this app (here, and the callers that read a response themselves)
+  // cannot drift apart.
+  if (!res.ok) throw await readRefusal(url, res);
 
+  const body: unknown = await res.json().catch(() => null);
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
     throw new ApiError(
       `unexpected response from ${url}`,
-      INVALID_RESPONSE_CODE,
+      CLIENT_ERROR_CODES.invalidResponse,
       res.status,
       "parse",
     );
@@ -81,18 +87,12 @@ export async function fetcher<S extends z.ZodType>(
   return parsed.data;
 }
 
-/** Code reported when the request never produced a response at all. */
-const NETWORK_ERROR_CODE = "NETWORK_ERROR";
-
-/** Code reported when the caller's own signal cut the request short. */
-const ABORTED_CODE = "ABORTED";
-
 /**
  * The refusal the server described, or the status when it described nothing.
  *
- * For the callers that read a response themselves rather than through
- * `fetcher` — the chat stream and the PDF binary, neither of which is JSON —
- * so that a refusal reaches them in the same words it reaches everyone else.
+ * The single place a refusal is turned into words, for `fetcher` and for the
+ * callers that read a response themselves — the chat stream and the PDF
+ * binary, neither of which is JSON.
  */
 export async function readRefusal(url: string, response: Response): Promise<ApiError> {
   const body: unknown = await response.json().catch(() => null);
@@ -101,7 +101,7 @@ export async function readRefusal(url: string, response: Response): Promise<ApiE
     ? new ApiError(envelope.data.error.message, envelope.data.error.code, response.status)
     : new ApiError(
         `request to ${url} failed with status ${response.status}`,
-        UNKNOWN_ERROR_CODE,
+        CLIENT_ERROR_CODES.unknown,
         response.status,
       );
 }
@@ -115,9 +115,14 @@ export async function readRefusal(url: string, response: Response): Promise<ApiE
  */
 export function networkFailure(url: string, cause: unknown): ApiError {
   if ((cause instanceof DOMException || cause instanceof Error) && cause.name === "AbortError") {
-    return new ApiError(cause.message, ABORTED_CODE, 0, "network");
+    return new ApiError(cause.message, CLIENT_ERROR_CODES.aborted, 0, "network");
   }
-  return new ApiError(`request to ${url} could not be sent`, NETWORK_ERROR_CODE, 0, "network");
+  return new ApiError(
+    `request to ${url} could not be sent`,
+    CLIENT_ERROR_CODES.network,
+    0,
+    "network",
+  );
 }
 
 /**

--- a/src/front/lib/pdfLoader.ts
+++ b/src/front/lib/pdfLoader.ts
@@ -33,6 +33,10 @@ export async function renderCoverThumbnail(doc: PDFDocumentProxy): Promise<Blob 
       canvas.toBlob((blob) => resolve(blob), "image/webp", 0.8);
     });
   } catch {
+    // Deliberately the one failure this app does not report. A cover is
+    // decoration: the shelf draws the title in its place, and stopping an
+    // upload — or putting an error beside a book that opened perfectly well —
+    // over a missing picture would cost the reader more than it tells them.
     return null;
   }
 }

--- a/src/front/lib/pdfTextMatcher.ts
+++ b/src/front/lib/pdfTextMatcher.ts
@@ -5,16 +5,19 @@ export interface SelectionPosition {
   rects: { x: number; y: number; width: number; height: number }[];
 }
 
-/**
- * Get the text item indices from the current Selection.
- * Returns null if the selection is empty or not within our text layer.
- */
-export function getSelectionFromTextLayer(): {
+/** The passage the reader dragged over, located in the page's text items. */
+export interface SelectionFromTextLayer {
   text: string;
   startIndex: number;
   endIndex: number;
   pageNumber: number;
-} | null {
+}
+
+/**
+ * Get the text item indices from the current Selection.
+ * Returns null if the selection is empty or not within our text layer.
+ */
+export function getSelectionFromTextLayer(): SelectionFromTextLayer | null {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || !selection.rangeCount) return null;
 

--- a/src/front/lib/textFragment.ts
+++ b/src/front/lib/textFragment.ts
@@ -52,6 +52,9 @@ export function passageFromNavigation(entries: { name: string }[]): string | nul
   try {
     return parseTextFragment(new URL(url).hash);
   } catch {
+    // The entry's name is whatever the browser recorded. One it cannot parse
+    // means this page was not opened from a link to a passage, which is the
+    // ordinary case, not a failure.
     return null;
   }
 }

--- a/src/front/pages/AppPage.test.tsx
+++ b/src/front/pages/AppPage.test.tsx
@@ -50,14 +50,19 @@ const isBookRequest = (url: string) => /^\/api\/pdf\/[^/]+$/.test(url);
  * how a test shows the reader opened the book without waiting for the server:
  * anything on screen got there from the cache, because nothing else can arrive.
  */
-function readerFetchStub({ holdTheBook = false } = {}) {
+function readerFetchStub({ holdTheBook = false, refuseChatHistory = false } = {}) {
   const urls: string[] = [];
   // Every caller here reaches the network through `fetcher`, which is only
   // ever handed a url string.
   const fetchFn = (url: string) => {
     urls.push(url);
     if (url.endsWith("/chats")) {
-      return Promise.resolve(new Response(JSON.stringify({ messages: [] }), { status: 200 }));
+      const body = refuseChatHistory
+        ? { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } }
+        : { messages: [] };
+      return Promise.resolve(
+        new Response(JSON.stringify(body), { status: refuseChatHistory ? 404 : 200 }),
+      );
     }
     if (holdTheBook && isBookRequest(url)) {
       return new Promise<Response>(() => {});
@@ -80,7 +85,7 @@ function OpenOtherBook({ pdfId }: { pdfId: string }) {
 function renderReader(
   pdfId: string,
   seed: Record<string, unknown>,
-  options: { holdTheBook?: boolean } = {},
+  options: { holdTheBook?: boolean; refuseChatHistory?: boolean } = {},
 ) {
   const { urls, fetchFn } = readerFetchStub(options);
   vi.stubGlobal("fetch", fetchFn);
@@ -131,6 +136,18 @@ describe("AppPage", () => {
     expect(await screen.findByText(BOOK_B.fileName)).toBeInTheDocument();
     expect(screen.getByText(B_PASSAGE)).toBeInTheDocument();
     expect(screen.queryByText(A_PASSAGE)).not.toBeInTheDocument();
+  });
+
+  it("says the conversation could not be read instead of showing it as empty", async () => {
+    // An empty conversation and one that failed to load looked identical: the
+    // catch put an empty list on screen either way.
+    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A }, { refuseChatHistory: true });
+
+    await userEvent.click(await screen.findByText(A_PASSAGE));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      /^チャット履歴を読み込めませんでした: Selection not found$/,
+    );
   });
 
   it("says what went wrong when the book cannot be read", async () => {

--- a/src/front/pages/AppPage.test.tsx
+++ b/src/front/pages/AppPage.test.tsx
@@ -10,6 +10,7 @@ import type { BookDetail } from "../../shared/schemas/book";
 import type { SelectionHighlight } from "../../shared/schemas/selection";
 
 const A_PASSAGE = "エッジはサーバーレス実行基盤で、実行単位をまたいでメモリを共有できません。";
+const A_SECOND_PASSAGE = "Workers は V8 isolate の上で動きます。";
 const B_PASSAGE = "Durable Objects は単一のインスタンスに処理を集約します。";
 
 function highlight(id: string, selectedText: string): SelectionHighlight {
@@ -28,7 +29,7 @@ const BOOK_A: BookDetail = {
   fileName: "Cloudflare Workers.pdf",
   pageCount: 209,
   hasThumbnail: true,
-  selections: [highlight("a1", A_PASSAGE)],
+  selections: [highlight("a1", A_PASSAGE), highlight("a2", A_SECOND_PASSAGE)],
 };
 
 const BOOK_B: BookDetail = {
@@ -50,7 +51,11 @@ const isBookRequest = (url: string) => /^\/api\/pdf\/[^/]+$/.test(url);
  * how a test shows the reader opened the book without waiting for the server:
  * anything on screen got there from the cache, because nothing else can arrive.
  */
-function readerFetchStub({ holdTheBook = false, refuseChatHistory = false } = {}) {
+function readerFetchStub({
+  holdTheBook = false,
+  /** Id of the one highlight whose conversation the server refuses to hand over. */
+  refuseChatHistoryFor,
+}: { holdTheBook?: boolean; refuseChatHistoryFor?: string } = {}) {
   const urls: string[] = [];
   // Every caller here reaches the network through `fetcher`, which is only
   // ever handed a url string.
@@ -60,12 +65,14 @@ function readerFetchStub({ holdTheBook = false, refuseChatHistory = false } = {}
       return Promise.resolve(new Response(JSON.stringify({ pageNumber: null }), { status: 200 }));
     }
     if (url.endsWith("/chats")) {
-      const body = refuseChatHistory
+      const selectionId = url.split("/selections/")[1].split("/")[0];
+      const refused = selectionId === refuseChatHistoryFor;
+      // The whole envelope, not just `messages`: the reader checks it against
+      // chatHistorySchema and reports anything else as an unreadable response.
+      const body = refused
         ? { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } }
-        : { messages: [] };
-      return Promise.resolve(
-        new Response(JSON.stringify(body), { status: refuseChatHistory ? 404 : 200 }),
-      );
+        : { selectionId, messages: [] };
+      return Promise.resolve(new Response(JSON.stringify(body), { status: refused ? 404 : 200 }));
     }
     if (holdTheBook && isBookRequest(url)) {
       return new Promise<Response>(() => {});
@@ -88,7 +95,7 @@ function OpenOtherBook({ pdfId }: { pdfId: string }) {
 function renderReader(
   pdfId: string,
   seed: Record<string, unknown>,
-  options: { holdTheBook?: boolean; refuseChatHistory?: boolean } = {},
+  options: { holdTheBook?: boolean; refuseChatHistoryFor?: string } = {},
 ) {
   const { urls, fetchFn } = readerFetchStub(options);
   vi.stubGlobal("fetch", fetchFn);
@@ -145,7 +152,7 @@ describe("AppPage", () => {
   it("says the conversation could not be read instead of showing it as empty", async () => {
     // An empty conversation and one that failed to load looked identical: the
     // catch put an empty list on screen either way.
-    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A }, { refuseChatHistory: true });
+    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A }, { refuseChatHistoryFor: "a1" });
 
     await userEvent.click(await screen.findByText(A_PASSAGE));
 
@@ -154,6 +161,25 @@ describe("AppPage", () => {
     expect(
       await screen.findByText("チャット履歴を読み込めませんでした: Selection not found"),
     ).toBeInTheDocument();
+  });
+
+  it("drops the failed conversation's message when another highlight is opened", async () => {
+    // Left behind, it would sit over a conversation it says nothing about.
+    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A }, { refuseChatHistoryFor: "a1" });
+
+    await userEvent.click(await screen.findByText(A_PASSAGE));
+    expect(
+      await screen.findByText("チャット履歴を読み込めませんでした: Selection not found"),
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "一覧に戻る" }));
+    await userEvent.click(screen.getByText(A_SECOND_PASSAGE));
+
+    // The second conversation is open, and the first one's failure is not on it
+    expect(await screen.findByPlaceholderText("質問を入力...")).toBeInTheDocument();
+    expect(
+      screen.queryByText("チャット履歴を読み込めませんでした: Selection not found"),
+    ).toBeNull();
   });
 
   it("says a linked passage was not found instead of quietly opening page 1", async () => {

--- a/src/front/pages/AppPage.test.tsx
+++ b/src/front/pages/AppPage.test.tsx
@@ -145,9 +145,11 @@ describe("AppPage", () => {
 
     await userEvent.click(await screen.findByText(A_PASSAGE));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      /^チャット履歴を読み込めませんでした: Selection not found$/,
-    );
+    // The viewer reports the missing binary of the same book at the same time,
+    // so this looks for the chat panel's own words rather than any alert.
+    expect(
+      await screen.findByText("チャット履歴を読み込めませんでした: Selection not found"),
+    ).toBeInTheDocument();
   });
 
   it("says what went wrong when the book cannot be read", async () => {

--- a/src/front/pages/AppPage.test.tsx
+++ b/src/front/pages/AppPage.test.tsx
@@ -56,6 +56,9 @@ function readerFetchStub({ holdTheBook = false, refuseChatHistory = false } = {}
   // ever handed a url string.
   const fetchFn = (url: string) => {
     urls.push(url);
+    if (url.includes("/locate?")) {
+      return Promise.resolve(new Response(JSON.stringify({ pageNumber: null }), { status: 200 }));
+    }
     if (url.endsWith("/chats")) {
       const body = refuseChatHistory
         ? { error: { code: "SELECTION_NOT_FOUND", message: "Selection not found" } }
@@ -110,6 +113,7 @@ function renderReader(
 describe("AppPage", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it("opens a book already in the cache without waiting for the server", async () => {
@@ -149,6 +153,21 @@ describe("AppPage", () => {
     // so this looks for the chat panel's own words rather than any alert.
     expect(
       await screen.findByText("チャット履歴を読み込めませんでした: Selection not found"),
+    ).toBeInTheDocument();
+  });
+
+  it("says a linked passage was not found instead of quietly opening page 1", async () => {
+    // The fragment is read off the navigation entry, since the browser strips
+    // it from location.hash before scripts can see it.
+    vi.spyOn(performance, "getEntriesByType").mockReturnValue([
+      {
+        name: `http://localhost/books/${BOOK_A.id}#:~:text=%E5%AD%98%E5%9C%A8%E3%81%97%E3%81%AA%E3%81%84`,
+      },
+    ] as PerformanceEntry[]);
+    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A });
+
+    expect(
+      await screen.findByText("リンクされた箇所が見つかりませんでした: 存在しない"),
     ).toBeInTheDocument();
   });
 

--- a/src/front/pages/AppPage.tsx
+++ b/src/front/pages/AppPage.tsx
@@ -62,7 +62,7 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
     () => passageFromNavigation(performance.getEntriesByType("navigation")),
     [],
   );
-  useReadingLocation(pdfId, locatePassage, linkedPassage);
+  const { passageNotFound } = useReadingLocation(pdfId, locatePassage, linkedPassage);
 
   // Load chat history when selection changes
   const handleSelectionClick = useCallback(
@@ -110,6 +110,15 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
           <SettingsMenu />
         </div>
       </header>
+
+      {/* A link that named a passage but did not land on it opens the book at
+          page 1, which is indistinguishable from an ordinary link. */}
+      {passageNotFound && linkedPassage !== null && (
+        <p role="status" className="shrink-0 bg-amber-50 px-4 py-2 text-sm text-amber-800">
+          リンクされた箇所が見つかりませんでした: {linkedPassage}
+        </p>
+      )}
+
       <main className="flex-1 min-h-0 flex">
         {/* Left panel: PDF Viewer */}
         <div style={{ width: `${leftWidth}%` }} className="h-full min-w-0">

--- a/src/front/pages/AppPage.tsx
+++ b/src/front/pages/AppPage.tsx
@@ -5,6 +5,7 @@ import { currentPageAtom } from "../atoms/pdfAtom";
 import {
   activeSelectionAtom,
   chatMessagesAtom,
+  chatErrorAtom,
   abortChatStreamAtom,
   type ActiveSelection,
 } from "../atoms/chatAtom";
@@ -14,7 +15,7 @@ import { SettingsMenu } from "../components/SettingsMenu";
 import { useBook } from "../hooks/useBook";
 import { useReadingLocation } from "../hooks/useReadingLocation";
 import { passageFromNavigation } from "../lib/textFragment";
-import { fetcher } from "../lib/fetcher";
+import { fetcher, resultFetcher } from "../lib/fetcher";
 import { locatedPageSchema } from "../../shared/schemas/book";
 import { chatHistorySchema } from "../../shared/schemas/chat";
 
@@ -51,6 +52,7 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
   const { data: book, error } = useBook(pdfId);
   const [, setActiveSelection] = useAtom(activeSelectionAtom);
   const [, setChatMessages] = useAtom(chatMessagesAtom);
+  const [, setChatError] = useAtom(chatErrorAtom);
   const [, setCurrentPage] = useAtom(currentPageAtom);
   const abortChatStream = useSetAtom(abortChatStreamAtom);
   const [leftWidth, setLeftWidth] = useState(60);
@@ -73,20 +75,23 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
       // Otherwise the conversation left behind shows under the new passage
       // until its own history arrives
       setChatMessages([]);
+      // Whatever failed in the chat being left is not about this one
+      setChatError(null);
       if (!pdfId) return;
 
-      try {
-        const data = await fetcher(
-          `/api/pdf/${pdfId}/selections/${selection.id}/chats`,
-          chatHistorySchema,
-        );
+      const history = await resultFetcher(
+        `/api/pdf/${pdfId}/selections/${selection.id}/chats`,
+        chatHistorySchema,
+      );
 
-        setChatMessages(data.messages);
-      } catch {
-        setChatMessages([]);
-      }
+      // An empty conversation and one that could not be read used to look the
+      // same, so a failure here read as "you never asked anything about this".
+      history.match(
+        (data) => setChatMessages(data.messages),
+        (failure) => setChatError(`チャット履歴を読み込めませんでした: ${failure.message}`),
+      );
     },
-    [abortChatStream, pdfId, setActiveSelection, setChatMessages, setCurrentPage],
+    [abortChatStream, pdfId, setActiveSelection, setChatError, setChatMessages, setCurrentPage],
   );
 
   return (
@@ -144,7 +149,11 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
 
         {/* Right panel: Chat Area */}
         <div style={{ width: `${100 - leftWidth}%` }} className="h-full min-w-0">
-          <ChatArea book={book} onSelectionClick={handleSelectionClick} />
+          <ChatArea
+            book={book}
+            bookError={error as Error | undefined}
+            onSelectionClick={handleSelectionClick}
+          />
         </div>
       </main>
     </div>

--- a/src/front/pages/ShelfPage.test.tsx
+++ b/src/front/pages/ShelfPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useParams } from "react-router";
 import { ShelfPage } from "./ShelfPage";
+import type { ExtractedPdfData } from "../lib/pdfLoader";
 import type { BookSummary } from "../../shared/schemas/book";
 import { SwrTestCache } from "../../test/swrTestCache";
 
@@ -20,6 +21,7 @@ function book(overrides: Partial<BookSummary> = {}): BookSummary {
 function renderShelf(props: {
   loadBooks?: () => Promise<BookSummary[]>;
   deleteBook?: (id: string) => Promise<unknown>;
+  extract?: (file: File) => Promise<ExtractedPdfData>;
 }) {
   render(
     <SwrTestCache>
@@ -147,6 +149,41 @@ describe("ShelfPage", () => {
       screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
     ).toBeInTheDocument();
     expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+  });
+
+  it("stays on the shelf and says why when a chosen file cannot be opened", async () => {
+    // Choosing a PDF that fails used to leave the shelf exactly as it was, so
+    // the reader had no way to tell it from a click that did not register.
+    const { container } = render(
+      <SwrTestCache>
+        <MemoryRouter>
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <ShelfPage
+                  loadBooks={TWO_BOOKS}
+                  extract={() => Promise.reject(new Error("Invalid PDF structure"))}
+                />
+              }
+            />
+            <Route path="/books/:pdfId" element={<ReaderStub />} />
+          </Routes>
+        </MemoryRouter>
+      </SwrTestCache>,
+    );
+
+    await userEvent.upload(
+      container.querySelector<HTMLInputElement>('input[type="file"]')!,
+      new File(["not a pdf"], "broken.pdf", { type: "application/pdf" }),
+    );
+
+    expect(
+      await screen.findByText("PDFを開けませんでした: Invalid PDF structure"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Cloudflare Workers 入門 を開く" }),
+    ).toBeInTheDocument();
   });
 
   it("keeps the book when the confirmation is dismissed with Escape", async () => {

--- a/src/front/pages/ShelfPage.test.tsx
+++ b/src/front/pages/ShelfPage.test.tsx
@@ -23,7 +23,7 @@ function renderShelf(props: {
   deleteBook?: (id: string) => Promise<unknown>;
   extract?: (file: File) => Promise<ExtractedPdfData>;
 }) {
-  render(
+  return render(
     <SwrTestCache>
       <MemoryRouter>
         <Routes>
@@ -154,24 +154,10 @@ describe("ShelfPage", () => {
   it("stays on the shelf and says why when a chosen file cannot be opened", async () => {
     // Choosing a PDF that fails used to leave the shelf exactly as it was, so
     // the reader had no way to tell it from a click that did not register.
-    const { container } = render(
-      <SwrTestCache>
-        <MemoryRouter>
-          <Routes>
-            <Route
-              path="/"
-              element={
-                <ShelfPage
-                  loadBooks={TWO_BOOKS}
-                  extract={() => Promise.reject(new Error("Invalid PDF structure"))}
-                />
-              }
-            />
-            <Route path="/books/:pdfId" element={<ReaderStub />} />
-          </Routes>
-        </MemoryRouter>
-      </SwrTestCache>,
-    );
+    const { container } = renderShelf({
+      loadBooks: TWO_BOOKS,
+      extract: () => Promise.reject(new Error("Invalid PDF structure")),
+    });
 
     await userEvent.upload(
       container.querySelector<HTMLInputElement>('input[type="file"]')!,

--- a/src/front/pages/ShelfPage.test.tsx
+++ b/src/front/pages/ShelfPage.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useParams } from "react-router";
-import { ShelfPage } from "./ShelfPage";
+import { errAsync, okAsync } from "neverthrow";
+import { ShelfPage, type DeleteBook } from "./ShelfPage";
+import { ApiError } from "../lib/fetcher";
 import type { ExtractedPdfData } from "../lib/pdfLoader";
 import type { BookSummary } from "../../shared/schemas/book";
 import { SwrTestCache } from "../../test/swrTestCache";
@@ -20,7 +22,7 @@ function book(overrides: Partial<BookSummary> = {}): BookSummary {
 
 function renderShelf(props: {
   loadBooks?: () => Promise<BookSummary[]>;
-  deleteBook?: (id: string) => Promise<unknown>;
+  deleteBook?: DeleteBook;
   extract?: (file: File) => Promise<ExtractedPdfData>;
 }) {
   return render(
@@ -45,9 +47,10 @@ function recordingDeleter() {
   const deletedIds: string[] = [];
   return {
     deletedIds,
-    deleteBook: async (id: string) => {
+    deleteBook: ((id: string) => {
       deletedIds.push(id);
-    },
+      return okAsync({ deleted: true });
+    }) satisfies DeleteBook,
   };
 }
 
@@ -134,9 +137,7 @@ describe("ShelfPage", () => {
   it("keeps the book on the shelf and says why when the deletion fails", async () => {
     renderShelf({
       loadBooks: TWO_BOOKS,
-      deleteBook: async () => {
-        throw new Error("Server exploded");
-      },
+      deleteBook: () => errAsync(new ApiError("Server exploded", "INTERNAL_ERROR", 500)),
     });
 
     await userEvent.click(

--- a/src/front/pages/ShelfPage.tsx
+++ b/src/front/pages/ShelfPage.tsx
@@ -1,22 +1,27 @@
 import { useState, useCallback } from "react";
 import { useNavigate } from "react-router";
 import useSWR from "swr";
+import type { ResultAsync } from "neverthrow";
 import { FileSelector } from "../components/PdfViewer/FileSelector";
-import { fetcher } from "../lib/fetcher";
+import { fetcher, resultFetcher, type ApiError } from "../lib/fetcher";
 import type { ExtractedPdfData } from "../lib/pdfLoader";
 import { bookDeletedSchema, bookListSchema, type BookSummary } from "../../shared/schemas/book";
 
 /** Cache key of the shelf, and the endpoint it is read from. */
 const SHELF_KEY = "/api/pdfs";
 
+/** Read by SWR, so a refusal belongs in its `error` state: this one throws. */
 const fetchBooks = () => fetcher(SHELF_KEY, bookListSchema).then((data) => data.books);
 
-const requestBookDeletion = (id: string) =>
-  fetcher(`/api/pdf/${id}`, bookDeletedSchema, { method: "DELETE" });
+/** Removes a book. A write, so its failure comes back in the value. */
+export type DeleteBook = (id: string) => ResultAsync<unknown, ApiError>;
+
+const requestBookDeletion: DeleteBook = (id) =>
+  resultFetcher(`/api/pdf/${id}`, bookDeletedSchema, { method: "DELETE" });
 
 interface ShelfPageProps {
   loadBooks?: () => Promise<BookSummary[]>;
-  deleteBook?: (id: string) => Promise<unknown>;
+  deleteBook?: DeleteBook;
   /** Passed straight to the file picker; injectable so tests can fail a read. */
   extract?: (file: File) => Promise<ExtractedPdfData>;
 }
@@ -152,14 +157,16 @@ export function ShelfPage({
   const removeBook = async (book: BookSummary) => {
     setActionError(null);
     setBookPendingDeletion(null);
-    try {
-      await deleteBook(book.id);
-      // The server has already dropped it, so re-reading the shelf would only
-      // confirm what this list can work out for itself.
-      await mutate((current) => current?.filter((b) => b.id !== book.id), { revalidate: false });
-    } catch (err) {
-      setActionError(`削除に失敗しました: ${(err as Error).message}`);
+
+    const removal = await deleteBook(book.id);
+    if (removal.isErr()) {
+      setActionError(`削除に失敗しました: ${removal.error.message}`);
+      return;
     }
+
+    // The server has already dropped it, so re-reading the shelf would only
+    // confirm what this list can work out for itself.
+    await mutate((current) => current?.filter((b) => b.id !== book.id), { revalidate: false });
   };
 
   return (

--- a/src/front/pages/ShelfPage.tsx
+++ b/src/front/pages/ShelfPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router";
 import useSWR from "swr";
 import { FileSelector } from "../components/PdfViewer/FileSelector";
 import { fetcher } from "../lib/fetcher";
+import type { ExtractedPdfData } from "../lib/pdfLoader";
 import { bookDeletedSchema, bookListSchema, type BookSummary } from "../../shared/schemas/book";
 
 /** Cache key of the shelf, and the endpoint it is read from. */
@@ -16,6 +17,8 @@ const requestBookDeletion = (id: string) =>
 interface ShelfPageProps {
   loadBooks?: () => Promise<BookSummary[]>;
   deleteBook?: (id: string) => Promise<unknown>;
+  /** Passed straight to the file picker; injectable so tests can fail a read. */
+  extract?: (file: File) => Promise<ExtractedPdfData>;
 }
 
 function bookTitle(fileName: string): string {
@@ -131,20 +134,23 @@ function DeleteConfirmDialog({
 export function ShelfPage({
   loadBooks = fetchBooks,
   deleteBook = requestBookDeletion,
+  extract,
 }: ShelfPageProps = {}) {
   const navigate = useNavigate();
   const { data: books, error: loadError, mutate } = useSWR(SHELF_KEY, loadBooks);
-  const [deletionError, setDeletionError] = useState<string | null>(null);
+  // What the reader's last action did wrong: adding a book, or removing one.
+  // Both are worded by whoever detected them and shown in the same place.
+  const [actionError, setActionError] = useState<string | null>(null);
   const [bookPendingDeletion, setBookPendingDeletion] = useState<BookSummary | null>(null);
 
   const error =
-    deletionError ??
+    actionError ??
     (loadError ? `本棚の読み込みに失敗しました: ${(loadError as Error).message}` : null);
 
   const openBook = useCallback((id: string) => navigate(`/books/${id}`), [navigate]);
 
   const removeBook = async (book: BookSummary) => {
-    setDeletionError(null);
+    setActionError(null);
     setBookPendingDeletion(null);
     try {
       await deleteBook(book.id);
@@ -152,7 +158,7 @@ export function ShelfPage({
       // confirm what this list can work out for itself.
       await mutate((current) => current?.filter((b) => b.id !== book.id), { revalidate: false });
     } catch (err) {
-      setDeletionError(`削除に失敗しました: ${(err as Error).message}`);
+      setActionError(`削除に失敗しました: ${(err as Error).message}`);
     }
   };
 
@@ -160,7 +166,15 @@ export function ShelfPage({
     <div className="min-h-screen bg-gray-50">
       <header className="flex h-12 items-center justify-between border-b border-gray-200 bg-white px-4">
         <h1 className="text-lg font-bold text-gray-800">chatbook</h1>
-        <FileSelector onOpened={openBook} label="PDFを追加" />
+        <FileSelector
+          onOpened={(id) => {
+            setActionError(null);
+            void openBook(id);
+          }}
+          onError={setActionError}
+          extract={extract}
+          label="PDFを追加"
+        />
       </header>
 
       <main className="mx-auto max-w-6xl p-6">

--- a/src/front/routes.tsx
+++ b/src/front/routes.tsx
@@ -1,9 +1,17 @@
 import { createBrowserRouter, Navigate } from "react-router";
 import { ShelfPage } from "./pages/ShelfPage";
 import { AppPage } from "./pages/AppPage";
+import { RouteErrorBoundary } from "./components/RouteErrorBoundary";
+
+/**
+ * Both pages carry the same boundary. A throw while rendering cannot be
+ * reported as a value the way every other failure in this app is, so without
+ * one the reader gets a blank document and no way back to the shelf.
+ */
+const errorElement = <RouteErrorBoundary />;
 
 export const router = createBrowserRouter([
-  { path: "/", element: <ShelfPage /> },
-  { path: "/books/:pdfId", element: <AppPage /> },
+  { path: "/", element: <ShelfPage />, errorElement },
+  { path: "/books/:pdfId", element: <AppPage />, errorElement },
   { path: "*", element: <Navigate to="/" replace /> },
 ]);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import type { ErrorCode } from "../shared/schemas/error";
 import { healthRoute } from "./routes/health";
 import { pdfRoute } from "./routes/pdf";
 
@@ -10,6 +11,36 @@ type Env = {
   };
 };
 
-const app = new Hono<Env>().basePath("/api").route("/", healthRoute).route("/", pdfRoute);
+/**
+ * The API under `/api`, with the two replies no route writes itself.
+ *
+ * Hono's own defaults answer an unhandled throw and an unknown path in
+ * `text/plain`, which is the one shape the client cannot read: `fetcher`
+ * reports anything that is not the `{ error: { code, message } }` envelope as
+ * `UNKNOWN`, so a D1 outage reached the reader as "something went wrong" with
+ * nothing behind it. These two put every reply back inside the envelope.
+ *
+ * Only `/api/*` reaches the Worker (`run_worker_first` in wrangler.jsonc), so
+ * `notFound` here cannot answer for a deep link into the SPA.
+ */
+const app = new Hono<Env>()
+  .basePath("/api")
+  .route("/", healthRoute)
+  .route("/", pdfRoute)
+  .notFound((c) =>
+    c.json(
+      { error: { code: "ROUTE_NOT_FOUND" satisfies ErrorCode, message: "No such API endpoint" } },
+      404,
+    ),
+  )
+  .onError((err, c) => {
+    // Last stop for a throw no route expected. What went wrong stays on the
+    // server; the client is told only that it was not its request's fault.
+    console.error("Unhandled API error:", err);
+    return c.json(
+      { error: { code: "INTERNAL_ERROR" satisfies ErrorCode, message: "Unexpected server error" } },
+      500,
+    );
+  });
 
 export default app;

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -1,6 +1,7 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { drizzle } from "drizzle-orm/d1";
 import { eq } from "drizzle-orm";
+import { ResultAsync } from "neverthrow";
 import { pdfs, selections, chatMessages } from "../db/schema";
 import {
   openPdf,
@@ -28,6 +29,7 @@ import { locateQuerySchema } from "../../shared/schemas/book";
 import { createSelectionRequestSchema } from "../../shared/schemas/selection";
 import { sendChatRequestSchema } from "../../shared/schemas/chat";
 import type { ErrorCode, ErrorPayload } from "../../shared/schemas/error";
+import { storageFailure, type ServiceError } from "../services/serviceError";
 import { validate } from "./validation";
 
 type Env = {
@@ -40,6 +42,43 @@ type Env = {
 
 /** A cover is one page rendered 400px wide; nothing that big is one. */
 const MAX_THUMBNAIL_BYTES = 2 * 1024 * 1024;
+
+/** What every endpoint says about a book id that is not on the shelf. */
+const PDF_NOT_FOUND = {
+  code: "PDF_NOT_FOUND" satisfies ErrorCode,
+  message: "PDF not found",
+} as const;
+
+/**
+ * The reply a store that refused to answer turns into.
+ *
+ * The cause never leaves the server, but it does reach its log: a 500 nobody
+ * can explain is worse than the plain-text one this replaced.
+ */
+function storageFailureResponse(c: Context<Env>, cause: unknown) {
+  console.error("Storage failure:", cause);
+  return c.json(
+    { error: { code: "INTERNAL_ERROR" satisfies ErrorCode, message: "Unexpected server error" } },
+    500,
+  );
+}
+
+/**
+ * The reply a failed service call turns into.
+ *
+ * The two cases a service reports map onto the two a client can act on: the
+ * thing is not there (404, in the endpoint's own words), or the store refused
+ * and nobody can do anything but try again (500).
+ */
+function serviceFailureResponse(
+  c: Context<Env>,
+  failure: ServiceError,
+  missing: { code: ErrorCode; message: string },
+) {
+  return failure.type === "NOT_FOUND"
+    ? c.json({ error: missing }, 404)
+    : storageFailureResponse(c, failure.cause);
+}
 
 /** A WebP file is a RIFF container whose form type, at offset 8, is "WEBP". */
 function isWebp(body: ArrayBuffer): boolean {
@@ -108,37 +147,42 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
         const thumbnail =
           thumbnailField instanceof File ? await thumbnailField.arrayBuffer() : undefined;
 
-        try {
-          const metadata = await openPdf(
-            c.env.DB,
-            c.env.PDF_BUCKET,
-            {
-              fileName: file.name,
-              fileHash,
-              fullText,
-              pageCount,
-              arrayBuffer,
-              thumbnail,
-            },
-            idClock,
-          );
-          return c.json(metadata);
-        } catch (err) {
-          console.error("PDF open error:", err);
-          return c.json(
-            {
-              error: {
-                code: "PDF_EXTRACT_FAILED" satisfies ErrorCode,
-                message: "Failed to process PDF",
+        const stored = await openPdf(
+          c.env.DB,
+          c.env.PDF_BUCKET,
+          {
+            fileName: file.name,
+            fileHash,
+            fullText,
+            pageCount,
+            arrayBuffer,
+            thumbnail,
+          },
+          idClock,
+        );
+
+        return stored.match(
+          (metadata) => c.json(metadata),
+          (failure) => {
+            console.error("PDF open error:", failure.cause);
+            return c.json(
+              {
+                error: {
+                  code: "PDF_EXTRACT_FAILED" satisfies ErrorCode,
+                  message: "Failed to process PDF",
+                },
               },
-            },
-            500,
-          );
-        }
+              500,
+            );
+          },
+        );
       })
       .get("/pdfs", async (c) => {
-        const books = await listPdfs(c.env.DB, c.env.PDF_BUCKET);
-        return c.json({ books });
+        const shelf = await listPdfs(c.env.DB, c.env.PDF_BUCKET);
+        return shelf.match(
+          (books) => c.json({ books }),
+          (failure) => storageFailureResponse(c, failure.cause),
+        );
       })
       .get("/pdf/:pdfId/thumbnail", async (c) => {
         const pdf = await drizzle(c.env.DB)
@@ -287,17 +331,12 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
         return c.json({ pageNumber: findPageNumber(text, pdf.fullText, pdf.pageCount) ?? null });
       })
       .get("/pdf/:pdfId", async (c) => {
-        const pdfId = c.req.param("pdfId");
-        const result = await getPdf(c.env.DB, c.env.PDF_BUCKET, pdfId);
+        const book = await getPdf(c.env.DB, c.env.PDF_BUCKET, c.req.param("pdfId"));
 
-        if (!result) {
-          return c.json(
-            { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
-            404,
-          );
-        }
-
-        return c.json(result);
+        return book.match(
+          (found) => c.json(found),
+          (failure) => serviceFailureResponse(c, failure, PDF_NOT_FOUND),
+        );
       })
       .post("/pdf/:pdfId/selections", validate("json", createSelectionRequestSchema), async (c) => {
         const pdfId = c.req.param("pdfId");
@@ -482,18 +521,35 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
                   // Save the answer before telling the client about it, so a client
                   // that already left cannot stop the save
                   const assistantMsgId = idClock.newId();
-                  await d1Db
-                    .insert(chatMessages)
-                    .values({
-                      id: assistantMsgId,
-                      selectionId: selId,
-                      role: "assistant",
-                      content: fullResponse,
-                      citations: JSON.stringify(citations),
-                      createdAt: idClock.now(),
-                    })
-                    .run()
-                    .catch((err: Error) => console.error("Failed to save assistant message:", err));
+                  const saved = await ResultAsync.fromPromise(
+                    d1Db
+                      .insert(chatMessages)
+                      .values({
+                        id: assistantMsgId,
+                        selectionId: selId,
+                        role: "assistant",
+                        content: fullResponse,
+                        citations: JSON.stringify(citations),
+                        createdAt: idClock.now(),
+                      })
+                      .run(),
+                    storageFailure,
+                  );
+
+                  // An answer that was not stored is gone the moment the chat is
+                  // reopened. Sending `done` for it would show the reader a
+                  // finished conversation that empties itself on the next visit.
+                  if (saved.isErr()) {
+                    console.error("Failed to save assistant message:", saved.error.cause);
+                    send(
+                      `event: error\ndata: ${JSON.stringify({
+                        code: "CHAT_SAVE_FAILED" satisfies ErrorCode,
+                        message: "The answer could not be saved",
+                      } satisfies ErrorPayload)}\n\n`,
+                    );
+                    closeStream();
+                    return;
+                  }
 
                   for (const citation of citations) {
                     send(`event: citation\ndata: ${JSON.stringify(citation)}\n\n`);
@@ -555,15 +611,12 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
         },
       )
       .delete("/pdf/:pdfId", async (c) => {
-        const deleted = await deletePdf(c.env.DB, c.env.PDF_BUCKET, c.req.param("pdfId"));
-        if (!deleted) {
-          return c.json(
-            { error: { code: "PDF_NOT_FOUND" satisfies ErrorCode, message: "PDF not found" } },
-            404,
-          );
-        }
+        const removal = await deletePdf(c.env.DB, c.env.PDF_BUCKET, c.req.param("pdfId"));
 
-        return c.json({ deleted: true });
+        return removal.match(
+          () => c.json({ deleted: true }),
+          (failure) => serviceFailureResponse(c, failure, PDF_NOT_FOUND),
+        );
       })
       .delete("/pdf/:pdfId/selections/:selId", async (c) => {
         const selId = c.req.param("selId");

--- a/src/server/services/pdfService.ts
+++ b/src/server/services/pdfService.ts
@@ -1,9 +1,11 @@
 import { ulid } from "ulid";
 import { drizzle } from "drizzle-orm/d1";
 import { desc, eq } from "drizzle-orm";
+import { ResultAsync, err, ok } from "neverthrow";
 import { pdfs, selections } from "../db/schema";
 import type { BookSummary, PdfMetadata } from "../../shared/schemas/book";
 import { positionDataSchema, type PositionData } from "../../shared/schemas/selection";
+import { notFound, storageFailure, type ServiceError, type StorageError } from "./serviceError";
 
 /**
  * R2 object key for a PDF, derived from its content hash.
@@ -51,7 +53,14 @@ export type { BookSummary } from "../../shared/schemas/book";
 /**
  * List every stored book, most recently opened first, for the shelf view.
  */
-export async function listPdfs(db: D1Database, bucket: R2Bucket): Promise<BookSummary[]> {
+export function listPdfs(
+  db: D1Database,
+  bucket: R2Bucket,
+): ResultAsync<BookSummary[], StorageError> {
+  return ResultAsync.fromPromise(readShelf(db, bucket), storageFailure);
+}
+
+async function readShelf(db: D1Database, bucket: R2Bucket): Promise<BookSummary[]> {
   const rows = await drizzle(db)
     .select({
       id: pdfs.id,
@@ -79,11 +88,20 @@ export async function listPdfs(db: D1Database, bucket: R2Bucket): Promise<BookSu
  * The PDF binary is stored in R2; D1 keeps the metadata and the object key.
  * Returns the existing record if a file with the same hash already exists.
  */
-export async function openPdf(
+export function openPdf(
   db: D1Database,
   bucket: R2Bucket,
   input: OpenPdfInput,
   idClock: IdClock = systemIdClock,
+): ResultAsync<PdfMetadata, StorageError> {
+  return ResultAsync.fromPromise(storePdf(db, bucket, input, idClock), storageFailure);
+}
+
+async function storePdf(
+  db: D1Database,
+  bucket: R2Bucket,
+  input: OpenPdfInput,
+  idClock: IdClock,
 ): Promise<PdfMetadata> {
   const { fileName, fileHash, fullText, pageCount, arrayBuffer, thumbnail } = input;
   const d1Db = drizzle(db);
@@ -142,9 +160,23 @@ export async function openPdf(
  * D1 is cleared first — if the R2 cleanup then fails, only an unreachable
  * object is left behind, whereas the reverse order would leave a book on the
  * shelf whose binary is gone.
- * Returns false when no such book exists.
+ *
+ * "No such book" and "the store refused" both come back as failures now: the
+ * old boolean made the first look like a result and left the second to escape
+ * as an exception, so the two ends of the same operation were reported in two
+ * different ways.
  */
-export async function deletePdf(db: D1Database, bucket: R2Bucket, pdfId: string): Promise<boolean> {
+export function deletePdf(
+  db: D1Database,
+  bucket: R2Bucket,
+  pdfId: string,
+): ResultAsync<void, ServiceError> {
+  return ResultAsync.fromPromise(removePdf(db, bucket, pdfId), storageFailure).andThen((deleted) =>
+    deleted ? ok(undefined) : err(notFound()),
+  );
+}
+
+async function removePdf(db: D1Database, bucket: R2Bucket, pdfId: string): Promise<boolean> {
   const d1Db = drizzle(db);
   const pdf = await d1Db.select().from(pdfs).where(eq(pdfs.id, pdfId)).get();
   if (!pdf) return false;
@@ -177,7 +209,13 @@ function readPositionData(stored: string): PositionData {
 /**
  * Get a PDF record by id, including its selections.
  */
-export async function getPdf(db: D1Database, bucket: R2Bucket, pdfId: string) {
+export function getPdf(db: D1Database, bucket: R2Bucket, pdfId: string) {
+  return ResultAsync.fromPromise(readPdf(db, bucket, pdfId), storageFailure).andThen((book) =>
+    book ? ok(book) : err(notFound()),
+  );
+}
+
+async function readPdf(db: D1Database, bucket: R2Bucket, pdfId: string) {
   const d1Db = drizzle(db);
   const pdf = await d1Db.select().from(pdfs).where(eq(pdfs.id, pdfId)).get();
   if (!pdf) return null;

--- a/src/server/services/serviceError.ts
+++ b/src/server/services/serviceError.ts
@@ -1,0 +1,16 @@
+/**
+ * Why a service could not deliver what was asked of it.
+ *
+ * Two cases is all the routes need to tell apart: the thing is not there
+ * (the caller asked for a book that was deleted), and the store the answer
+ * lives in refused to answer. Everything routes do with a failure — the status
+ * and the code they reply with — follows from that distinction alone.
+ */
+export type StorageError = { type: "STORAGE"; cause: unknown };
+
+export type ServiceError = { type: "NOT_FOUND" } | StorageError;
+
+export const notFound = (): ServiceError => ({ type: "NOT_FOUND" });
+
+/** Wraps a rejection from D1 or R2, keeping the original for the server log. */
+export const storageFailure = (cause: unknown): StorageError => ({ type: "STORAGE", cause });

--- a/src/shared/schemas/error.ts
+++ b/src/shared/schemas/error.ts
@@ -14,6 +14,9 @@ export const ERROR_CODES = [
   "CONFIG_ERROR",
   "AI_API_ERROR",
   "AI_STREAM_ERROR",
+  "CHAT_SAVE_FAILED",
+  "ROUTE_NOT_FOUND",
+  "INTERNAL_ERROR",
 ] as const;
 
 export type ErrorCode = (typeof ERROR_CODES)[number];

--- a/test/worker/chat.test.ts
+++ b/test/worker/chat.test.ts
@@ -272,6 +272,64 @@ describe("POST /api/pdf/:pdfId/selections/:selId/chats", () => {
     });
   });
 
+  it("tells the client the answer was lost when it cannot be saved", async () => {
+    const { pdfId, selectionId } = await createSelection("chat-save-failure");
+    const encoder = new TextEncoder();
+
+    // Hold the tail of the answer back so the highlight can be deleted while
+    // the answer is still streaming. The row the answer is saved as points at
+    // that highlight, so the save is refused once it is gone.
+    let deliverRest!: () => void;
+    const rest = new Promise<void>((resolve) => {
+      deliverRest = resolve;
+    });
+
+    server.use(
+      http.post("https://api.deepseek.com/chat/completions", () => {
+        const body = new ReadableStream({
+          async start(controller) {
+            controller.enqueue(encoder.encode(chatCompletionsToken("Durable ")));
+            await rest;
+            controller.enqueue(encoder.encode(chatCompletionsToken("Objects")));
+            controller.enqueue(encoder.encode(chatCompletionsTail()));
+            controller.close();
+          },
+        });
+        return new HttpResponse(body, {
+          status: 200,
+          headers: { "content-type": "text/event-stream" },
+        });
+      }),
+    );
+
+    const response = await postChat(pdfId, selectionId, {
+      content: "What are Durable Objects?",
+      useWebSearch: false,
+    });
+
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let received = decoder.decode((await reader.read()).value);
+
+    await SELF.fetch(`https://example.com/api/pdf/${pdfId}/selections/${selectionId}`, {
+      method: "DELETE",
+    });
+    deliverRest();
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += decoder.decode(value, { stream: true });
+    }
+
+    const events = parseSse(received);
+    expect(events.map((e) => e.event)).toStrictEqual(["token", "token", "error"]);
+    expect(events[2].data).toStrictEqual({
+      code: "CHAT_SAVE_FAILED",
+      message: "The answer could not be saved",
+    });
+  });
+
   it("reports an upstream failure to the client as an error event", async () => {
     const { pdfId, selectionId } = await createSelection("chat-upstream-error");
 

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from "vite-plus/test";
 import { env, applyD1Migrations, SELF } from "cloudflare:test";
 import { MINIMAL_PDF_BYTES } from "./fixtures/minimalPdf";
+import app from "../../src/server/index";
 import {
   openPdf,
   pdfObjectKey,
@@ -82,6 +83,70 @@ async function countRows(table: string, column: string, value: string): Promise<
     .first()) as { count: number };
   return row.count;
 }
+
+/**
+ * Bindings that fail every call, so the paths taken when D1 or R2 is
+ * unavailable can be driven without breaking the shared database.
+ */
+function unavailableBindings() {
+  return {
+    DB: {
+      prepare() {
+        throw new Error("D1 is unavailable");
+      },
+    },
+    PDF_BUCKET: {
+      head: () => Promise.reject(new Error("R2 is unavailable")),
+      get: () => Promise.reject(new Error("R2 is unavailable")),
+    },
+    DEEPSEEK_API_KEY: "test-key",
+  } as unknown as { DB: D1Database; PDF_BUCKET: R2Bucket; DEEPSEEK_API_KEY: string };
+}
+
+describe("failures outside a route's own handling", () => {
+  it("answers in the error envelope when the shelf cannot be read from storage", async () => {
+    const response = await app.request(
+      "https://example.com/api/pdfs",
+      undefined,
+      unavailableBindings(),
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toStrictEqual({
+      error: { code: "INTERNAL_ERROR", message: "Unexpected server error" },
+    });
+  });
+
+  it("answers in the error envelope when a route's own query throws", async () => {
+    // No try/catch stands between this route and D1, so before the app had an
+    // onError the reply was a text/plain "Internal Server Error" outside the
+    // envelope every client reads.
+    const response = await app.request(
+      "https://example.com/api/pdf/any-book/file",
+      undefined,
+      unavailableBindings(),
+    );
+
+    expect(response.status).toBe(500);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(await response.json()).toStrictEqual({
+      error: { code: "INTERNAL_ERROR", message: "Unexpected server error" },
+    });
+  });
+
+  it("answers in the error envelope for an API path that does not exist", async () => {
+    const response = await app.request(
+      "https://example.com/api/no-such-endpoint",
+      undefined,
+      unavailableBindings(),
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toStrictEqual({
+      error: { code: "ROUTE_NOT_FOUND", message: "No such API endpoint" },
+    });
+  });
+});
 
 describe("POST /api/pdf/open", () => {
   it("uploads a PDF file and returns its metadata", async () => {
@@ -698,7 +763,7 @@ describe("openPdf with an injected IdClock", () => {
   it("stores a new book under the id and timestamps the clock hands out", async () => {
     const fileHash = "hash-idclock-new";
 
-    const metadata = await openPdf(
+    const stored = await openPdf(
       env.DB,
       env.PDF_BUCKET,
       {
@@ -711,7 +776,7 @@ describe("openPdf with an injected IdClock", () => {
       fixedIdClock("book-idclock-new", "2026-01-02T03:04:05.678Z"),
     );
 
-    expect(metadata).toStrictEqual({
+    expect(stored._unsafeUnwrap()).toStrictEqual({
       id: "book-idclock-new",
       fileName: "injected.pdf",
       pageCount: 3,
@@ -745,14 +810,14 @@ describe("openPdf with an injected IdClock", () => {
       fixedIdClock("book-idclock-reopen", "2026-01-02T03:04:05.678Z"),
     );
 
-    const metadata = await openPdf(
+    const reopened = await openPdf(
       env.DB,
       env.PDF_BUCKET,
       { ...input, fileName: "second.pdf", fullText: "再抽出した本文", pageCount: 4 },
       fixedIdClock("book-idclock-ignored", "2026-03-04T05:06:07.891Z"),
     );
 
-    expect(metadata).toStrictEqual({
+    expect(reopened._unsafeUnwrap()).toStrictEqual({
       id: "book-idclock-reopen",
       fileName: "second.pdf",
       pageCount: 4,


### PR DESCRIPTION
Closes #8

## 概要

issue が挙げた 9 つの silent failure を、ユーザーに見える形か意図的な設計判断のどちらかにした。テンプレート由来の未使用依存だった `neverthrow` がこれで実使用になり、`swr` / `zod` と合わせて 3 つとも使われる状態になる。

| # | 経路 | 変更前 | 変更後 |
| --- | --- | --- | --- |
| 1 | チャット送信の全失敗 | 自分の質問だけ表示され返事が来ない | 「回答の取得に失敗しました: …」 |
| 2 | ハイライト保存失敗 | ポップオーバーが閉じて質問文も消える | 「ハイライトを保存できませんでした: …」+ **ポップオーバーを閉じない** |
| 3 | チャット履歴の取得失敗 | 過去の Q&A が消えたように見える | 「チャット履歴を読み込めませんでした: …」 |
| 4 | ハイライト一覧の取得失敗 | ハイライト 0 件の本に見える | 「ハイライトを読み込めませんでした: …」 |
| 5 | PDF の取得・描画失敗 | 白紙表示のまま | 「PDFを表示できません: …」/「このページを表示できません: …」 |
| 6 | AI 回答の DB 保存失敗 | 成功に見えるがリロードで消える | `event: error` (`CHAT_SAVE_FAILED`) を送り、**回答は画面に残したまま**「この回答は保存できませんでした。チャットを開き直すと消えます」 |
| 7 | `#:~:text=` のページ解決失敗 | 1 ページ目が開かれ理由が分からない | 「リンクされた箇所が見つかりませんでした: …」 |
| 8 | 目次の取得失敗 | 目次なしの本に見える | 「目次を読み込めませんでした: …」(目次が無い本と区別可能に) |
| 9 | 表紙生成失敗 | プレースホルダ | **意図的**。理由をコメントに明記 (表紙は装飾で、本棚がタイトルで代替する) |
| 追加 | アップロード失敗 | `console.error` のみ | 本棚のエラー枠に「PDFを開けませんでした: …」 |

## この PR で見つけて直した退行

**ポップオーバーからの二重送信** (レビューで検出)。「保存が成功したときだけポップオーバーを閉じる」という変更の副作用で、保存を待つ間にポップオーバーが開いたまま再送信できる状態になっていた。二重送信すると `selections` が 2 行作られてハイライトが重複し、2 本目の `sendMessage` が 1 本目を中断する。

症状を数える probe テストを書いたところ、**`onSubmit` が 1 回のはずが 3 回発火** (ボタン・Enter・ボタンの全部が通る) することを観測してから修正した。`SelectionPopover` に送信中フラグを入れ、`onSubmit` を await できる型にしている。

## 設計

- **`fetcher` は throw ベースのまま維持**した。SWR の読み取り境界では `error` state がその境界の Result そのもので、`Err` → throw のアダプタを挟むのは往復の無駄になる。mutation・イベントハンドラ起点の 1 回きりの取得だけが `resultFetcher(...): ResultAsync<T, ApiError>` を使う
- `ApiError` に `kind: "http" | "network" | "parse"` を追加。`parse` は `fetcher` も立て、`network` は `resultFetcher` だけが立てる (`fetcher` の「ネットワーク断・abort を包まない」契約は #7 のまま維持)
- **サーバ**は D1 / R2 に触る service (`pdfService`) を `ResultAsync<T, ServiceError>` にし、route で `.match()` して既存のエラー封筒へ落とす。**レスポンス形式は変えていない**。`app.onError` / `notFound` を安全網として追加 (これまで D1 / R2 の例外は `text/plain` の "Internal Server Error" として封筒の外に出ていた)
- `deletePdf(): Promise<boolean>` (「本が無い」を `false`、「R2 削除失敗」を例外に分けていた) を `ResultAsync<void, ServiceError>` に統一
- **`chatErrorAtom` が UI 表示の正、`sendMessage` の戻り値はフロー制御用**。エラー文言は「フックは理由だけを返し、描くコンポーネントが文を組み立てる」に統一した (`chatErrorAtom` だけが例外で、書き手が複数・読み手が 1 つのため。理由は CLAUDE.md に記載)
- レンダー中の例外は Result で拾えないため `errorElement` を追加。データルータでは `errorElement` が境界そのものなので、別途 class ErrorBoundary は作っていない (作れば重複した死にコードになる)

## テスト

jsdom **158 → 195** (+37)、worker **39 → 43** (+4)、E2E 21 pass。空の `catch` は 0 件。

レビューで「壊しても検出できない」と指摘された箇所は、`PdfViewer` に `measureSelection` / `saveSelection` の注入口を足して jsdom で駆動できるようにし、変異させて落ちることを確認した:

| 変異 | 落ちるテスト |
| --- | --- |
| `saveError` バナーの JSX を削除 | ハイライト保存失敗の表示 |
| `if (asked.isOk()) setPopoverState(null)` → 無条件クローズ | 同上 (質問文が残ること) |
| 二重送信ガードを外す | 送信回数とハイライト件数 |

サーバ側の保存失敗は、ストリーム中に selection を DELETE して外部キー違反を起こす形で再現している (FK が効いていなければ insert が成功して `done` が飛ぶので、仕掛け自体が自己検証的)。

| ゲート | 結果 |
| --- | --- |
| `vp check` | pass |
| `pnpm test` (jsdom) | 195 passed |
| `pnpm run test:worker` | 43 passed |
| `pnpm run test:e2e` | 21 passed |
| `vp build` | pass |

## 残る未固定 (既知)

`PdfOutline` への `error` 配線と `PdfPage` の `onError` 配線の 2 本は、実 pdf.js が無いとコンポーネントがマウントされず jsdom で検証できない。**型でしか守られていない**ことをコード内コメントに明示した。

## CLAUDE.md

エラーハンドリングの節を追加し、該当節を全文書き直した (局所的な追記を重ねると実態とずれることが前 issue の監査で分かったため)。

- 「意図的に握りつぶしているのは 3 種類だけ」→ 実測 7 箇所の表に置き換え (文書内の自己矛盾を解消)
- mutation の規則をコードと一致させた (削除を `resultFetcher` へ移行し、`storeCoverIfMissing` を明示的な例外として記載)
- 存在しない型名 (`MessageId`) を実際のシグネチャに修正

## 申し送り (別 issue 候補)

- `PDFDocumentProxy` を `destroy()` していない (本を切り替えるたび pdf.js の worker リソースが残るリークになりうる)
- チャット履歴だけ SWR を経由していない
- `ChatStreamOptions` の `onCitation` / `onDone` が本番で未使用 (変更前からの dead code)
- `findPageNumber` の 3 通りの「見つからない」が `undefined` に潰れる (issue 対応内容 4。silent failure 表には含まれないため未対応)

🤖 Generated with [Claude Code](https://claude.com/claude-code)