### PR TITLE
🐛 fix: 読み終えた本の pdf.js ドキュメントを破棄する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,11 +383,26 @@ jsdom テストと Workers pool テストは同一プロセスで共存できな
 （`vite.config.ts` は `process.env.VITEST` のとき `cloudflare()` を無効化する）。
 
 **jsdom 側は `include` を書かず `exclude` だけで拾っている**（`node_modules` / `dist` /
-`test/worker/**` / `e2e/**` を除外）。そのため実装とコロケーションした
+`test/worker/**` / `e2e/**` / `.claude/**` を除外）。そのため実装とコロケーションした
 `src/server/services/*.test.ts` も自動的に jsdom で走る。バインディングを触らない純粋な
 サーバロジック（`chatService` の引用パース、`deepseekService` の SSE パースを注入 fetch で
 叩くもの）はこちらで書き、workerd の実物が要るものだけ `test/worker/**` に置く。
 **`include` を足して絞ると、これらが無言で走らなくなる**ので注意。
+
+### `.claude/**` を除外している理由
+
+Claude Code はエージェント用の worktree を `.claude/worktrees/` に作る。これはこのリポジトリの
+まるごとのチェックアウトなので、除外しないとメインクローンの `vp check` と `pnpm test` が
+**別ブランチのファイルを拾う**。実際に起きるのは次の 2 つ:
+
+- 作業中の未整形ファイルで `vp check` が落ちる（メインクローンのソースは健全なのに）
+- worktree 側の `e2e/**` と `test/worker/**` が jsdom の実行に混ざり、
+  `Playwright Test did not expect test() to be called here` や
+  `Failed to resolve import "cloudflare:test"` で落ちる
+
+`vite.config.ts` の `AGENT_WORKTREES` を `fmt.ignorePatterns` / `lint.ignorePatterns` /
+`test.exclude` の 3 箇所に渡している。**各 worktree の中で実行する `vp check` は自分の
+チェックアウトしか見ない**ので影響を受けず、CI もクリーンな checkout なので元から無関係。
 
 ### E2E の前提
 

--- a/src/front/hooks/usePdfDocument.test.tsx
+++ b/src/front/hooks/usePdfDocument.test.tsx
@@ -165,4 +165,51 @@ describe("usePdfDocument", () => {
 
     await waitFor(() => expect(result.current.error).toBe("Failed to fetch"));
   });
+
+  it("closes the document of the book being left when another one is opened", async () => {
+    // pdf.js keeps a worker per document, so a reader moving between books
+    // stacks one up for every book opened until the tab is closed.
+    const { closed, build } = documentBuilder();
+    const { result, rerender } = loadWith(servesBytes, build);
+    await waitFor(() => expect(result.current.pdfDocument).not.toBeNull());
+
+    rerender({ book: { ...BOOK, id: "01JOTHER" } });
+
+    await waitFor(() => expect(closed).toStrictEqual(["doc-1"]));
+  });
+
+  it("closes the document when the reader leaves the book", async () => {
+    const { closed, build } = documentBuilder();
+    const { result, unmount } = loadWith(servesBytes, build);
+    await waitFor(() => expect(result.current.pdfDocument).not.toBeNull());
+
+    unmount();
+
+    await waitFor(() => expect(closed).toStrictEqual(["doc-1"]));
+  });
+
+  it("closes a document that pdf.js finished after the reader had already left", async () => {
+    // Nothing is ever shown for this one, so the hook holds the only reference
+    // to the worker and the cleanup has already run by the time it arrives.
+    const closed: string[] = [];
+    let finishBuild: (() => void) | null = null;
+    const buildSlowly = () =>
+      new Promise<pdfjsTypes.PDFDocumentProxy>((resolve) => {
+        finishBuild = () =>
+          resolve({
+            destroy: () => {
+              closed.push("doc-1");
+              return Promise.resolve();
+            },
+          } as unknown as pdfjsTypes.PDFDocumentProxy);
+      });
+
+    const { unmount } = loadWith(servesBytes, buildSlowly);
+    await waitFor(() => expect(finishBuild).not.toBeNull());
+
+    unmount();
+    finishBuild!();
+
+    await waitFor(() => expect(closed).toStrictEqual(["doc-1"]));
+  });
 });

--- a/src/front/hooks/usePdfDocument.test.tsx
+++ b/src/front/hooks/usePdfDocument.test.tsx
@@ -79,14 +79,51 @@ const BOOK: BookDetail = {
  * wrapped like every other SWR user: the default cache is a module-level
  * singleton and would carry that entry between tests.
  */
-function loadWith(fetchFn: typeof fetch) {
+function loadWith(
+  fetchFn: typeof fetch,
+  buildDocument?: (data: ArrayBuffer) => Promise<pdfjsTypes.PDFDocumentProxy>,
+) {
   const wrapper = ({ children }: { children: ReactNode }) => (
     <SwrTestCache>{children}</SwrTestCache>
   );
-  return renderHook(() => usePdfDocument(BOOK, fetchFn), { wrapper });
+  return renderHook(
+    ({ book }: { book: BookDetail | undefined }) => usePdfDocument(book, fetchFn, buildDocument),
+    {
+      wrapper,
+      initialProps: { book: BOOK as BookDetail | undefined },
+    },
+  );
+}
+
+/** A stored PDF whose bytes pdf.js is standing in for. */
+const servesBytes: typeof fetch = () => Promise.resolve(new Response(new ArrayBuffer(8)));
+
+/** Records the documents pdf.js handed over and which of them were closed. */
+function documentBuilder() {
+  const closed: string[] = [];
+  let built = 0;
+  const build = () => {
+    const name = `doc-${++built}`;
+    return Promise.resolve({
+      destroy: () => {
+        closed.push(name);
+        return Promise.resolve();
+      },
+    } as unknown as pdfjsTypes.PDFDocumentProxy);
+  };
+  return { closed, build };
 }
 
 describe("usePdfDocument", () => {
+  it("hands the viewer the document pdf.js built from the stored bytes", async () => {
+    const { build } = documentBuilder();
+
+    const { result } = loadWith(servesBytes, build);
+
+    await waitFor(() => expect(result.current.pdfDocument).not.toBeNull());
+    expect(result.current.error).toBeNull();
+  });
+
   it("reports the server's reason when the book's file cannot be fetched", async () => {
     // The viewer used to be left with no document and no reason for it, which
     // reads on screen as a book that opened to a blank page.

--- a/src/front/hooks/usePdfDocument.ts
+++ b/src/front/hooks/usePdfDocument.ts
@@ -50,6 +50,10 @@ export async function storeCoverIfMissing(
   }
 }
 
+/** Hands the fetched bytes to pdf.js. Injected so tests can stand in for it. */
+const buildPdfDocument = (data: ArrayBuffer) =>
+  pdfjsLib.getDocument({ data, ...PDFJS_ASSET_OPTIONS }).promise;
+
 /**
  * Load the pdfjs-dist PDFDocumentProxy for the given book by fetching the
  * stored PDF binary from the API.
@@ -59,7 +63,11 @@ export async function storeCoverIfMissing(
  * a book that opened to a blank page. `error` is why, in the words of whoever
  * refused; the viewer is what turns it into a sentence.
  */
-export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fetch = fetch) {
+export function usePdfDocument(
+  book: BookDetail | undefined,
+  fetchFn: typeof fetch = fetch,
+  buildDocument: (data: ArrayBuffer) => Promise<pdfjsTypes.PDFDocumentProxy> = buildPdfDocument,
+) {
   const [pdfDocument, setPdfDocument] = useState<pdfjsTypes.PDFDocumentProxy | null>(null);
   const [error, setError] = useState<string | null>(null);
   const loadingRef = useRef<string | null>(null);
@@ -107,10 +115,7 @@ export function usePdfDocument(book: BookDetail | undefined, fetchFn: typeof fet
         const arrayBuffer = await response.arrayBuffer();
         if (cancelled) return;
 
-        const doc = await pdfjsLib.getDocument({
-          data: arrayBuffer,
-          ...PDFJS_ASSET_OPTIONS,
-        }).promise;
+        const doc = await buildDocument(arrayBuffer);
         if (cancelled) return;
 
         setPdfDocument(doc);

--- a/src/front/hooks/usePdfDocument.ts
+++ b/src/front/hooks/usePdfDocument.ts
@@ -102,6 +102,9 @@ export function usePdfDocument(
     const hasThumbnail = book.hasThumbnail;
     const url = `/api/pdf/${pdfId}/file`;
     let cancelled = false;
+    // pdf.js runs a worker per document and only releases it on destroy, so the
+    // one built here is closed when this book is left behind.
+    let opened: pdfjsTypes.PDFDocumentProxy | null = null;
     setError(null);
 
     async function loadPdf() {
@@ -116,7 +119,11 @@ export function usePdfDocument(
         if (cancelled) return;
 
         const doc = await buildDocument(arrayBuffer);
-        if (cancelled) return;
+        opened = doc;
+        if (cancelled) {
+          void doc.destroy();
+          return;
+        }
 
         setPdfDocument(doc);
         void backfillCover({ pdfId, doc, hasThumbnail });
@@ -133,6 +140,7 @@ export function usePdfDocument(
 
     return () => {
       cancelled = true;
+      void opened?.destroy();
     };
   }, [book?.id]);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,19 @@ import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { cloudflare } from "@cloudflare/vite-plugin";
 
+// Claude Code keeps its agent worktrees under `.claude/worktrees/`, which are
+// whole checkouts of this repo. Without this, `vp check` and `pnpm test` in the
+// main clone pick those up and report failures that belong to another branch —
+// or collect their Playwright and workers-pool specs into the jsdom run.
+const AGENT_WORKTREES = ".claude/**";
+
 export default defineConfig({
   plugins: [react(), tailwindcss(), !process.env.VITEST && cloudflare()],
+  fmt: {
+    ignorePatterns: [AGENT_WORKTREES],
+  },
   lint: {
+    ignorePatterns: [AGENT_WORKTREES],
     options: {
       typeAware: true,
       typeCheck: true,
@@ -31,6 +41,6 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./src/test/setup.ts"],
     // e2e/ holds Playwright specs, which must not be collected by vitest
-    exclude: ["**/node_modules/**", "**/dist/**", "test/worker/**", "e2e/**"],
+    exclude: ["**/node_modules/**", "**/dist/**", "test/worker/**", "e2e/**", AGENT_WORKTREES],
   },
 });


### PR DESCRIPTION
## 概要

pdf.js はドキュメントごとに worker を持ち、`destroy()` を呼ぶまで解放しない。`usePdfDocument` はこれを一度も呼んでおらず (`rg -n "destroy" src e2e` が 0 件だった)、**本を切り替えるたび・リーダーを離れるたびに worker が積み上がる**状態だった。

併せて、エージェント用 worktree がメインクローンの `vp check` / `pnpm test` を汚す問題も塞いだ。

## 変更

### 1. pdf.js ドキュメントの破棄

- 本を切り替えたとき / リーダーを離れたときに、その本のドキュメントを破棄する
- **構築中に離脱した場合も破棄する**。届いたドキュメントを掴んでいるのはこのフックだけで、画面には一度も出ないため

破棄の順序は安全側に倒れている。`PdfPage` は自身の cleanup で `cancelled` を立てるため、破棄済みドキュメントに触れて出た例外は `onError` に流れず、ページ送りのたびにエラーバナーが出ることはない。

### 2. `.claude/**` を check・テストの対象から外す

`.claude/worktrees/` はこのリポジトリのまるごとのチェックアウトなので、除外しないとメインクローンの実行が別ブランチのファイルを拾う。実際に次の 2 つが起きていた:

- 作業中の未整形ファイルで `vp check` が落ちる (メインクローンのソースは健全なのに)
- worktree 側の `e2e/**` と `test/worker/**` が jsdom の実行に混ざり、`Playwright Test did not expect test() to be called here` や `Failed to resolve import "cloudflare:test"` で落ちる

`vite.config.ts` の `AGENT_WORKTREES` を `fmt.ignorePatterns` / `lint.ignorePatterns` / `test.exclude` の 3 箇所に渡している。各 worktree の中で実行する `vp check` は自分のチェックアウトしか見ないので影響を受けず、CI もクリーンな checkout なので元から無関係。

## テスト

jsdom **195 → 199** (+4)。破棄の 3 経路 (本の切り替え / 離脱 / 構築中の離脱) は**先に失敗を観測してから**実装した (`expected [] to strictly equal [ 'doc-1' ]` の 3 件)。

3 件目は最初に書いた形では成立しなかった。バイナリ取得の直後に中断判定があるため、その経路ではドキュメントが構築されず漏れも起きない。構築中に離脱する競合を再現する形に書き直している。

これらを書けるようにするため、pdf.js のドキュメント構築をデフォルト引数で注入可能にした (別コミット・STRUCTURAL)。これまでフックの成功パスは jsdom で駆動できず、失敗パスしか固定できていなかった。

| ゲート | 結果 |
| --- | --- |
| `vp check` | pass |
| `pnpm test` (jsdom) | 199 passed |
| `pnpm run test:worker` | 43 passed |
| `pnpm run test:e2e` | 21 passed |

除外設定が効くことは、`.claude/` 配下に未整形ファイルと必ず失敗するテストを置いて実測で確認した (どちらも検出されないこと、設定前は検出されることの両方)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)