### PR TITLE
🔧 chore: cloudflare:test の deprecated な SELF / env を置き換える

### DIFF
--- a/test/worker/chat.test.ts
+++ b/test/worker/chat.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from "vite-plus/test";
-import { env, applyD1Migrations, SELF } from "cloudflare:test";
+import { applyD1Migrations } from "cloudflare:test";
+import { env, exports } from "cloudflare:workers";
 import { http, HttpResponse } from "msw";
 import { server } from "./setup/msw";
 import { MINIMAL_PDF_BYTES } from "./fixtures/minimalPdf";
@@ -30,21 +31,24 @@ async function createSelection(tag: string): Promise<{ pdfId: string; selectionI
   formData.append("fullText", BOOK_TEXT);
   formData.append("pageCount", "1");
 
-  const uploadResponse = await SELF.fetch("https://example.com/api/pdf/open", {
+  const uploadResponse = await exports.default.fetch("https://example.com/api/pdf/open", {
     method: "POST",
     body: formData,
   });
   const { id: pdfId } = (await uploadResponse.json()) as { id: string };
 
-  const selectionResponse = await SELF.fetch(`https://example.com/api/pdf/${pdfId}/selections`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      selectedText: HIGHLIGHTED_PASSAGE,
-      pageNumber: 1,
-      positionData: { rects: [] },
-    }),
-  });
+  const selectionResponse = await exports.default.fetch(
+    `https://example.com/api/pdf/${pdfId}/selections`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        selectedText: HIGHLIGHTED_PASSAGE,
+        pageNumber: 1,
+        positionData: { rects: [] },
+      }),
+    },
+  );
   const { id: selectionId } = (await selectionResponse.json()) as { id: string };
 
   return { pdfId, selectionId };
@@ -123,7 +127,7 @@ interface StoredMessage {
  * words "Internal Server Error".
  */
 async function readChatHistory(pdfId: string, selectionId: string): Promise<StoredMessage[]> {
-  const response = await SELF.fetch(
+  const response = await exports.default.fetch(
     `https://example.com/api/pdf/${pdfId}/selections/${selectionId}/chats`,
   );
   expect(response.status).toBe(200);
@@ -132,11 +136,14 @@ async function readChatHistory(pdfId: string, selectionId: string): Promise<Stor
 }
 
 async function postChat(pdfId: string, selectionId: string, payload: unknown): Promise<Response> {
-  return SELF.fetch(`https://example.com/api/pdf/${pdfId}/selections/${selectionId}/chats`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
+  return exports.default.fetch(
+    `https://example.com/api/pdf/${pdfId}/selections/${selectionId}/chats`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    },
+  );
 }
 
 describe("POST /api/pdf/:pdfId/selections/:selId/chats", () => {
@@ -311,7 +318,7 @@ describe("POST /api/pdf/:pdfId/selections/:selId/chats", () => {
     const decoder = new TextDecoder();
     let received = decoder.decode((await reader.read()).value);
 
-    await SELF.fetch(`https://example.com/api/pdf/${pdfId}/selections/${selectionId}`, {
+    await exports.default.fetch(`https://example.com/api/pdf/${pdfId}/selections/${selectionId}`, {
       method: "DELETE",
     });
     deliverRest();

--- a/test/worker/health.test.ts
+++ b/test/worker/health.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vite-plus/test";
-import { env, applyD1Migrations, SELF } from "cloudflare:test";
+import { applyD1Migrations } from "cloudflare:test";
+import { env, exports } from "cloudflare:workers";
 
 describe("GET /api/health", () => {
   it("returns ok once the D1 migration has been applied", async () => {
     await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
 
-    const response = await SELF.fetch("https://example.com/api/health");
+    const response = await exports.default.fetch("https://example.com/api/health");
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ status: "ok" });

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from "vite-plus/test";
-import { env, applyD1Migrations, SELF } from "cloudflare:test";
+import { applyD1Migrations } from "cloudflare:test";
+import { env, exports } from "cloudflare:workers";
 import { MINIMAL_PDF_BYTES } from "./fixtures/minimalPdf";
 import app from "../../src/server/index";
 import {
@@ -46,7 +47,7 @@ async function uploadBook(options: {
     );
   }
 
-  const response = await SELF.fetch("https://example.com/api/pdf/open", {
+  const response = await exports.default.fetch("https://example.com/api/pdf/open", {
     method: "POST",
     body: formData,
   });
@@ -155,7 +156,7 @@ describe("POST /api/pdf/open", () => {
     formData.append("fullText", "test content");
     formData.append("pageCount", "1");
 
-    const response = await SELF.fetch("https://example.com/api/pdf/open", {
+    const response = await exports.default.fetch("https://example.com/api/pdf/open", {
       method: "POST",
       body: formData,
     });
@@ -173,7 +174,7 @@ describe("POST /api/pdf/open", () => {
     formData.append("fullText", "test");
     formData.append("pageCount", "1");
 
-    const response = await SELF.fetch("https://example.com/api/pdf/open", {
+    const response = await exports.default.fetch("https://example.com/api/pdf/open", {
       method: "POST",
       body: formData,
     });
@@ -190,7 +191,7 @@ describe("POST /api/pdf/open", () => {
     staleForm.append("fullText", "stale text");
     staleForm.append("pageCount", "16");
 
-    const staleResponse = await SELF.fetch("https://example.com/api/pdf/open", {
+    const staleResponse = await exports.default.fetch("https://example.com/api/pdf/open", {
       method: "POST",
       body: staleForm,
     });
@@ -204,7 +205,7 @@ describe("POST /api/pdf/open", () => {
     freshForm.append("fullText", "fresh text");
     freshForm.append("pageCount", "209");
 
-    const freshResponse = await SELF.fetch("https://example.com/api/pdf/open", {
+    const freshResponse = await exports.default.fetch("https://example.com/api/pdf/open", {
       method: "POST",
       body: freshForm,
     });
@@ -216,7 +217,7 @@ describe("POST /api/pdf/open", () => {
     expect(fresh.fileName).toBe("fresh.pdf");
 
     // The refreshed values must be persisted, not just echoed back
-    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${fresh.id}`);
+    const getResponse = await exports.default.fetch(`https://example.com/api/pdf/${fresh.id}`);
     const persisted = (await getResponse.json()) as PdfResponse;
     expect(persisted.pageCount).toBe(209);
     expect(persisted.fileName).toBe("fresh.pdf");
@@ -228,7 +229,7 @@ describe("POST /api/pdf/open", () => {
     formData.append("fullText", "test content");
     formData.append("pageCount", "1");
 
-    const response1 = await SELF.fetch("https://example.com/api/pdf/open", {
+    const response1 = await exports.default.fetch("https://example.com/api/pdf/open", {
       method: "POST",
       body: formData,
     });
@@ -243,7 +244,7 @@ describe("POST /api/pdf/open", () => {
     formData2.append("fullText", "test content");
     formData2.append("pageCount", "1");
 
-    const response2 = await SELF.fetch("https://example.com/api/pdf/open", {
+    const response2 = await exports.default.fetch("https://example.com/api/pdf/open", {
       method: "POST",
       body: formData2,
     });
@@ -260,13 +261,13 @@ describe("GET /api/pdf/:pdfId", () => {
     formData.append("fullText", "test content");
     formData.append("pageCount", "1");
 
-    const uploadResponse = await SELF.fetch("https://example.com/api/pdf/open", {
+    const uploadResponse = await exports.default.fetch("https://example.com/api/pdf/open", {
       method: "POST",
       body: formData,
     });
     const uploadJson = (await uploadResponse.json()) as PdfResponse;
 
-    const response = await SELF.fetch(`https://example.com/api/pdf/${uploadJson.id}`);
+    const response = await exports.default.fetch(`https://example.com/api/pdf/${uploadJson.id}`);
     expect(response.status).toBe(200);
 
     const json = (await response.json()) as PdfResponse;
@@ -276,7 +277,7 @@ describe("GET /api/pdf/:pdfId", () => {
   });
 
   it("returns 404 for a non-existent pdfId", async () => {
-    const response = await SELF.fetch("https://example.com/api/pdf/non-existent-id");
+    const response = await exports.default.fetch("https://example.com/api/pdf/non-existent-id");
     expect(response.status).toBe(404);
   });
 });
@@ -288,13 +289,15 @@ describe("GET /api/pdf/:pdfId/file", () => {
     formData.append("fullText", "test content");
     formData.append("pageCount", "1");
 
-    const uploadResponse = await SELF.fetch("https://example.com/api/pdf/open", {
+    const uploadResponse = await exports.default.fetch("https://example.com/api/pdf/open", {
       method: "POST",
       body: formData,
     });
     const uploadJson = (await uploadResponse.json()) as PdfResponse;
 
-    const response = await SELF.fetch(`https://example.com/api/pdf/${uploadJson.id}/file`);
+    const response = await exports.default.fetch(
+      `https://example.com/api/pdf/${uploadJson.id}/file`,
+    );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("application/pdf");
@@ -303,7 +306,9 @@ describe("GET /api/pdf/:pdfId/file", () => {
   });
 
   it("returns 404 for a non-existent pdfId", async () => {
-    const response = await SELF.fetch("https://example.com/api/pdf/non-existent-id/file");
+    const response = await exports.default.fetch(
+      "https://example.com/api/pdf/non-existent-id/file",
+    );
     expect(response.status).toBe(404);
   });
 });
@@ -320,7 +325,7 @@ describe("GET /api/pdfs", () => {
       fileName: "without-cover.pdf",
     });
 
-    const response = await SELF.fetch("https://example.com/api/pdfs");
+    const response = await exports.default.fetch("https://example.com/api/pdfs");
     expect(response.status).toBe(200);
 
     const { books } = (await response.json()) as {
@@ -349,7 +354,9 @@ describe("PDF thumbnails", () => {
       thumbnail: new Blob([FAKE_WEBP], { type: "image/webp" }),
     });
 
-    const response = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`);
+    const response = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+    );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("image/webp");
@@ -359,7 +366,9 @@ describe("PDF thumbnails", () => {
   it("returns 404 when the book has no thumbnail yet", async () => {
     const book = await uploadBook({ tag: "thumb-missing", fileName: "no-cover.pdf" });
 
-    const response = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`);
+    const response = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+    );
 
     expect(response.status).toBe(404);
   });
@@ -367,14 +376,19 @@ describe("PDF thumbnails", () => {
   it("stores a thumbnail uploaded later via PUT", async () => {
     const book = await uploadBook({ tag: "thumb-backfill", fileName: "backfill.pdf" });
 
-    const putResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`, {
-      method: "PUT",
-      headers: { "Content-Type": "image/webp" },
-      body: FAKE_WEBP,
-    });
+    const putResponse = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "image/webp" },
+        body: FAKE_WEBP,
+      },
+    );
     expect(putResponse.status).toBe(200);
 
-    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`);
+    const getResponse = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+    );
     expect(getResponse.status).toBe(200);
     expect(new Uint8Array(await getResponse.arrayBuffer())).toEqual(FAKE_WEBP);
   });
@@ -383,18 +397,23 @@ describe("PDF thumbnails", () => {
     const book = await uploadBook({ tag: "thumb-not-webp", fileName: "not-webp.pdf" });
     const png = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
 
-    const putResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`, {
-      method: "PUT",
-      headers: { "Content-Type": "image/webp" },
-      body: png,
-    });
+    const putResponse = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "image/webp" },
+        body: png,
+      },
+    );
 
     expect(putResponse.status).toBe(400);
     expect(await putResponse.json()).toStrictEqual({
       error: { code: "VALIDATION_ERROR", message: "Thumbnail is not a WebP image" },
     });
     // Nothing was stored, so the shelf still falls back to the placeholder
-    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`);
+    const getResponse = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+    );
     expect(getResponse.status).toBe(404);
   });
 
@@ -403,14 +422,19 @@ describe("PDF thumbnails", () => {
     const atLimit = new Uint8Array(2 * 1024 * 1024);
     atLimit.set(FAKE_WEBP, 0);
 
-    const putResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`, {
-      method: "PUT",
-      headers: { "Content-Type": "image/webp" },
-      body: atLimit,
-    });
+    const putResponse = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "image/webp" },
+        body: atLimit,
+      },
+    );
 
     expect(putResponse.status).toBe(200);
-    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`);
+    const getResponse = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+    );
     expect(getResponse.status).toBe(200);
     expect((await getResponse.arrayBuffer()).byteLength).toBe(2 * 1024 * 1024);
   });
@@ -420,26 +444,34 @@ describe("PDF thumbnails", () => {
     const oversized = new Uint8Array(2 * 1024 * 1024 + 1);
     oversized.set(FAKE_WEBP, 0);
 
-    const putResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`, {
-      method: "PUT",
-      headers: { "Content-Type": "image/webp" },
-      body: oversized,
-    });
+    const putResponse = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+      {
+        method: "PUT",
+        headers: { "Content-Type": "image/webp" },
+        body: oversized,
+      },
+    );
 
     expect(putResponse.status).toBe(400);
     expect(await putResponse.json()).toStrictEqual({
       error: { code: "VALIDATION_ERROR", message: "Thumbnail is larger than 2097152 bytes" },
     });
-    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}/thumbnail`);
+    const getResponse = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/thumbnail`,
+    );
     expect(getResponse.status).toBe(404);
   });
 
   it("returns 404 when putting a thumbnail for an unknown book", async () => {
-    const response = await SELF.fetch("https://example.com/api/pdf/does-not-exist/thumbnail", {
-      method: "PUT",
-      headers: { "Content-Type": "image/webp" },
-      body: FAKE_WEBP,
-    });
+    const response = await exports.default.fetch(
+      "https://example.com/api/pdf/does-not-exist/thumbnail",
+      {
+        method: "PUT",
+        headers: { "Content-Type": "image/webp" },
+        body: FAKE_WEBP,
+      },
+    );
 
     expect(response.status).toBe(404);
   });
@@ -458,7 +490,7 @@ describe("DELETE /api/pdf/:pdfId", () => {
       thumbnail: new Blob([FAKE_WEBP], { type: "image/webp" }),
     });
 
-    const selectionResponse = await SELF.fetch(
+    const selectionResponse = await exports.default.fetch(
       `https://example.com/api/pdf/${book.id}/selections`,
       {
         method: "POST",
@@ -494,14 +526,14 @@ describe("DELETE /api/pdf/:pdfId", () => {
     expect(await env.PDF_BUCKET.head(pdfObjectKey(fileHash))).not.toBeNull();
     expect(await env.PDF_BUCKET.head(thumbnailObjectKey(fileHash))).not.toBeNull();
 
-    const response = await SELF.fetch(`https://example.com/api/pdf/${book.id}`, {
+    const response = await exports.default.fetch(`https://example.com/api/pdf/${book.id}`, {
       method: "DELETE",
     });
 
     expect(response.status).toBe(200);
     expect(await response.json()).toStrictEqual({ deleted: true });
 
-    const getResponse = await SELF.fetch(`https://example.com/api/pdf/${book.id}`);
+    const getResponse = await exports.default.fetch(`https://example.com/api/pdf/${book.id}`);
     expect(getResponse.status).toBe(404);
     expect(await countRows("selections", "pdf_id", book.id)).toBe(0);
     expect(await countRows("chat_messages", "selection_id", selection.id)).toBe(0);
@@ -509,14 +541,16 @@ describe("DELETE /api/pdf/:pdfId", () => {
     expect(await env.PDF_BUCKET.head(thumbnailObjectKey(fileHash))).toBeNull();
 
     // A delete that lost its WHERE clause would empty the whole shelf
-    const survivorResponse = await SELF.fetch(`https://example.com/api/pdf/${survivor.id}`);
+    const survivorResponse = await exports.default.fetch(
+      `https://example.com/api/pdf/${survivor.id}`,
+    );
     expect(survivorResponse.status).toBe(200);
     expect(await env.PDF_BUCKET.head(pdfObjectKey(survivorHash))).not.toBeNull();
     expect(await env.PDF_BUCKET.head(thumbnailObjectKey(survivorHash))).not.toBeNull();
   });
 
   it("returns 404 for an unknown book", async () => {
-    const response = await SELF.fetch("https://example.com/api/pdf/does-not-exist", {
+    const response = await exports.default.fetch("https://example.com/api/pdf/does-not-exist", {
       method: "DELETE",
     });
 
@@ -535,7 +569,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
       pages: ["まえがき", "第1章", "エッジ は サーバーレス 実行基盤 です"],
     });
 
-    const response = await SELF.fetch(
+    const response = await exports.default.fetch(
       `https://example.com/api/pdf/${book.id}/locate?text=${encodeURIComponent("エッジはサーバーレス実行基盤です")}`,
     );
 
@@ -550,7 +584,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
       pages: ["まえがき", "第1章"],
     });
 
-    const response = await SELF.fetch(
+    const response = await exports.default.fetch(
       `https://example.com/api/pdf/${book.id}/locate?text=${encodeURIComponent("存在しない一文")}`,
     );
 
@@ -561,7 +595,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
   it("returns 400 when no text is given", async () => {
     const book = await uploadBook({ tag: "locate-empty", fileName: "locate-empty.pdf" });
 
-    const response = await SELF.fetch(`https://example.com/api/pdf/${book.id}/locate`);
+    const response = await exports.default.fetch(`https://example.com/api/pdf/${book.id}/locate`);
 
     expect(response.status).toBe(400);
     expect(await response.json()).toStrictEqual({
@@ -577,7 +611,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
       pages: ["まえがき", passage],
     });
 
-    const response = await SELF.fetch(
+    const response = await exports.default.fetch(
       `https://example.com/api/pdf/${book.id}/locate?text=${encodeURIComponent(passage)}`,
     );
 
@@ -588,7 +622,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
   it("refuses a passage longer than any quotable one instead of scanning the book for it", async () => {
     const book = await uploadBook({ tag: "locate-long", fileName: "locate-long.pdf" });
 
-    const response = await SELF.fetch(
+    const response = await exports.default.fetch(
       `https://example.com/api/pdf/${book.id}/locate?text=${"あ".repeat(2001)}`,
     );
 
@@ -599,7 +633,9 @@ describe("GET /api/pdf/:pdfId/locate", () => {
   });
 
   it("returns 404 for an unknown book", async () => {
-    const response = await SELF.fetch("https://example.com/api/pdf/does-not-exist/locate?text=x");
+    const response = await exports.default.fetch(
+      "https://example.com/api/pdf/does-not-exist/locate?text=x",
+    );
 
     expect(response.status).toBe(404);
     expect(await response.json()).toStrictEqual({
@@ -610,7 +646,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
 
 /** Post a highlight the way the viewer does, with the body left to the caller. */
 async function postSelection(pdfId: string, body: unknown): Promise<Response> {
-  return SELF.fetch(`https://example.com/api/pdf/${pdfId}/selections`, {
+  return exports.default.fetch(`https://example.com/api/pdf/${pdfId}/selections`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -625,7 +661,7 @@ async function postSelection(pdfId: string, body: unknown): Promise<Response> {
  * "Internal Server Error".
  */
 async function readSelections(pdfId: string): Promise<Record<string, unknown>[]> {
-  const response = await SELF.fetch(`https://example.com/api/pdf/${pdfId}`);
+  const response = await exports.default.fetch(`https://example.com/api/pdf/${pdfId}`);
   expect(response.status).toBe(200);
   const { selections } = (await response.json()) as { selections: Record<string, unknown>[] };
   return selections;


### PR DESCRIPTION
## 背景

`@cloudflare/vitest-pool-workers` 0.19 の型定義 (`types/cloudflare-test.d.ts`) で、`cloudflare:test` の `env` と `SELF` が `@deprecated` になっている。

- `env` → `import { env } from "cloudflare:workers"`
- `SELF` → `import { exports } from "cloudflare:workers"` の `exports.default.fetch()`

## 変更内容

worker テスト 3 ファイル (`test/worker/health.test.ts` / `pdf.test.ts` / `chat.test.ts`) の import を置き換えた。

```ts
// before
import { env, applyD1Migrations, SELF } from "cloudflare:test";
// after
import { applyD1Migrations } from "cloudflare:test";
import { env, exports } from "cloudflare:workers";
```

呼び出し側は `SELF.fetch(...)` → `exports.default.fetch(...)` に一括置換。`applyD1Migrations` は deprecated ではないので `cloudflare:test` のまま残す。

`exports.default` に型が付くのは `worker-configuration.d.ts` に `Cloudflare.GlobalProps.mainModule` が生成済みのためで、追加の型定義は不要だった。

テストの検証内容は 1 行も変えていない STRUCTURAL 変更。

## 動作確認

- `pnpm run test:worker` — 3 ファイル 43 テスト全 pass
- `vp check` — 型エラー・lint 警告なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)