### PR TITLE
✨ feat: 引用とリンクのページが解決できない理由を読者に伝える

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,20 @@ Web 検索は既定で ON（`useWebSearchAtom`）。API キーは `.dev.vars` �
 出典は system prompt で `## Sources` セクションを書かせ、`parseCitations` が抽出する。
 PDF 引用は `fullText` 内の位置からページ番号を割り出してジャンプ可能にしている。
 
+ページ解決は `src/server/services/chatService.ts` の `findPageNumber` が行い、
+`src/shared/schemas/book.ts` の `LocatedPage`（`{found: true, pageNumber}` か
+`{found: false, miss}`）を返す。**見つからない理由を潰さないこと**——`miss` は
+`no-quote`（引用文が空）/ `not-in-book`（本文に無い）/ `single-page-book`（1 ページの本）の
+3 つで、読者に伝える内容がそれぞれ違う。とくに `not-in-book` は、**AI が引用を本文どおりに
+書かなかった可能性**を読者が知る唯一の手がかりになる。消費者は 2 つ:
+
+- `GET /pdf/:pdfId/locate` がそのまま返し、`useReadingLocation` の `passageMiss`
+  （lookup 自体が失敗した `lookup-failed` を加えた 4 値）を経て `AppPage` の
+  `PASSAGE_MISS_MESSAGE` が文言にする
+- `parseCitations` が `pageMiss` として引用に載せ、`CitationBadge` の `PAGE_MISS_TITLE` が
+  title にする。**引用は JSON で保存される**ため、`pageMiss` は discriminated union ではなく
+  任意フィールドにしてある（この列が無い既存の行も読めるようにするため）
+
 なお 209 ページの本では全文をコンテキストに載せるため、最初のトークンまで **10 秒前後** かかる。
 ストリーミングが壊れているのと区別すること（`read()` が複数回に分かれるかで判別できる）。
 

--- a/src/front/components/ChatArea/CitationBadge.test.tsx
+++ b/src/front/components/ChatArea/CitationBadge.test.tsx
@@ -68,6 +68,17 @@ describe("CitationBadge", () => {
     );
   });
 
+  it("says a source with no quotable text is missing one rather than missing a page", () => {
+    renderBadge({
+      id: "4",
+      type: "pdf",
+      text: "「」",
+      pageMiss: "no-quote",
+    });
+
+    expect(screen.getByText("[4]")).toHaveAttribute("title", "出典に引用文が入っていません: 「」");
+  });
+
   it("says a book of one page has nowhere to jump to instead of blaming the quote", () => {
     renderBadge({
       id: "3",

--- a/src/front/components/ChatArea/CitationBadge.test.tsx
+++ b/src/front/components/ChatArea/CitationBadge.test.tsx
@@ -53,4 +53,32 @@ describe("CitationBadge", () => {
     expect(screen.getByText("[2]")).toBeInTheDocument();
     expect(screen.queryByRole("button")).toBeNull();
   });
+
+  it("says a quote the book does not hold may not be its words, not just that it has no page", () => {
+    renderBadge({
+      id: "2",
+      type: "pdf",
+      text: "本文に無い引用",
+      pageMiss: "not-in-book",
+    });
+
+    expect(screen.getByText("[2]")).toHaveAttribute(
+      "title",
+      "本文に一致する箇所が見つかりませんでした（引用が本文どおりでない可能性があります）: 本文に無い引用",
+    );
+  });
+
+  it("says a book of one page has nowhere to jump to instead of blaming the quote", () => {
+    renderBadge({
+      id: "3",
+      type: "pdf",
+      text: "1ページの本からの引用",
+      pageMiss: "single-page-book",
+    });
+
+    expect(screen.getByText("[3]")).toHaveAttribute(
+      "title",
+      "この本は1ページなので移動先がありません: 1ページの本からの引用",
+    );
+  });
 });

--- a/src/front/components/ChatArea/CitationBadge.tsx
+++ b/src/front/components/ChatArea/CitationBadge.tsx
@@ -8,6 +8,18 @@ interface CitationBadgeProps {
 
 const BADGE_CLASS = "inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-xs font-medium";
 
+/**
+ * Why a source has no page to jump to. A badge that simply cannot be clicked
+ * looks like a bug; "not in the book" in particular is the reader's only hint
+ * that the model may not have quoted the passage as it is written.
+ */
+const PAGE_MISS_TITLE: Record<NonNullable<Citation["pageMiss"]>, string> = {
+  "not-in-book":
+    "本文に一致する箇所が見つかりませんでした（引用が本文どおりでない可能性があります）",
+  "no-quote": "出典に引用文が入っていません",
+  "single-page-book": "この本は1ページなので移動先がありません",
+};
+
 export function CitationBadge({ citation }: CitationBadgeProps) {
   const setCurrentPage = useSetAtom(currentPageAtom);
 
@@ -28,8 +40,10 @@ export function CitationBadge({ citation }: CitationBadgeProps) {
   const pageNumber = citation.pageNumber;
   // Without a page there is nowhere to jump to, so the badge is not a control
   if (!pageNumber) {
+    const reason = citation.pageMiss;
+    const title = reason ? `${PAGE_MISS_TITLE[reason]}: ${citation.text}` : citation.text;
     return (
-      <span title={citation.text} className={`${BADGE_CLASS} bg-gray-100 text-gray-500`}>
+      <span title={title} className={`${BADGE_CLASS} bg-gray-100 text-gray-500`}>
         [{citation.id}]
       </span>
     );

--- a/src/front/hooks/useReadingLocation.test.tsx
+++ b/src/front/hooks/useReadingLocation.test.tsx
@@ -9,21 +9,24 @@ import { SwrTestCache } from "../../test/swrTestCache";
 
 const PDF_ID = "01JBOOK";
 
+/** The answer for a passage the book does not hold. */
+const MISSING = { found: false, miss: "not-in-book" } as const;
+
 /** Exposes the URL the hook drives and a way to turn pages like the viewer does. */
 function useHarness(locatePassage: LocatePassage, linkedPassage: string | null, visited: string[]) {
-  const { passageNotFound } = useReadingLocation(PDF_ID, locatePassage, linkedPassage);
+  const { passageMiss } = useReadingLocation(PDF_ID, locatePassage, linkedPassage);
 
   const { search } = useLocation();
   if (visited[visited.length - 1] !== search) visited.push(search);
 
-  return { search, passageNotFound, setCurrentPage: useSetAtom(currentPageAtom) };
+  return { search, passageMiss, setCurrentPage: useSetAtom(currentPageAtom) };
 }
 
 function renderAt(
   url: string,
   options: { locatePassage?: LocatePassage; linkedPassage?: string | null } = {},
 ) {
-  const { locatePassage = async () => null, linkedPassage = null } = options;
+  const { locatePassage = async () => MISSING, linkedPassage = null } = options;
   const store = createStore();
   // Every distinct URL the hook drives, in order, so tests can tell "landed on
   // page 20" apart from "bounced through page 1 first"
@@ -71,7 +74,8 @@ describe("useReadingLocation", () => {
   it("opens the page holding the passage of a browser text-fragment link", async () => {
     const { store } = renderAt(`/books/${PDF_ID}`, {
       linkedPassage: "エッジは速い",
-      locatePassage: async (_pdfId, passage) => (passage === "エッジは速い" ? 88 : null),
+      locatePassage: async (_pdfId, passage) =>
+        passage === "エッジは速い" ? { found: true, pageNumber: 88 } : MISSING,
     });
 
     await waitFor(() => expect(store.get(currentPageAtom)).toBe(88));
@@ -82,7 +86,7 @@ describe("useReadingLocation", () => {
     // is only where the sender happened to be
     const { store } = renderAt(`/books/${PDF_ID}?page=5`, {
       linkedPassage: "エッジは速い",
-      locatePassage: async () => 88,
+      locatePassage: async () => ({ found: true, pageNumber: 88 }),
     });
 
     await waitFor(() => expect(store.get(currentPageAtom)).toBe(88));
@@ -91,17 +95,17 @@ describe("useReadingLocation", () => {
   it("stays on the first page when the linked passage is not found in the book", async () => {
     const { store, view } = renderAt(`/books/${PDF_ID}`, {
       linkedPassage: "missing",
-      locatePassage: async () => null,
+      locatePassage: async () => MISSING,
     });
 
-    await waitFor(() => expect(view.result.current.passageNotFound).toBe(true));
+    await waitFor(() => expect(view.result.current.passageMiss).toBe("not-in-book"));
     expect(view.result.current.search).toBe("?page=1");
     expect(store.get(currentPageAtom)).toBe(1);
   });
 
-  it("reports a lookup that failed the same way as one that found nothing", async () => {
-    // Both leave the reader on page 1 with no idea why the link did not take
-    // them to the passage it named.
+  it("tells a lookup that never answered apart from one that searched and found nothing", async () => {
+    // Both leave the reader on page 1, but only one of them says anything
+    // about whether the quote is the book's own words.
     const { view } = renderAt(`/books/${PDF_ID}`, {
       linkedPassage: "エッジは速い",
       locatePassage: async () => {
@@ -109,7 +113,16 @@ describe("useReadingLocation", () => {
       },
     });
 
-    await waitFor(() => expect(view.result.current.passageNotFound).toBe(true));
+    await waitFor(() => expect(view.result.current.passageMiss).toBe("lookup-failed"));
+  });
+
+  it("passes on a book of one page as its own reason rather than a missing passage", async () => {
+    const { view } = renderAt(`/books/${PDF_ID}`, {
+      linkedPassage: "エッジは速い",
+      locatePassage: async () => ({ found: false, miss: "single-page-book" }) as const,
+    });
+
+    await waitFor(() => expect(view.result.current.passageMiss).toBe("single-page-book"));
   });
 
   it("keeps quiet while the lookup is still running", async () => {
@@ -118,13 +131,13 @@ describe("useReadingLocation", () => {
       locatePassage: () => new Promise(() => {}),
     });
 
-    expect(view.result.current.passageNotFound).toBe(false);
+    expect(view.result.current.passageMiss).toBeNull();
   });
 
   it("keeps quiet for a page opened without a linked passage at all", async () => {
     const { view } = renderAt(`/books/${PDF_ID}?page=42`);
 
     await waitFor(() => expect(view.result.current.search).toBe("?page=42"));
-    expect(view.result.current.passageNotFound).toBe(false);
+    expect(view.result.current.passageMiss).toBeNull();
   });
 });

--- a/src/front/hooks/useReadingLocation.ts
+++ b/src/front/hooks/useReadingLocation.ts
@@ -4,11 +4,27 @@ import { useAtom } from "jotai";
 import { useSearchParams } from "react-router";
 import useSWRImmutable from "swr/immutable";
 import { currentPageAtom } from "../atoms/pdfAtom";
+import type { LocatedPage, PageMiss } from "../../shared/schemas/book";
 
-/** Resolves a quoted passage to the page it appears on, or null if absent. */
-export type LocatePassage = (pdfId: string, passage: string) => Promise<number | null>;
+/** Resolves a quoted passage to the page it appears on, or why it has none. */
+export type LocatePassage = (pdfId: string, passage: string) => Promise<LocatedPage>;
+
+/** What the reader is told when a link named a passage the book will not open at. */
+export type PassageMiss = PageMiss | "lookup-failed";
 
 const PAGE_PARAM = "page";
+
+/** Nothing is missing until a link named a passage and the answer is in. */
+function missOf(
+  linkedPassage: string | null,
+  linkedPage: LocatedPage | undefined,
+  locateError: unknown,
+): PassageMiss | null {
+  if (linkedPassage === null) return null;
+  if (locateError !== undefined) return "lookup-failed";
+  if (linkedPage === undefined || linkedPage.found) return null;
+  return linkedPage.miss;
+}
 
 function parsePage(value: string | null): number | null {
   const page = Number(value);
@@ -26,16 +42,16 @@ function parsePage(value: string | null): number | null {
  * A `#:~:text=` fragment — what Chrome's "Copy link to highlight" writes — wins
  * over `?page=`, since it names the passage the reader actually wants.
  *
- * `passageNotFound` is how a link that named a passage but did not deliver it
- * says so. A book that simply does not contain it and a lookup that failed are
- * the same thing from the reader's chair — the book opens on page 1 with no
- * explanation — so they are reported together.
+ * `passageMiss` is how a link that named a passage but did not deliver it says
+ * so, and which of the reasons it was: the book opens on page 1 either way, and
+ * a quote that is nowhere in the book means something different to the reader
+ * than a book of one page or a lookup that never answered.
  */
 export function useReadingLocation(
   pdfId: string | undefined,
   locatePassage: LocatePassage,
   linkedPassage: string | null,
-): { passageNotFound: boolean } {
+): { passageMiss: PassageMiss | null } {
   const [searchParams, setSearchParams] = useSearchParams();
   const [currentPage, setCurrentPage] = useAtom(currentPageAtom);
 
@@ -90,13 +106,12 @@ export function useReadingLocation(
   );
 
   useEffect(() => {
-    if (linkedPage) setCurrentPage(linkedPage);
+    if (linkedPage?.found) setCurrentPage(linkedPage.pageNumber);
   }, [linkedPage, setCurrentPage]);
 
-  // `undefined` is "still asking" and must not raise this; `null` is the
-  // server's answer that the passage is nowhere in the book.
-  const passageNotFound =
-    linkedPassage !== null && (linkedPage === null || locateError !== undefined);
+  // `undefined` is "still asking" and must not raise this; anything else is the
+  // server's answer, or the lookup itself never getting one.
+  const passageMiss = missOf(linkedPassage, linkedPage, locateError);
 
-  return { passageNotFound };
+  return { passageMiss };
 }

--- a/src/front/pages/AppPage.test.tsx
+++ b/src/front/pages/AppPage.test.tsx
@@ -62,7 +62,9 @@ function readerFetchStub({
   const fetchFn = (url: string) => {
     urls.push(url);
     if (url.includes("/locate?")) {
-      return Promise.resolve(new Response(JSON.stringify({ pageNumber: null }), { status: 200 }));
+      return Promise.resolve(
+        new Response(JSON.stringify({ found: false, miss: "not-in-book" }), { status: 200 }),
+      );
     }
     if (url.endsWith("/chats")) {
       const selectionId = url.split("/selections/")[1].split("/")[0];
@@ -182,7 +184,7 @@ describe("AppPage", () => {
     ).toBeNull();
   });
 
-  it("says a linked passage was not found instead of quietly opening page 1", async () => {
+  it("says a linked passage is not in the book rather than only that it was not found", async () => {
     // The fragment is read off the navigation entry, since the browser strips
     // it from location.hash before scripts can see it.
     vi.spyOn(performance, "getEntriesByType").mockReturnValue([
@@ -193,7 +195,7 @@ describe("AppPage", () => {
     renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A });
 
     expect(
-      await screen.findByText("リンクされた箇所が見つかりませんでした: 存在しない"),
+      await screen.findByText("リンクされた箇所が本文に見つかりませんでした: 存在しない"),
     ).toBeInTheDocument();
   });
 

--- a/src/front/pages/AppPage.test.tsx
+++ b/src/front/pages/AppPage.test.tsx
@@ -6,7 +6,7 @@ import { SWRConfig } from "swr";
 import { AppPage } from "./AppPage";
 import { bookKey } from "../hooks/useBook";
 import { SwrTestCache } from "../../test/swrTestCache";
-import type { BookDetail } from "../../shared/schemas/book";
+import type { BookDetail, LocatedPage } from "../../shared/schemas/book";
 import type { SelectionHighlight } from "../../shared/schemas/selection";
 
 const A_PASSAGE = "エッジはサーバーレス実行基盤で、実行単位をまたいでメモリを共有できません。";
@@ -55,16 +55,30 @@ function readerFetchStub({
   holdTheBook = false,
   /** Id of the one highlight whose conversation the server refuses to hand over. */
   refuseChatHistoryFor,
-}: { holdTheBook?: boolean; refuseChatHistoryFor?: string } = {}) {
+  /** The answer the lookup of a linked passage gets, or a refusal of it. */
+  locate = { found: false, miss: "not-in-book" } as const,
+  refuseLocate = false,
+}: {
+  holdTheBook?: boolean;
+  refuseChatHistoryFor?: string;
+  locate?: LocatedPage;
+  refuseLocate?: boolean;
+} = {}) {
   const urls: string[] = [];
   // Every caller here reaches the network through `fetcher`, which is only
   // ever handed a url string.
   const fetchFn = (url: string) => {
     urls.push(url);
     if (url.includes("/locate?")) {
-      return Promise.resolve(
-        new Response(JSON.stringify({ found: false, miss: "not-in-book" }), { status: 200 }),
-      );
+      if (refuseLocate) {
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({ error: { code: "PDF_NOT_FOUND", message: "PDF not found" } }),
+            { status: 404, headers: { "Content-Type": "application/json" } },
+          ),
+        );
+      }
+      return Promise.resolve(new Response(JSON.stringify(locate), { status: 200 }));
     }
     if (url.endsWith("/chats")) {
       const selectionId = url.split("/selections/")[1].split("/")[0];
@@ -94,10 +108,28 @@ function OpenOtherBook({ pdfId }: { pdfId: string }) {
   );
 }
 
+/**
+ * Opens the book through a `#:~:text=` link naming 「存在しない」. The fragment is
+ * read off the navigation entry, since the browser strips it from location.hash
+ * before scripts can see it.
+ */
+function linkTo(pdfId: string) {
+  vi.spyOn(performance, "getEntriesByType").mockReturnValue([
+    {
+      name: `http://localhost/books/${pdfId}#:~:text=%E5%AD%98%E5%9C%A8%E3%81%97%E3%81%AA%E3%81%84`,
+    },
+  ] as PerformanceEntry[]);
+}
+
 function renderReader(
   pdfId: string,
   seed: Record<string, unknown>,
-  options: { holdTheBook?: boolean; refuseChatHistoryFor?: string } = {},
+  options: {
+    holdTheBook?: boolean;
+    refuseChatHistoryFor?: string;
+    locate?: LocatedPage;
+    refuseLocate?: boolean;
+  } = {},
 ) {
   const { urls, fetchFn } = readerFetchStub(options);
   vi.stubGlobal("fetch", fetchFn);
@@ -185,17 +217,33 @@ describe("AppPage", () => {
   });
 
   it("says a linked passage is not in the book rather than only that it was not found", async () => {
-    // The fragment is read off the navigation entry, since the browser strips
-    // it from location.hash before scripts can see it.
-    vi.spyOn(performance, "getEntriesByType").mockReturnValue([
-      {
-        name: `http://localhost/books/${BOOK_A.id}#:~:text=%E5%AD%98%E5%9C%A8%E3%81%97%E3%81%AA%E3%81%84`,
-      },
-    ] as PerformanceEntry[]);
+    linkTo(BOOK_A.id);
     renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A });
 
     expect(
       await screen.findByText("リンクされた箇所が本文に見つかりませんでした: 存在しない"),
+    ).toBeInTheDocument();
+  });
+
+  it("says a book of one page has nowhere to jump to rather than blaming the passage", async () => {
+    linkTo(BOOK_A.id);
+    renderReader(
+      BOOK_A.id,
+      { [bookKey(BOOK_A.id)]: BOOK_A },
+      { locate: { found: false, miss: "single-page-book" } },
+    );
+
+    expect(
+      await screen.findByText("この本は1ページなので移動先がありません: 存在しない"),
+    ).toBeInTheDocument();
+  });
+
+  it("says the lookup itself did not answer rather than that the book lacks the passage", async () => {
+    linkTo(BOOK_A.id);
+    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A }, { refuseLocate: true });
+
+    expect(
+      await screen.findByText("リンクされた箇所を探せませんでした: 存在しない"),
     ).toBeInTheDocument();
   });
 

--- a/src/front/pages/AppPage.tsx
+++ b/src/front/pages/AppPage.tsx
@@ -13,20 +13,28 @@ import { PdfViewer } from "../components/PdfViewer/PdfViewer";
 import { ChatArea } from "../components/ChatArea/ChatArea";
 import { SettingsMenu } from "../components/SettingsMenu";
 import { useBook } from "../hooks/useBook";
-import { useReadingLocation } from "../hooks/useReadingLocation";
+import { useReadingLocation, type PassageMiss } from "../hooks/useReadingLocation";
 import { passageFromNavigation } from "../lib/textFragment";
 import { fetcher, resultFetcher } from "../lib/fetcher";
-import { locatedPageSchema } from "../../shared/schemas/book";
+import { locatedPageSchema, type LocatedPage } from "../../shared/schemas/book";
 import { chatHistorySchema } from "../../shared/schemas/chat";
 
 /** Asks the server which page a passage from a `#:~:text=` link is on. */
-async function locatePassage(pdfId: string, passage: string): Promise<number | null> {
-  const { pageNumber } = await fetcher(
-    `/api/pdf/${pdfId}/locate?text=${encodeURIComponent(passage)}`,
-    locatedPageSchema,
-  );
-  return pageNumber;
+async function locatePassage(pdfId: string, passage: string): Promise<LocatedPage> {
+  return fetcher(`/api/pdf/${pdfId}/locate?text=${encodeURIComponent(passage)}`, locatedPageSchema);
 }
+
+/**
+ * What to tell a reader whose link named a passage the book did not open at.
+ * "Not found" alone reads as a broken link; each of these is a different thing
+ * to do next, and one of them means the quote may not be the book's words.
+ */
+const PASSAGE_MISS_MESSAGE: Record<PassageMiss, string> = {
+  "not-in-book": "リンクされた箇所が本文に見つかりませんでした",
+  "no-quote": "リンクに引用文が入っていません",
+  "single-page-book": "この本は1ページなので移動先がありません",
+  "lookup-failed": "リンクされた箇所を探せませんでした",
+};
 
 /**
  * The reader, with a store of its own per book.
@@ -62,7 +70,7 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
     () => passageFromNavigation(performance.getEntriesByType("navigation")),
     [],
   );
-  const { passageNotFound } = useReadingLocation(pdfId, locatePassage, linkedPassage);
+  const { passageMiss } = useReadingLocation(pdfId, locatePassage, linkedPassage);
 
   // Load chat history when selection changes
   const handleSelectionClick = useCallback(
@@ -113,9 +121,9 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
 
       {/* A link that named a passage but did not land on it opens the book at
           page 1, which is indistinguishable from an ordinary link. */}
-      {passageNotFound && linkedPassage !== null && (
+      {passageMiss !== null && (
         <p role="status" className="shrink-0 bg-amber-50 px-4 py-2 text-sm text-amber-800">
-          リンクされた箇所が見つかりませんでした: {linkedPassage}
+          {PASSAGE_MISS_MESSAGE[passageMiss]}: {linkedPassage}
         </p>
       )}
 

--- a/src/server/routes/pdf.ts
+++ b/src/server/routes/pdf.ts
@@ -328,7 +328,7 @@ export function createPdfRoute(idClock: IdClock = systemIdClock) {
           );
         }
 
-        return c.json({ pageNumber: findPageNumber(text, pdf.fullText, pdf.pageCount) ?? null });
+        return c.json(findPageNumber(text, pdf.fullText, pdf.pageCount));
       })
       .get("/pdf/:pdfId", async (c) => {
         const book = await getPdf(c.env.DB, c.env.PDF_BUCKET, c.req.param("pdfId"));

--- a/src/server/services/chatService.test.ts
+++ b/src/server/services/chatService.test.ts
@@ -93,12 +93,19 @@ describe("parseCitations", () => {
     ]);
   });
 
-  it("leaves the page unresolved when the quoted passage is not in the document", () => {
+  it("says a quoted passage is not in the document rather than leaving the page blank", () => {
+    // A quote the book does not hold is the reader's only hint that the model
+    // reworded it, so the citation carries the reason instead of just no page.
     const fullText = fullTextOf("まえがき", "第1章 Cloudflare Workers とは");
     const response = `本文[1]\n\n## Sources\n[1] 「この文は本文に存在しません」`;
 
     expect(parseCitations(response, fullText, 2)).toStrictEqual([
-      { id: "1", type: "pdf", text: "この文は本文に存在しません", pageNumber: undefined },
+      {
+        id: "1",
+        type: "pdf",
+        text: "この文は本文に存在しません",
+        pageMiss: "not-in-book",
+      },
     ]);
   });
 

--- a/src/server/services/chatService.test.ts
+++ b/src/server/services/chatService.test.ts
@@ -16,14 +16,26 @@ describe("findPageNumber", () => {
     });
   });
 
-  it("tells a passage the book does not contain apart from a quote with no text", () => {
+  it("reports a passage the book does not contain as one it does not hold", () => {
     const fullText = fullTextOf("まえがき", "エッジ で 動く");
 
     expect(findPageNumber("この本にない一文", fullText, 2)).toStrictEqual({
       found: false,
       miss: "not-in-book",
     });
+  });
+
+  it("reports a quote that is only whitespace as having no text to look up", () => {
+    const fullText = fullTextOf("まえがき", "エッジ で 動く");
+
     expect(findPageNumber("  \n ", fullText, 2)).toStrictEqual({
+      found: false,
+      miss: "no-quote",
+    });
+  });
+
+  it("blames the empty quote rather than the page count when a one-page book gets one", () => {
+    expect(findPageNumber("  ", "エッジ で 動く", 1)).toStrictEqual({
       found: false,
       miss: "no-quote",
     });
@@ -36,16 +48,19 @@ describe("findPageNumber", () => {
     });
   });
 
-  it("tells a passage missing from an undelimited book apart from one it holds", () => {
-    // Books stored before the extractor delimited pages are searched by ratio,
-    // so the passage has to sit in the second half to land on page 2
-    const undelimited = "まえがき の ながい はじめに エッジ で 動く";
+  // Books stored before the extractor delimited pages are searched by ratio, so
+  // the passage has to sit in the second half to land on page 2
+  const UNDELIMITED = "まえがき の ながい はじめに エッジ で 動く";
 
-    expect(findPageNumber("エッジで動く", undelimited, 2)).toStrictEqual({
+  it("estimates the page of a passage an undelimited book holds", () => {
+    expect(findPageNumber("エッジで動く", UNDELIMITED, 2)).toStrictEqual({
       found: true,
       pageNumber: 2,
     });
-    expect(findPageNumber("この本にない一文", undelimited, 2)).toStrictEqual({
+  });
+
+  it("reports a passage an undelimited book does not hold as one it does not hold", () => {
+    expect(findPageNumber("この本にない一文", UNDELIMITED, 2)).toStrictEqual({
       found: false,
       miss: "not-in-book",
     });
@@ -131,6 +146,12 @@ describe("parseCitations", () => {
     expect(parseCitations(response, fullText, 3)).toStrictEqual([
       { id: "1", type: "pdf", text: "目的の文", pageNumber: 2 },
     ]);
+  });
+
+  it("gives a citation neither a page nor a reason when the book has no text to search", () => {
+    const response = `本文[1]\n\n## Sources\n[1] 「引用」`;
+
+    expect(parseCitations(response)).toStrictEqual([{ id: "1", type: "pdf", text: "引用" }]);
   });
 
   it("returns no citations when the answer has no Sources section", () => {

--- a/src/server/services/chatService.test.ts
+++ b/src/server/services/chatService.test.ts
@@ -1,10 +1,56 @@
 import { describe, it, expect } from "vite-plus/test";
-import { parseCitations } from "./chatService";
+import { parseCitations, findPageNumber } from "./chatService";
 
 /** pdfLoader が作る fullText と同じ形 (ページ区切りは \f) */
 function fullTextOf(...pages: string[]): string {
   return pages.join("\f");
 }
+
+describe("findPageNumber", () => {
+  it("reports the page a quoted passage was found on", () => {
+    const fullText = fullTextOf("まえがき", "エッジ で 動く");
+
+    expect(findPageNumber("エッジで動く", fullText, 2)).toStrictEqual({
+      found: true,
+      pageNumber: 2,
+    });
+  });
+
+  it("tells a passage the book does not contain apart from a quote with no text", () => {
+    const fullText = fullTextOf("まえがき", "エッジ で 動く");
+
+    expect(findPageNumber("この本にない一文", fullText, 2)).toStrictEqual({
+      found: false,
+      miss: "not-in-book",
+    });
+    expect(findPageNumber("  \n ", fullText, 2)).toStrictEqual({
+      found: false,
+      miss: "no-quote",
+    });
+  });
+
+  it("says a book of one page has nowhere to jump to", () => {
+    expect(findPageNumber("エッジで動く", "エッジ で 動く", 1)).toStrictEqual({
+      found: false,
+      miss: "single-page-book",
+    });
+  });
+
+  it("tells a passage missing from an undelimited book apart from one it holds", () => {
+    // Books stored before the extractor delimited pages are searched by ratio,
+    // so the passage has to sit in the second half to land on page 2
+    const undelimited = "まえがき の ながい はじめに エッジ で 動く";
+
+    expect(findPageNumber("エッジで動く", undelimited, 2)).toStrictEqual({
+      found: true,
+      pageNumber: 2,
+    });
+    expect(findPageNumber("この本にない一文", undelimited, 2)).toStrictEqual({
+      found: false,
+      miss: "not-in-book",
+    });
+  });
+});
 
 describe("parseCitations", () => {
   it("resolves the page of a Japanese-quoted pdf citation to the page holding the passage", () => {

--- a/src/server/services/chatService.ts
+++ b/src/server/services/chatService.ts
@@ -165,7 +165,9 @@ export function parseCitations(
         id,
         type: "pdf",
         text: quotedText,
-        pageNumber: located?.found ? located.pageNumber : undefined,
+        // One of the two, never both, and neither when there was no book text
+        ...(located?.found === true ? { pageNumber: located.pageNumber } : {}),
+        ...(located?.found === false ? { pageMiss: located.miss } : {}),
       });
     }
   }

--- a/src/server/services/chatService.ts
+++ b/src/server/services/chatService.ts
@@ -1,4 +1,5 @@
 import { citationSchema, type Citation } from "../../shared/schemas/citation";
+import type { LocatedPage } from "../../shared/schemas/book";
 
 export type { Citation } from "../../shared/schemas/citation";
 
@@ -75,39 +76,38 @@ function pageContaining(normalizedPages: string[], needle: string): number {
  * whole-quote match falls back to fragments of it. Falls back further to a
  * position ratio for records stored before the extractor delimited pages.
  */
-export function findPageNumber(
-  text: string,
-  fullText: string,
-  pageCount: number,
-): number | undefined {
+export function findPageNumber(text: string, fullText: string, pageCount: number): LocatedPage {
   const needle = normalize(text);
-  if (pageCount <= 1 || !needle) return undefined;
+  if (!needle) return { found: false, miss: "no-quote" };
+  if (pageCount <= 1) return { found: false, miss: "single-page-book" };
 
   const pages = fullText.split(PAGE_DELIMITER);
   if (pages.length <= 1) {
     const idx = normalize(fullText).indexOf(needle);
-    if (idx < 0) return undefined;
+    if (idx < 0) return { found: false, miss: "not-in-book" };
     const pageSize = normalize(fullText).length / pageCount;
-    return Math.min(pageCount, Math.floor(idx / pageSize) + 1);
+    return { found: true, pageNumber: Math.min(pageCount, Math.floor(idx / pageSize) + 1) };
   }
 
   const normalizedPages = pages.map(normalize);
   const onOnePage = pageContaining(normalizedPages, needle);
-  if (onOnePage >= 0) return onOnePage + 1;
+  if (onOnePage >= 0) return { found: true, pageNumber: onOnePage + 1 };
 
   // A quote can start near the bottom of a page and finish on the next one
   for (let i = 0; i < normalizedPages.length - 1; i++) {
-    if ((normalizedPages[i] + normalizedPages[i + 1]).includes(needle)) return i + 1;
+    if ((normalizedPages[i] + normalizedPages[i + 1]).includes(needle)) {
+      return { found: true, pageNumber: i + 1 };
+    }
   }
 
   // Scan fragments from the start of the quote, so the first hit is the page
   // the passage begins on
   for (let start = 0; start + FRAGMENT_LENGTH <= needle.length; start += FRAGMENT_STEP) {
     const page = pageContaining(normalizedPages, needle.slice(start, start + FRAGMENT_LENGTH));
-    if (page >= 0) return page + 1;
+    if (page >= 0) return { found: true, pageNumber: page + 1 };
   }
 
-  return undefined;
+  return { found: false, miss: "not-in-book" };
 }
 
 /**
@@ -158,14 +158,14 @@ export function parseCitations(
     } else {
       // PDF citation - extract quoted text and find page number
       const quotedText = extractQuotedText(content);
-      const pageNumber =
+      const located =
         fullText && pageCount ? findPageNumber(quotedText, fullText, pageCount) : undefined;
 
       citations.push({
         id,
         type: "pdf",
         text: quotedText,
-        pageNumber,
+        pageNumber: located?.found ? located.pageNumber : undefined,
       });
     }
   }

--- a/src/shared/schemas/book.ts
+++ b/src/shared/schemas/book.ts
@@ -46,10 +46,22 @@ export const locateQuerySchema = z.object({
   text: z.string().min(1).max(MAX_LOCATE_TEXT_LENGTH),
 });
 
-/** Where a passage quoted from a `#:~:text=` link lives, or null if nowhere. */
-export const locatedPageSchema = z.object({
-  pageNumber: z.number().int().positive().nullable(),
-});
+/**
+ * Why a quoted passage has no page. Each one is a different thing to tell the
+ * reader: a quote that is nowhere in the book is a sign the model reworded it,
+ * while a book of one page simply has nowhere to jump to.
+ */
+export const pageMissSchema = z.enum(["no-quote", "not-in-book", "single-page-book"]);
+
+export type PageMiss = z.infer<typeof pageMissSchema>;
+
+/** Where a passage quoted from a `#:~:text=` link lives, or why it has no page. */
+export const locatedPageSchema = z.discriminatedUnion("found", [
+  z.object({ found: z.literal(true), pageNumber: z.number().int().positive() }),
+  z.object({ found: z.literal(false), miss: pageMissSchema }),
+]);
+
+export type LocatedPage = z.infer<typeof locatedPageSchema>;
 
 export const bookDeletedSchema = z.object({ deleted: z.literal(true) });
 

--- a/src/shared/schemas/citation.ts
+++ b/src/shared/schemas/citation.ts
@@ -1,14 +1,21 @@
 import { z } from "zod";
+import { pageMissSchema } from "./book";
 
 /**
  * A source the assistant named in its `## Sources` section. PDF citations carry
  * the page the passage was found on; web citations carry the page's URL.
+ *
+ * `pageNumber` and `pageMiss` are the two halves of one answer and never both
+ * appear, but they are kept as optional fields rather than a union because
+ * citations are stored as JSON and the rows written before `pageMiss` existed
+ * still have to parse.
  */
 export const citationSchema = z.object({
   id: z.string(),
   type: z.enum(["pdf", "web"]),
   text: z.string(),
   pageNumber: z.number().int().positive().optional(),
+  pageMiss: pageMissSchema.optional(),
   url: z.string().optional(),
 });
 

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -540,7 +540,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ pageNumber: 3 });
+    expect(await response.json()).toStrictEqual({ found: true, pageNumber: 3 });
   });
 
   it("reports no page when the passage is not in the book", async () => {
@@ -555,7 +555,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ pageNumber: null });
+    expect(await response.json()).toStrictEqual({ found: false, miss: "not-in-book" });
   });
 
   it("returns 400 when no text is given", async () => {
@@ -582,7 +582,22 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toStrictEqual({ pageNumber: 2 });
+    expect(await response.json()).toStrictEqual({ found: true, pageNumber: 2 });
+  });
+
+  it("says a book of one page has nowhere to jump to rather than calling the passage missing", async () => {
+    const book = await uploadBook({
+      tag: "locate-single",
+      fileName: "locate-single.pdf",
+      pages: ["エッジ で 動く"],
+    });
+
+    const response = await SELF.fetch(
+      `https://example.com/api/pdf/${book.id}/locate?text=${encodeURIComponent("エッジで動く")}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toStrictEqual({ found: false, miss: "single-page-book" });
   });
 
   it("refuses a passage longer than any quotable one instead of scanning the book for it", async () => {

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -619,6 +619,20 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     expect(await response.json()).toStrictEqual({ found: true, pageNumber: 2 });
   });
 
+  it("says a link whose passage is only whitespace carried no quote to look up", async () => {
+    // `min(1)` lets a single space through, and normalising leaves nothing of it
+    const book = await uploadBook({
+      tag: "locate-blank",
+      fileName: "locate-blank.pdf",
+      pages: ["まえがき", "エッジ で 動く"],
+    });
+
+    const response = await SELF.fetch(`https://example.com/api/pdf/${book.id}/locate?text=%20`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toStrictEqual({ found: false, miss: "no-quote" });
+  });
+
   it("says a book of one page has nowhere to jump to rather than calling the passage missing", async () => {
     const book = await uploadBook({
       tag: "locate-single",

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -627,7 +627,9 @@ describe("GET /api/pdf/:pdfId/locate", () => {
       pages: ["まえがき", "エッジ で 動く"],
     });
 
-    const response = await SELF.fetch(`https://example.com/api/pdf/${book.id}/locate?text=%20`);
+    const response = await exports.default.fetch(
+      `https://example.com/api/pdf/${book.id}/locate?text=%20`,
+    );
 
     expect(response.status).toBe(200);
     expect(await response.json()).toStrictEqual({ found: false, miss: "no-quote" });
@@ -640,7 +642,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
       pages: ["エッジ で 動く"],
     });
 
-    const response = await SELF.fetch(
+    const response = await exports.default.fetch(
       `https://example.com/api/pdf/${book.id}/locate?text=${encodeURIComponent("エッジで動く")}`,
     );
 

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -574,7 +574,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ pageNumber: 3 });
+    expect(await response.json()).toStrictEqual({ found: true, pageNumber: 3 });
   });
 
   it("reports no page when the passage is not in the book", async () => {
@@ -589,7 +589,7 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual({ pageNumber: null });
+    expect(await response.json()).toStrictEqual({ found: false, miss: "not-in-book" });
   });
 
   it("returns 400 when no text is given", async () => {
@@ -616,7 +616,22 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.json()).toStrictEqual({ pageNumber: 2 });
+    expect(await response.json()).toStrictEqual({ found: true, pageNumber: 2 });
+  });
+
+  it("says a book of one page has nowhere to jump to rather than calling the passage missing", async () => {
+    const book = await uploadBook({
+      tag: "locate-single",
+      fileName: "locate-single.pdf",
+      pages: ["エッジ で 動く"],
+    });
+
+    const response = await SELF.fetch(
+      `https://example.com/api/pdf/${book.id}/locate?text=${encodeURIComponent("エッジで動く")}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toStrictEqual({ found: false, miss: "single-page-book" });
   });
 
   it("refuses a passage longer than any quotable one instead of scanning the book for it", async () => {

--- a/test/worker/pdf.test.ts
+++ b/test/worker/pdf.test.ts
@@ -585,6 +585,20 @@ describe("GET /api/pdf/:pdfId/locate", () => {
     expect(await response.json()).toStrictEqual({ found: true, pageNumber: 2 });
   });
 
+  it("says a link whose passage is only whitespace carried no quote to look up", async () => {
+    // `min(1)` lets a single space through, and normalising leaves nothing of it
+    const book = await uploadBook({
+      tag: "locate-blank",
+      fileName: "locate-blank.pdf",
+      pages: ["まえがき", "エッジ で 動く"],
+    });
+
+    const response = await SELF.fetch(`https://example.com/api/pdf/${book.id}/locate?text=%20`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toStrictEqual({ found: false, miss: "no-quote" });
+  });
+
   it("says a book of one page has nowhere to jump to rather than calling the passage missing", async () => {
     const book = await uploadBook({
       tag: "locate-single",


### PR DESCRIPTION
## 概要

`findPageNumber` は「ページが見つからない」3 通りをすべて `undefined` に潰していたため、読者からは「引用が飛べるときと飛べないときがある」としか見えず、原因が区別できなかった (issue #8 の対応内容 4。完了条件の対象外だったため未着手だったもの)。

理由を型で分け、**2 つの消費者から読者に届く**ようにした。

| 理由 | いつ起きるか | 読者に何が見えるか |
| --- | --- | --- |
| `not-in-book` | 引用文を本文中に見つけられない | 「本文に一致する箇所が見つかりませんでした（引用が本文どおりでない可能性があります）」 |
| `no-quote` | 引用文が空 (空白のみを含む) | 「出典に引用文が入っていません」 |
| `single-page-book` | 本が 1 ページ | 「この本は1ページなので移動先がありません」 |

`#:~:text=` リンクの経路では、上の 3 つに加えて lookup 自体が失敗した `lookup-failed` (「リンクされた箇所を探せませんでした」) を区別する。

**とくに `not-in-book` は、AI が引用を本文どおりに書かなかった可能性を読者が知る唯一の手がかり**になる。これまでは他の理由と一緒くたに「ページの付かないバッジ」になっていた。

## 変更

- `findPageNumber` の戻り値を `LocatedPage` (`{found: true, pageNumber}` / `{found: false, miss}`) に
- `GET /pdf/:pdfId/locate` がそれをそのまま返す (**ワイヤ形式が変わる**。ローカル専用でフロントとサーバが同時に出るため互換の必要なし)
- `useReadingLocation` が `passageNotFound: boolean` → `passageMiss: PassageMiss | null`
- `parseCitations` が見つからないとき `pageMiss` を引用に載せ、`CitationBadge` が title にする

`pageMiss` は discriminated union ではなく**任意フィールド**にした。引用は JSON で保存されるため、この列を持たない既存の行が読めなくなるのを避けている (`pageNumber` と同時には出ない)。

## テスト

jsdom **199 → 213** (+14)、worker **43 → 45** (+2)、E2E 21 pass。

各段階で先に失敗を観測してから実装した。途中、比率計算のテストで**期待値のほうが誤っていた**ケースがあり (未区切りの本ではページ 1 が正解)、実装ではなくテストを直している。

**レビューで穴が 4 件見つかり、埋めた。** 理由ごとの文言を書き換えても検出できない箇所があり、区別を入れたこと自体がこの変更の目的なので、写像が壊れたら落ちるところまで固定した。埋めたあとに文言を壊して実際に落ちることも確認している:

| 変異 | 落ちるテスト |
| --- | --- |
| バナーの `single-page-book` / `lookup-failed` を書き換え | 2 件 |
| バッジの `no-quote` を書き換え | 1 件 |

併せて、1 つのテストに 2 つの振る舞いを詰めていた 2 件を分割し、本文を持たない本での引用 (どちらのキーも生えない) と、空引用が 1 ページの本に来たときの理由の優先順位も固定した。

| ゲート | 結果 |
| --- | --- |
| `vp check` | pass |
| `pnpm test` (jsdom) | 213 passed |
| `pnpm run test:worker` | 45 passed |
| `pnpm run test:e2e` | 21 passed |
| `vp build` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)