### PR TITLE
✨ feat: 右パネルの開閉と開いているチャットを URL に持たせる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,11 +71,14 @@ echo 'DEEPSEEK_API_KEY=dummy' > .dev.vars
 2 箇所に載り、更新のたびに 1 レンダー遅れる。読み手が少ないなら props で配る
 （`AppPage` → `PdfViewer` / `ChatArea` の `book` がその形）。
 
-これと紛らわしいものが 1 つだけある。`useReadingLocation.ts` は
-`useSWRImmutable` が解いた「引用箇所のページ番号」を `currentPageAtom` に書く。これは
-写しではない: `currentPageAtom` は「読者が今どのページにいるか」というクライアント状態で、
-キーボード・ページ送りボタン・目次・URL も書き込む。取得結果はその状態を**一度だけ動かす
-きっかけ**であって、サーバのデータを atom に常駐させているわけではない。
+これと紛らわしいものが 2 つある。どちらも `useReadingLocation.ts` で、SWR が解いた値を
+atom に一度だけ書く——`useSWRImmutable` が解いた「引用箇所のページ番号」を
+`currentPageAtom` に、`useBook` が返した本の中から URL の `?selection=` が名指した
+ハイライトを `activeSelectionAtom` に（`openChat` 経由。下記「リーダーの URL は
+`useReadingLocation` が単独で書く」）。これは写しではない: どちらの atom も「読者が今どこを
+見ているか」というクライアント状態で、キーボード・ページ送りボタン・目次・URL・一覧の
+クリックも書き込む。取得結果はその状態を**一度だけ動かすきっかけ**であって、サーバのデータを
+atom に常駐させているわけではない。
 **サーバの値がそのまま atom に載り続けるなら写し（禁止）、一度きりの入力なら可**。
 
 ## アーキテクチャ
@@ -185,7 +188,7 @@ union + `satisfies` で固定する。
 | 目次の取得                        | `usePdfOutline` の `error`                            | 目次パネル                                 |
 | ハイライトの保存                  | `useAskAboutSelection` の `saveError`                 | ビューア上部（ポップオーバーは開いたまま） |
 | チャットの送信・履歴の取得        | `chatErrorAtom`                                       | チャットパネル                             |
-| リンク先の passage が見つからない | `useReadingLocation` の `passageNotFound`             | ヘッダ直下の帯                             |
+| リンク先の passage が見つからない | `useReadingLocation` の `passageMiss`                 | ヘッダ直下の帯                             |
 
 `chatErrorAtom` だけ二重の口がある。**atom が表示の正、`sendMessage` の戻り値
 （`ResultAsync<string, ApiError>`。成功時の値は保存された回答の id）は呼び出し元の
@@ -324,8 +327,36 @@ PDF 引用は `fullText` 内の位置からページ番号を割り出してジ�
   渡す（atom に写さない。読み手はこの 2 つだけなので prop drilling にならない）
 - どちらのルートにも `errorElement` が付く（上記「失敗の運び方（neverthrow）」）
 
+#### リーダーの URL は `useReadingLocation` が単独で書く
+
+リロードと共有リンクで同じ状態に戻るよう、リーダーの状態は 3 つのクエリパラメータに
+載っている。**書き手は `src/front/hooks/useReadingLocation.ts` 1 つだけ**で、これを
+分けてはいけない——`setSearchParams` は同一 commit 内でマージされないので、書き手が 2 つ
+あるとハイライトを選んだとき（`page` と `selection` が同時に動く）に片方が黙って消える。
+
+| パラメータ  | 値                             | 反映先 atom           | 省略時の扱い                                       |
+| ----------- | ------------------------------ | --------------------- | -------------------------------------------------- |
+| `page`      | 1 以上の整数（例: `5`）        | `currentPageAtom`     | 1。既定値でも `?page=1` と書き出す                 |
+| `panel`     | `open` / `closed`              | `chatPanelOpenAtom`   | `open`。既定値でも `?panel=open` と書き出す        |
+| `selection` | ハイライトの ID（例: `01KZ…`） | `activeSelectionAtom` | チャットを開いていない（ハイライト一覧）ことを表す |
+
+`page` / `panel` は既定値も明示するが、`selection` の「無い」は省略で表す（null を綴る
+自然な形が無いため）。Chrome の「ハイライトへのリンクをコピー」が書く `#:~:text=`
+フラグメント（`src/front/lib/textFragment.ts` が解析する）は `?page=` より優先する——
+送り手がたまたま開いていたページより、名指しされた引用文の方が読者の目的に近いため。
+
+`selection` の復元だけは**本（`useBook` の SWR）の到着を待つ**。ハイライトは本から読むため。
+待っている間は URL の値を温存し（`pendingSelectionId`）、その間のページ送りで空の atom から
+`?selection=` を消してしまわないようにしている。本から消えたハイライトを指す URL は一覧を
+表示し、パラメータ自体を落とす。
+
+**復元では現在ページを動かさない**（URL の `page` が正）。一覧から選んだときだけその
+ハイライトのページへ移るので、`setCurrentPage` は `AppPage` の `handleSelectionClick` に
+あり、復元と共用する `openChat` には入れない。**ここを `openChat` に戻すと、途中まで
+読んで再訪したときにハイライトのページへ引き戻される。**
+
 **チャットだけは SWR に載っていない**。`chatMessagesAtom` が持ち、履歴の読み込みは
-`AppPage` の `handleSelectionClick` が `resultFetcher` を直接呼ぶ。理由は、同じ状態を SSE の
+`AppPage` の `openChat` が `resultFetcher` を直接呼ぶ。理由は、同じ状態を SSE の
 ストリームがトークンごとに書き換えるため（`useChatStream`）——キャッシュに載せると
 再検証が流れてきた回答を上書きしうる。**「データ取得はすべて SWR」ではない**。
 イベントハンドラ起点の 1 回きりの取得（履歴・選択の作成・アップロード）は SWR を通さず

--- a/e2e/chatbook.spec.ts
+++ b/e2e/chatbook.spec.ts
@@ -109,8 +109,9 @@ test("adding a PDF from the shelf opens the reader and renders its pages", async
   await page.goto("/");
   await page.setInputFiles('input[type="file"]', pdfPath);
 
-  // Uploading navigates into the reader for that book, on its first page
-  await expect(page).toHaveURL(/\/books\/[A-Z0-9]+\?page=1$/, { timeout: 60000 });
+  // Uploading navigates into the reader for that book, on its first page, with
+  // the chat panel showing
+  await expect(page).toHaveURL(/\/books\/[A-Z0-9]+\?page=1&panel=open$/, { timeout: 60000 });
 
   // The viewer shows the real page count from client-side extraction
   await expect(page.getByText("1 / 209", { exact: true })).toBeVisible({ timeout: 60000 });
@@ -684,6 +685,51 @@ test("the chat panel lists the highlights, opens one, and comes back to the list
   await chatPanel.getByRole("button", { name: "一覧に戻る" }).click();
   await expect(chatPanel.getByText("ハイライト 2件")).toBeVisible();
   await expect(chatPanel.getByPlaceholder("質問を入力...")).toBeHidden();
+});
+
+test("reloading brings back the folded panel and the chat that was open in it", async ({
+  page,
+}) => {
+  if (!fs.existsSync(TEST_PDF)) {
+    test.skip(true, "Test PDF not found");
+    return;
+  }
+
+  const pdfId = await openTestBook(page);
+  const passage = "はじめてのWorkers";
+  await page.request.post(`/api/pdf/${pdfId}/selections`, {
+    data: {
+      selectedText: passage,
+      pageNumber: 1,
+      positionData: {
+        startIndex: 0,
+        endIndex: passage.length,
+        rects: [{ x: 40, y: 40, width: 160, height: 24 }],
+      },
+    },
+  });
+  await page.reload();
+
+  // Scope to the panel: the passage can also appear in the page's text layer
+  const chatPanel = page.locator("main > div").last();
+  await chatPanel.getByText(passage, { exact: true }).click({ timeout: 60000 });
+  await expect(chatPanel.getByPlaceholder("質問を入力...")).toBeVisible();
+
+  await page.getByRole("button", { name: "チャットを隠す" }).click();
+  await expect(page.getByPlaceholder("質問を入力...")).toBeHidden();
+  await expect(page).toHaveURL(/\?page=1&panel=closed&selection=[A-Z0-9]+$/);
+
+  await page.reload();
+
+  // Still folded, with the conversation waiting behind it rather than the list
+  await expect(page.getByRole("button", { name: "チャットを表示" })).toBeVisible({
+    timeout: 60000,
+  });
+  await expect(page.getByPlaceholder("質問を入力...")).toBeHidden();
+
+  await page.getByRole("button", { name: "チャットを表示" }).click();
+  await expect(page.getByPlaceholder("質問を入力...")).toBeVisible();
+  await expect(page.getByRole("button", { name: "一覧に戻る" })).toBeVisible();
 });
 
 test("dragging the splitter renders the PDF at the new panel width", async ({ page }) => {

--- a/src/front/atoms/chatAtom.ts
+++ b/src/front/atoms/chatAtom.ts
@@ -9,6 +9,10 @@ export interface ActiveSelection {
 }
 
 export const activeSelectionAtom = atom<ActiveSelection | null>(null);
+
+/** Whether the panel on the right — the highlight list, or a chat — is showing. */
+export const chatPanelOpenAtom = atom<boolean>(true);
+
 export const chatMessagesAtom = atom<ChatMessage[]>([]);
 export const streamingContentAtom = atom<string>("");
 export const isStreamingAtom = atom<boolean>(false);

--- a/src/front/hooks/useReadingLocation.test.tsx
+++ b/src/front/hooks/useReadingLocation.test.tsx
@@ -1,32 +1,83 @@
-import { describe, it, expect } from "vite-plus/test";
+import { describe, it, expect, vi } from "vite-plus/test";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { MemoryRouter, useLocation } from "react-router";
 import { Provider, createStore, useSetAtom } from "jotai";
 import type { ReactNode } from "react";
 import { useReadingLocation, type LocatePassage } from "./useReadingLocation";
 import { currentPageAtom } from "../atoms/pdfAtom";
+import { activeSelectionAtom, chatPanelOpenAtom, type ActiveSelection } from "../atoms/chatAtom";
 import { SwrTestCache } from "../../test/swrTestCache";
+import type { BookDetail } from "../../shared/schemas/book";
+import type { SelectionHighlight } from "../../shared/schemas/selection";
 
 const PDF_ID = "01JBOOK";
 
 /** The answer for a passage the book does not hold. */
 const MISSING = { found: false, miss: "not-in-book" } as const;
 
+const A_PASSAGE = "エッジは速い";
+
+function highlight(id: string, selectedText: string, pageNumber: number): SelectionHighlight {
+  return {
+    id,
+    selectedText,
+    pageNumber,
+    positionData: { rects: [] },
+    color: "#FFEB3B",
+    createdAt: "2026-08-01T10:00:00.000Z",
+  };
+}
+
+const BOOK: BookDetail = {
+  id: PDF_ID,
+  fileName: "Cloudflare Workers.pdf",
+  pageCount: 209,
+  hasThumbnail: true,
+  selections: [highlight("a1", A_PASSAGE, 12), highlight("a2", "V8 isolate", 30)],
+};
+
+/** The whole query string, named, so a test states every parameter it expects. */
+function paramsOf(search: string): Record<string, string> {
+  const named: Record<string, string> = {};
+  new URLSearchParams(search).forEach((value, key) => {
+    named[key] = value;
+  });
+  return named;
+}
+
+const pageOf = (search: string) => new URLSearchParams(search).get("page");
+
 /** Exposes the URL the hook drives and a way to turn pages like the viewer does. */
-function useHarness(locatePassage: LocatePassage, linkedPassage: string | null, visited: string[]) {
-  const { passageMiss } = useReadingLocation(PDF_ID, locatePassage, linkedPassage);
+function useHarness(
+  locatePassage: LocatePassage,
+  linkedPassage: string | null,
+  visited: string[],
+  book: BookDetail | undefined,
+  openChat: (selection: ActiveSelection) => void,
+) {
+  const { passageMiss } = useReadingLocation(PDF_ID, locatePassage, linkedPassage, book, openChat);
 
   const { search } = useLocation();
   if (visited[visited.length - 1] !== search) visited.push(search);
 
-  return { search, passageMiss, setCurrentPage: useSetAtom(currentPageAtom) };
+  return {
+    search,
+    passageMiss,
+    setCurrentPage: useSetAtom(currentPageAtom),
+    setChatPanelOpen: useSetAtom(chatPanelOpenAtom),
+    setActiveSelection: useSetAtom(activeSelectionAtom),
+  };
 }
 
 function renderAt(
   url: string,
-  options: { locatePassage?: LocatePassage; linkedPassage?: string | null } = {},
+  options: {
+    locatePassage?: LocatePassage;
+    linkedPassage?: string | null;
+    book?: BookDetail;
+  } = {},
 ) {
-  const { locatePassage = async () => MISSING, linkedPassage = null } = options;
+  const { locatePassage = async () => MISSING, linkedPassage = null, book } = options;
   const store = createStore();
   // Every distinct URL the hook drives, in order, so tests can tell "landed on
   // page 20" apart from "bounced through page 1 first"
@@ -38,11 +89,19 @@ function renderAt(
       </Provider>
     </SwrTestCache>
   );
+  // Stands in for the reader's own opener: the chat it puts on screen is the
+  // active selection, which is also what keeps the id in the URL afterwards.
+  const openChat = vi.fn((selection: ActiveSelection) => store.set(activeSelectionAtom, selection));
 
   return {
     store,
     visited,
-    view: renderHook(() => useHarness(locatePassage, linkedPassage, visited), { wrapper }),
+    openChat,
+    view: renderHook(
+      ({ book }: { book: BookDetail | undefined }) =>
+        useHarness(locatePassage, linkedPassage, visited, book, openChat),
+      { wrapper, initialProps: { book } },
+    ),
   };
 }
 
@@ -58,17 +117,156 @@ describe("useReadingLocation", () => {
 
     act(() => view.result.current.setCurrentPage(7));
 
-    await waitFor(() => expect(view.result.current.search).toBe("?page=7"));
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({ page: "7", panel: "open" }),
+    );
     expect(store.get(currentPageAtom)).toBe(7);
   });
 
   it("stays on the page it was given instead of bouncing back to the first one", async () => {
     const { store, visited, view } = renderAt(`/books/${PDF_ID}?page=20`);
 
-    await waitFor(() => expect(view.result.current.search).toBe("?page=20"));
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({ page: "20", panel: "open" }),
+    );
 
-    expect(visited).toEqual(["?page=20"]);
+    // Spelling the panel out takes another replace, but page 20 is the only page
+    // any of them names
+    expect(new Set(visited.map(pageOf))).toEqual(new Set(["20"]));
     expect(store.get(currentPageAtom)).toBe(20);
+  });
+
+  it("opens with the panel folded away when the URL says it is closed", () => {
+    const { store } = renderAt(`/books/${PDF_ID}?page=3&panel=closed`);
+
+    expect(store.get(chatPanelOpenAtom)).toBe(false);
+  });
+
+  it("spells the open panel out so the address bar reopens the reader as it stands", async () => {
+    const { store, view } = renderAt(`/books/${PDF_ID}`);
+
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({ page: "1", panel: "open" }),
+    );
+    expect(store.get(chatPanelOpenAtom)).toBe(true);
+  });
+
+  it("writes the folded panel into the URL, keeping the page being read", async () => {
+    const { view } = renderAt(`/books/${PDF_ID}?page=12`);
+
+    act(() => view.result.current.setChatPanelOpen(false));
+
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({ page: "12", panel: "closed" }),
+    );
+  });
+
+  it("reopens the chat the URL names once the book it belongs to is in hand", async () => {
+    const { store, openChat } = renderAt(`/books/${PDF_ID}?page=5&selection=a1`, { book: BOOK });
+
+    await waitFor(() => expect(openChat).toHaveBeenCalledTimes(1));
+    expect(openChat).toHaveBeenCalledWith({
+      id: "a1",
+      selectedText: A_PASSAGE,
+      pageNumber: 12,
+    });
+    // The URL's page wins over the highlight's own: it is where the reader was
+    expect(store.get(currentPageAtom)).toBe(5);
+  });
+
+  it("waits for the book rather than deciding the chat is gone", async () => {
+    const { openChat, view } = renderAt(`/books/${PDF_ID}?selection=a1`);
+
+    // Highlights are read out of the book, so until it lands there is nothing
+    // to look the id up in
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({
+        page: "1",
+        selection: "a1",
+        panel: "open",
+      }),
+    );
+    expect(openChat).toHaveBeenCalledTimes(0);
+
+    await act(async () => view.rerender({ book: BOOK }));
+
+    expect(openChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the chat named in the URL through a page turn taken before the book lands", async () => {
+    const { openChat, view } = renderAt(`/books/${PDF_ID}?page=5&selection=a1`);
+
+    act(() => view.result.current.setCurrentPage(9));
+
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({
+        page: "9",
+        selection: "a1",
+        panel: "open",
+      }),
+    );
+
+    await act(async () => view.rerender({ book: BOOK }));
+    expect(openChat).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the highlight list for a chat the book no longer has, and stops saying otherwise", async () => {
+    const { openChat, view } = renderAt(`/books/${PDF_ID}?page=5&selection=deleted`, {
+      book: BOOK,
+    });
+
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({ page: "5", panel: "open" }),
+    );
+    expect(openChat).toHaveBeenCalledTimes(0);
+  });
+
+  it("writes the open chat into the URL, and drops it on the way back to the list", async () => {
+    const { view } = renderAt(`/books/${PDF_ID}?page=12`, { book: BOOK });
+
+    act(() =>
+      view.result.current.setActiveSelection({
+        id: "a2",
+        selectedText: "V8 isolate",
+        pageNumber: 30,
+      }),
+    );
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({
+        page: "12",
+        panel: "open",
+        selection: "a2",
+      }),
+    );
+
+    act(() => view.result.current.setActiveSelection(null));
+
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({ page: "12", panel: "open" }),
+    );
+  });
+
+  it("carries the page and the chat opened in the same breath into one URL", async () => {
+    // Picking a highlight off the list moves both at once, and a writer that
+    // handled them apart would leave the URL holding only the later one.
+    const { view } = renderAt(`/books/${PDF_ID}?page=1`, { book: BOOK });
+
+    act(() => {
+      view.result.current.setCurrentPage(30);
+      view.result.current.setActiveSelection({
+        id: "a2",
+        selectedText: "V8 isolate",
+        pageNumber: 30,
+      });
+    });
+
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({
+        page: "30",
+        panel: "open",
+        selection: "a2",
+      }),
+    );
   });
 
   it("opens the page holding the passage of a browser text-fragment link", async () => {
@@ -99,7 +297,7 @@ describe("useReadingLocation", () => {
     });
 
     await waitFor(() => expect(view.result.current.passageMiss).toBe("not-in-book"));
-    expect(view.result.current.search).toBe("?page=1");
+    expect(paramsOf(view.result.current.search)).toEqual({ page: "1", panel: "open" });
     expect(store.get(currentPageAtom)).toBe(1);
   });
 
@@ -137,7 +335,9 @@ describe("useReadingLocation", () => {
   it("keeps quiet for a page opened without a linked passage at all", async () => {
     const { view } = renderAt(`/books/${PDF_ID}?page=42`);
 
-    await waitFor(() => expect(view.result.current.search).toBe("?page=42"));
+    await waitFor(() =>
+      expect(paramsOf(view.result.current.search)).toEqual({ page: "42", panel: "open" }),
+    );
     expect(view.result.current.passageMiss).toBeNull();
   });
 });

--- a/src/front/hooks/useReadingLocation.ts
+++ b/src/front/hooks/useReadingLocation.ts
@@ -1,10 +1,11 @@
-// oxlint-disable-next-line no-restricted-imports -- 読書位置を URL (外部状態) へ同期し、SWR が解決したページを共有ストアへ反映するために必要
-import { useEffect, useRef } from "react";
-import { useAtom } from "jotai";
+// oxlint-disable-next-line no-restricted-imports -- 読書位置とパネルの状態を URL (外部状態) へ同期し、SWR が解決したページを共有ストアへ反映するために必要
+import { useEffect, useRef, useState } from "react";
+import { useAtom, useAtomValue } from "jotai";
 import { useSearchParams } from "react-router";
 import useSWRImmutable from "swr/immutable";
 import { currentPageAtom } from "../atoms/pdfAtom";
-import type { LocatedPage, PageMiss } from "../../shared/schemas/book";
+import { activeSelectionAtom, chatPanelOpenAtom, type ActiveSelection } from "../atoms/chatAtom";
+import type { BookDetail, LocatedPage, PageMiss } from "../../shared/schemas/book";
 
 /** Resolves a quoted passage to the page it appears on, or why it has none. */
 export type LocatePassage = (pdfId: string, passage: string) => Promise<LocatedPage>;
@@ -12,7 +13,14 @@ export type LocatePassage = (pdfId: string, passage: string) => Promise<LocatedP
 /** What the reader is told when a link named a passage the book will not open at. */
 export type PassageMiss = PageMiss | "lookup-failed";
 
+/** Puts the chat about a highlight on screen, with whatever was asked before. */
+export type OpenChat = (selection: ActiveSelection) => void;
+
 const PAGE_PARAM = "page";
+const PANEL_PARAM = "panel";
+const PANEL_OPEN = "open";
+const PANEL_CLOSED = "closed";
+const SELECTION_PARAM = "selection";
 
 /** Nothing is missing until a link named a passage and the answer is in. */
 function missOf(
@@ -32,11 +40,17 @@ function parsePage(value: string | null): number | null {
 }
 
 /**
- * Keep the page being read and the URL in sync, so a reload or a shared link
- * resumes on the same page.
+ * Keep the reader's place — the page being read, the state of the panel on the
+ * right and the chat open in it — in sync with the URL, so a reload or a shared
+ * link resumes there.
  *
- * The page being read is the single source of truth: the URL is read once per
- * book and written on every page turn. Watching the URL as well would make the
+ * This hook owns every parameter of the reader's URL, and is the only thing that
+ * writes them. `setSearchParams` does not merge within a commit, so a second
+ * writer working from its own copy of the query would drop whatever the first
+ * one had just put there — and one handler moves the page and the panel at once.
+ *
+ * The reader's own state is the single source of truth: the URL is read once per
+ * book and written on every change. Watching the URL as well would make the
  * two effects feed each other, and the reader would bounce between pages.
  *
  * A `#:~:text=` fragment — what Chrome's "Copy link to highlight" writes — wins
@@ -46,14 +60,28 @@ function parsePage(value: string | null): number | null {
  * so, and which of the reasons it was: the book opens on page 1 either way, and
  * a quote that is nowhere in the book means something different to the reader
  * than a book of one page or a lookup that never answered.
+ *
+ * The chat named by the URL can only be reopened once `book` arrives, since the
+ * highlight it is about is read out of it. `openChat` is the reader's own opener,
+ * so a restored chat is the same thing as one picked off the list.
  */
 export function useReadingLocation(
   pdfId: string | undefined,
   locatePassage: LocatePassage,
   linkedPassage: string | null,
+  book: BookDetail | undefined,
+  openChat: OpenChat,
 ): { passageMiss: PassageMiss | null } {
   const [searchParams, setSearchParams] = useSearchParams();
   const [currentPage, setCurrentPage] = useAtom(currentPageAtom);
+  const [chatPanelOpen, setChatPanelOpen] = useAtom(chatPanelOpenAtom);
+  const activeSelectionId = useAtomValue(activeSelectionAtom)?.id ?? null;
+
+  // The chat this book was opened at, until the book itself arrives and says
+  // whether that highlight is still in it. Holding it in state rather than a ref
+  // is what re-runs the write below once it clears, so a URL naming a highlight
+  // the book has lost stops claiming so.
+  const [pendingSelectionId, setPendingSelectionId] = useState<string | null>(null);
 
   // The URL is read and written through refs. Both values change identity on
   // every navigation, so depending on them would re-run these effects on each
@@ -68,35 +96,70 @@ export function useReadingLocation(
   // send the reader to page 1 and straight back, which reads as a flicker.
   const urlIsAuthoritative = useRef(true);
 
-  // Opening a book starts from the page its URL names, not the previous book's
+  // Opening a book starts from the place its URL names, not the previous book's
   useEffect(() => {
     const params = searchParamsRef.current;
     const page = parsePage(params.get(PAGE_PARAM)) ?? 1;
+    // Anything but "closed" is an open panel, which is also how a URL that says
+    // nothing about the panel is read
+    const panelOpen = params.get(PANEL_PARAM) !== PANEL_CLOSED;
 
     urlIsAuthoritative.current = true;
     setCurrentPage(page);
+    setChatPanelOpen(panelOpen);
+    setPendingSelectionId(params.get(SELECTION_PARAM));
 
-    // Spell the page out even when it was implied, so the address bar always
-    // holds a link that reopens the book where it is now
-    if (params.get(PAGE_PARAM) !== String(page)) {
-      const next = new URLSearchParams(params);
-      next.set(PAGE_PARAM, String(page));
+    // Spell the place out even where it was implied, so the address bar always
+    // holds a link that reopens the book as it stands
+    const next = new URLSearchParams(params);
+    next.set(PAGE_PARAM, String(page));
+    next.set(PANEL_PARAM, panelOpen ? PANEL_OPEN : PANEL_CLOSED);
+    if (next.toString() !== params.toString()) {
       setSearchParamsRef.current(next, { replace: true });
     }
-  }, [pdfId, setCurrentPage]);
+  }, [pdfId, setCurrentPage, setChatPanelOpen]);
 
-  // Reader -> URL, replacing so page turns do not pile up in the history
+  // Reader -> URL, replacing so page turns do not pile up in the history. Every
+  // parameter is written together: one commit, one navigation, nothing dropped.
   useEffect(() => {
     if (urlIsAuthoritative.current) {
       urlIsAuthoritative.current = false;
       return;
     }
 
-    const next = new URLSearchParams(searchParamsRef.current);
-    if (next.get(PAGE_PARAM) === String(currentPage)) return;
+    const params = searchParamsRef.current;
+    const next = new URLSearchParams(params);
     next.set(PAGE_PARAM, String(currentPage));
+    next.set(PANEL_PARAM, chatPanelOpen ? PANEL_OPEN : PANEL_CLOSED);
+    // While the chat the URL named is still waiting for its book, the URL is the
+    // only place it exists: syncing from the empty atom — which a page turn taken
+    // in the meantime would do — would throw away what is being restored.
+    if (pendingSelectionId === null) {
+      if (activeSelectionId === null) next.delete(SELECTION_PARAM);
+      else next.set(SELECTION_PARAM, activeSelectionId);
+    }
+    if (next.toString() === params.toString()) return;
     setSearchParamsRef.current(next, { replace: true });
-  }, [currentPage]);
+  }, [currentPage, chatPanelOpen, activeSelectionId, pendingSelectionId]);
+
+  // The chat named by the URL, reopened as soon as the book can say which
+  // highlight that is
+  useEffect(() => {
+    if (pendingSelectionId === null || book === undefined) return;
+
+    const highlight = book.selections.find((selection) => selection.id === pendingSelectionId);
+    if (highlight !== undefined) {
+      openChat({
+        id: highlight.id,
+        selectedText: highlight.selectedText,
+        pageNumber: highlight.pageNumber,
+      });
+    }
+
+    // Cleared either way: a highlight that is no longer in the book leaves the
+    // list showing, and the write above takes the id back out of the URL.
+    setPendingSelectionId(null);
+  }, [book, pendingSelectionId, openChat]);
 
   // Where a passage sits in a book cannot change while the book is open, so
   // this is asked once per link and never revalidated.

--- a/src/front/pages/AppPage.test.tsx
+++ b/src/front/pages/AppPage.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, vi } from "vite-plus/test";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { MemoryRouter, Route, Routes, useNavigate } from "react-router";
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from "react-router";
 import { SWRConfig } from "swr";
 import { AppPage } from "./AppPage";
 import { bookKey } from "../hooks/useBook";
@@ -13,11 +13,11 @@ const A_PASSAGE = "エッジはサーバーレス実行基盤で、実行単位�
 const A_SECOND_PASSAGE = "Workers は V8 isolate の上で動きます。";
 const B_PASSAGE = "Durable Objects は単一のインスタンスに処理を集約します。";
 
-function highlight(id: string, selectedText: string): SelectionHighlight {
+function highlight(id: string, selectedText: string, pageNumber = 1): SelectionHighlight {
   return {
     id,
     selectedText,
-    pageNumber: 1,
+    pageNumber,
     positionData: { rects: [] },
     color: "#FFEB3B",
     createdAt: "2026-08-01T10:00:00.000Z",
@@ -29,7 +29,9 @@ const BOOK_A: BookDetail = {
   fileName: "Cloudflare Workers.pdf",
   pageCount: 209,
   hasThumbnail: true,
-  selections: [highlight("a1", A_PASSAGE), highlight("a2", A_SECOND_PASSAGE)],
+  // The second one is pages away, so what a highlight does to the page the
+  // reader is on can be told apart from doing nothing at all
+  selections: [highlight("a1", A_PASSAGE), highlight("a2", A_SECOND_PASSAGE, 30)],
 };
 
 const BOOK_B: BookDetail = {
@@ -98,6 +100,20 @@ function readerFetchStub({
   return { urls, fetchFn };
 }
 
+/**
+ * The query string, on screen, so a test can read what the reader put there.
+ *
+ * jsdom has no pdf.js, so the viewer never draws a page and its toolbar — where
+ * the page being read is otherwise shown — is not on screen at all.
+ */
+function ShowSearch() {
+  // Named and sorted, since where a parameter lands in the query depends on the
+  // order the link happened to spell them in
+  const named: string[] = [];
+  new URLSearchParams(useLocation().search).forEach((value, key) => named.push(`${key}=${value}`));
+  return <p>{`URL: ${named.sort().join(" ")}`}</p>;
+}
+
 /** Lets a test leave the book it is on, the way the shelf link would. */
 function OpenOtherBook({ pdfId }: { pdfId: string }) {
   const navigate = useNavigate();
@@ -129,6 +145,7 @@ function renderReader(
     refuseChatHistoryFor?: string;
     locate?: LocatedPage;
     refuseLocate?: boolean;
+    search?: string;
   } = {},
 ) {
   const { urls, fetchFn } = readerFetchStub(options);
@@ -139,8 +156,9 @@ function renderReader(
       {/* Seeded entries are revalidated on mount here, as they are in the app.
           What the reader shows before that lands is what these tests are about. */}
       <SWRConfig value={{ revalidateIfStale: true }}>
-        <MemoryRouter initialEntries={[`/books/${pdfId}`]}>
+        <MemoryRouter initialEntries={[`/books/${pdfId}${options.search ?? ""}`]}>
           <OpenOtherBook pdfId={BOOK_B.id} />
+          <ShowSearch />
           <Routes>
             <Route path="/books/:pdfId" element={<AppPage />} />
           </Routes>
@@ -245,6 +263,67 @@ describe("AppPage", () => {
     expect(
       await screen.findByText("リンクされた箇所を探せませんでした: 存在しない"),
     ).toBeInTheDocument();
+  });
+
+  it("reopens the chat its URL names, on the page that URL was left at", async () => {
+    // The highlight sits on page 1, so a reader who had scrolled on to page 5
+    // and reloaded would be dragged back to it if the restore moved the page.
+    const { urls } = renderReader(
+      BOOK_A.id,
+      { [bookKey(BOOK_A.id)]: BOOK_A },
+      { search: "?page=5&selection=a1" },
+    );
+
+    expect(await screen.findByRole("button", { name: "一覧に戻る" })).toBeInTheDocument();
+    expect(urls).toContain(`/api/pdf/${BOOK_A.id}/selections/a1/chats`);
+    // Still page 5: reopening the chat is not the reader picking it off the list
+    expect(screen.getByText("URL: page=5 panel=open selection=a1")).toBeInTheDocument();
+  });
+
+  it("goes to the passage of a highlight picked off the list", async () => {
+    // The other half of the restore above: choosing a highlight is the reader
+    // asking to be taken to it, so here the page does move.
+    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A });
+
+    await userEvent.click(await screen.findByText(A_SECOND_PASSAGE));
+
+    expect(screen.getByText("URL: page=30 panel=open selection=a2")).toBeInTheDocument();
+  });
+
+  it("shows the highlight list when the URL names a chat the book no longer has", async () => {
+    const { urls } = renderReader(
+      BOOK_A.id,
+      { [bookKey(BOOK_A.id)]: BOOK_A },
+      { search: "?selection=deleted" },
+    );
+
+    expect(await screen.findByText(A_PASSAGE)).toBeInTheDocument();
+    expect(urls.some((url) => url.endsWith("/chats"))).toBe(false);
+    // And the URL stops naming it, rather than restoring nothing every reload
+    expect(screen.getByText("URL: page=1 panel=open")).toBeInTheDocument();
+  });
+
+  it("opens with the panel folded away when its URL says so", async () => {
+    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A }, { search: "?panel=closed" });
+
+    expect(await screen.findByRole("button", { name: "チャットを表示" })).toBeInTheDocument();
+    expect(screen.queryByText(A_PASSAGE)).toBeNull();
+    expect(screen.queryByRole("separator")).toBeNull();
+  });
+
+  it("folds the panel away and brings it back on the toggle", async () => {
+    renderReader(BOOK_A.id, { [bookKey(BOOK_A.id)]: BOOK_A });
+
+    expect(await screen.findByText(A_PASSAGE)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "チャットを隠す" }));
+    expect(screen.queryByText(A_PASSAGE)).toBeNull();
+    // Written down, so the fold survives a reload
+    expect(screen.getByText("URL: page=1 panel=closed")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "チャットを表示" }));
+    expect(screen.getByText(A_PASSAGE)).toBeInTheDocument();
+    expect(screen.getByText("URL: page=1 panel=open")).toBeInTheDocument();
   });
 
   it("says what went wrong when the book cannot be read", async () => {

--- a/src/front/pages/AppPage.tsx
+++ b/src/front/pages/AppPage.tsx
@@ -6,6 +6,7 @@ import {
   activeSelectionAtom,
   chatMessagesAtom,
   chatErrorAtom,
+  chatPanelOpenAtom,
   abortChatStreamAtom,
   type ActiveSelection,
 } from "../atoms/chatAtom";
@@ -62,6 +63,7 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
   const [, setChatMessages] = useAtom(chatMessagesAtom);
   const [, setChatError] = useAtom(chatErrorAtom);
   const [, setCurrentPage] = useAtom(currentPageAtom);
+  const [chatPanelOpen, setChatPanelOpen] = useAtom(chatPanelOpenAtom);
   const abortChatStream = useSetAtom(abortChatStreamAtom);
   const [leftWidth, setLeftWidth] = useState(60);
 
@@ -70,16 +72,19 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
     () => passageFromNavigation(performance.getEntriesByType("navigation")),
     [],
   );
-  const { passageMiss } = useReadingLocation(pdfId, locatePassage, linkedPassage);
 
-  // Load chat history when selection changes
-  const handleSelectionClick = useCallback(
+  /**
+   * Put a highlight's conversation on screen, with whatever was asked before.
+   *
+   * Which page the reader is on is deliberately not part of this: a chat picked
+   * off the list moves the page to its passage, while one restored from the URL
+   * leaves the page that same URL named alone.
+   */
+  const openChat = useCallback(
     async (selection: ActiveSelection) => {
       // An answer still streaming belongs to the chat being left behind
       abortChatStream();
       setActiveSelection(selection);
-      // The highlight can be picked from the list while another page is shown
-      setCurrentPage(selection.pageNumber);
       // Otherwise the conversation left behind shows under the new passage
       // until its own history arrives
       setChatMessages([]);
@@ -99,7 +104,20 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
         (failure) => setChatError(`チャット履歴を読み込めませんでした: ${failure.message}`),
       );
     },
-    [abortChatStream, pdfId, setActiveSelection, setChatError, setChatMessages, setCurrentPage],
+    [abortChatStream, pdfId, setActiveSelection, setChatError, setChatMessages],
+  );
+
+  const { passageMiss } = useReadingLocation(pdfId, locatePassage, linkedPassage, book, openChat);
+
+  const handleSelectionClick = useCallback(
+    (selection: ActiveSelection) => {
+      // The highlight can be picked from the list while another page is shown
+      setCurrentPage(selection.pageNumber);
+      // Nothing to wait for: reading the history in shows it, and a history that
+      // could not be read says so through `chatErrorAtom`
+      void openChat(selection);
+    },
+    [openChat, setCurrentPage],
   );
 
   return (
@@ -114,7 +132,17 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
         {book && (
           <span className="ml-3 text-sm text-gray-500 truncate max-w-xs">{book.fileName}</span>
         )}
-        <div className="ml-auto">
+        {/* The toggle lives up here rather than in the panel it folds away,
+            which would take the way back out with it. */}
+        <div className="ml-auto flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setChatPanelOpen((open) => !open)}
+            aria-pressed={chatPanelOpen}
+            className="px-3 py-1 bg-white border rounded cursor-pointer text-sm text-gray-600 hover:bg-gray-50"
+          >
+            {chatPanelOpen ? "チャットを隠す" : "チャットを表示"}
+          </button>
           <SettingsMenu />
         </div>
       </header>
@@ -128,8 +156,9 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
       )}
 
       <main className="flex-1 min-h-0 flex">
-        {/* Left panel: PDF Viewer */}
-        <div style={{ width: `${leftWidth}%` }} className="h-full min-w-0">
+        {/* Left panel: PDF Viewer. It takes the whole width the folded panel
+            leaves behind, and gets its share back on the way out. */}
+        <div style={{ width: chatPanelOpen ? `${leftWidth}%` : "100%" }} className="h-full min-w-0">
           <PdfViewer
             book={book}
             bookError={error as Error | undefined}
@@ -137,41 +166,47 @@ function BookReader({ pdfId }: { pdfId: string | undefined }) {
           />
         </div>
 
-        {/* Resize handle */}
-        <div
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="PDFとチャットの幅を変更"
-          className="w-1.5 bg-gray-200 hover:bg-blue-400 cursor-col-resize shrink-0 transition-colors active:bg-blue-500"
-          onMouseDown={(e) => {
-            e.preventDefault();
-            const startX = e.clientX;
-            const startWidth = leftWidth;
+        {/* The handle and the panel it sizes come and go together: a handle for
+            a panel that is not there has nothing to drag. */}
+        {chatPanelOpen && (
+          <>
+            {/* Resize handle */}
+            <div
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="PDFとチャットの幅を変更"
+              className="w-1.5 bg-gray-200 hover:bg-blue-400 cursor-col-resize shrink-0 transition-colors active:bg-blue-500"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                const startX = e.clientX;
+                const startWidth = leftWidth;
 
-            const handleMouseMove = (moveEvent: MouseEvent) => {
-              const delta = ((moveEvent.clientX - startX) / window.innerWidth) * 100;
-              const newWidth = Math.min(80, Math.max(20, startWidth + delta));
-              setLeftWidth(newWidth);
-            };
+                const handleMouseMove = (moveEvent: MouseEvent) => {
+                  const delta = ((moveEvent.clientX - startX) / window.innerWidth) * 100;
+                  const newWidth = Math.min(80, Math.max(20, startWidth + delta));
+                  setLeftWidth(newWidth);
+                };
 
-            const handleMouseUp = () => {
-              document.removeEventListener("mousemove", handleMouseMove);
-              document.removeEventListener("mouseup", handleMouseUp);
-            };
+                const handleMouseUp = () => {
+                  document.removeEventListener("mousemove", handleMouseMove);
+                  document.removeEventListener("mouseup", handleMouseUp);
+                };
 
-            document.addEventListener("mousemove", handleMouseMove);
-            document.addEventListener("mouseup", handleMouseUp);
-          }}
-        />
+                document.addEventListener("mousemove", handleMouseMove);
+                document.addEventListener("mouseup", handleMouseUp);
+              }}
+            />
 
-        {/* Right panel: Chat Area */}
-        <div style={{ width: `${100 - leftWidth}%` }} className="h-full min-w-0">
-          <ChatArea
-            book={book}
-            bookError={error as Error | undefined}
-            onSelectionClick={handleSelectionClick}
-          />
-        </div>
+            {/* Right panel: Chat Area */}
+            <div style={{ width: `${100 - leftWidth}%` }} className="h-full min-w-0">
+              <ChatArea
+                book={book}
+                bookError={error as Error | undefined}
+                onSelectionClick={handleSelectionClick}
+              />
+            </div>
+          </>
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
## 概要

リーダー画面 (`/books/:pdfId`) の右パネルについて、次の 2 つを実装しました。

1. 右パネルを畳む / 開くトグルを header に新設 (これまで閉じる手段が無かった)
2. パネルの開閉と、パネル内で開いているチャットのハイライト ID を URL クエリパラメータに保持し、リロード・共有リンクで復元

## URL スキーマ

| パラメータ | 値 | 省略時 |
|---|---|---|
| `panel` | `open` / `closed` | 既定は `open`。既存の `?page=1` と同じ流儀で、既定値も明示的に書き出す |
| `selection` | ハイライトの ID (例: `01KZJ0...`) | チャットを開いていないときは付かない (一覧表示) |

2 軸は独立で、`?panel=closed&selection=abc` は「畳んでいるが chat abc を保持」を意味します (展開するとそのチャットが出る)。

## 設計上のポイント

- **URL の書き手は `useReadingLocation` 1 つに集約**。`setSearchParams` は同一 commit 内でマージされないため、書き手を分けるとハイライトを選んだとき (page と selection が同時に動く) に片方が黙って消える
- **復元は本 (`useBook` の SWR) の到着を待つ**。ハイライトは本から読むため。待っている間は URL の `selection` を温存し、その間のページ送りで復元先を失わないようにした
- **本から消えたハイライトを指す URL** は一覧を表示し、パラメータ自体を落とす (URL に嘘を残さない)
- **復元では現在ページを動かさない** (URL の `page` が正)。一覧から選んだときだけそのハイライトのページへ移る分担にしたので、`setCurrentPage` は `handleSelectionClick` に置き `openChat` から外した
- 畳んでもストリーミング中の回答は abort しない (`useChatStream` は atom に書き続けるので、展開すると続きが見える)

## 動作確認

- `pnpm test`: 213 passed (34 files)
- `pnpm run test:e2e`: 22 passed / 0 failed
- `vp check`: format / lint / 型エラーなし
- 追加した jsdom テストは実装 (`setCurrentPage` の除去) を壊すと落ちることを確認済み
- E2E に「チャットを開く → 畳む → リロード → 畳まれたまま、展開すると会話が復元」を 1 本追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)